### PR TITLE
Birger adaptor focuser support

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,3 +9,4 @@ ignore:
   - "pocs/tests/test_sbig.py"
   - "pocs/mount/mount_serial.py"
   - "pocs/mount/ioptron.py"
+  - "pocs/focuser/birger.py"

--- a/examples/notebooks/Birger Focuser Control.ipynb
+++ b/examples/notebooks/Birger Focuser Control.ipynb
@@ -223,6 +223,39 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "f.position = -75"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "-75"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f.position"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {
     "collapsed": true

--- a/examples/notebooks/Birger Focuser Control.ipynb
+++ b/examples/notebooks/Birger Focuser Control.ipynb
@@ -1,0 +1,256 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Demonstration of control of Birger focusers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Load the PANOPTES module dir\n",
+    "import sys\n",
+    "sys.path.append('../../')\n",
+    "\n",
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from pocs.focuser.simulator import Focuser"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "f = Focuser()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Simulated Focuser'"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f.name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'simulator'"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f.model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/dev/ttyFAKE'"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f.port"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'SF9999'"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f.uid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f.position"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "f.move_to(100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "100"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f.position"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "f.move_by(-13)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "87"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f.position"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python [conda env:POCS]",
+   "language": "python",
+   "name": "conda-env-POCS-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/notebooks/Birger Focuser Control.ipynb
+++ b/examples/notebooks/Birger Focuser Control.ipynb
@@ -17,10 +17,7 @@
    "source": [
     "# Load the PANOPTES module dir\n",
     "import sys\n",
-    "sys.path.append('../../')\n",
-    "\n",
-    "%load_ext autoreload\n",
-    "%autoreload 2"
+    "sys.path.append('../../')"
    ]
   },
   {
@@ -51,7 +48,15 @@
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2017-01-13 19:27:32 aaomc48as.aao.gov.au panoptes[47163] INFO Birger Focuser(10858) on /dev/tty.USA49WG2P4.4 initialised\n"
+     ]
+    }
+   ],
    "source": [
     "f = Focuser(port=port)"
    ]
@@ -64,23 +69,25 @@
    },
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "'Birger Focuser'"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
+     "ename": "TypeError",
+     "evalue": "int() argument must be a string, a bytes-like object or a number, not 'NoneType'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-5-cf206e8d4fe6>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mf\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mposition\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m/Users/ajh/Documents/git/POCS/pocs/focuser/birger.py\u001b[0m in \u001b[0;36mposition\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m     36\u001b[0m         \u001b[0mReturns\u001b[0m \u001b[0mcurrent\u001b[0m \u001b[0mfocus\u001b[0m \u001b[0mposition\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mthe\u001b[0m \u001b[0mlens\u001b[0m \u001b[0mfocus\u001b[0m \u001b[0mencoder\u001b[0m \u001b[0munits\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     37\u001b[0m         \"\"\"\n\u001b[0;32m---> 38\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_send_command\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'pf'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     39\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     40\u001b[0m \u001b[0;31m##################################################################################################\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mTypeError\u001b[0m: int() argument must be a string, a bytes-like object or a number, not 'NoneType'"
+     ]
     }
    ],
    "source": [
-    "f.name"
+    "f.position"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 10,
    "metadata": {
     "collapsed": false
    },
@@ -88,21 +95,22 @@
     {
      "data": {
       "text/plain": [
-       "'Canon EF-232'"
+       "['pf\\n', 'OK\\n', '500\\n']"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "f.model"
+    "f._send_command('pf', check_response=False)\n",
+    "f._serial_io.readlines()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 11,
    "metadata": {
     "collapsed": false
    },
@@ -110,16 +118,17 @@
     {
      "data": {
       "text/plain": [
-       "'/dev/tty.USA49WG2P4.4'"
+       "['rm1,0\\n', 'OK\\n']"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "f.port"
+    "f._send_command('rm1,0', check_response=False)\n",
+    "f._serial_io.readlines()"
    ]
   },
   {
@@ -132,7 +141,7 @@
     {
      "data": {
       "text/plain": [
-       "'XXXXXX'"
+       "True"
       ]
      },
      "execution_count": 8,
@@ -141,12 +150,12 @@
     }
    ],
    "source": [
-    "f.uid"
+    "f.is_connected"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 13,
    "metadata": {
     "collapsed": false
    },
@@ -154,69 +163,270 @@
     {
      "data": {
       "text/plain": [
-       "['DONE0,1']"
+       "['mz\\n', 'OK\\n', 'DONE0,1\\n']"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "f._send_command('mz')"
+    "f._send_command('mz', check_response=False)\n",
+    "f._serial_io.readlines()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "f._send_command('sf0')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "f._send_command('la')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "metadata": {
     "collapsed": false
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2017-01-12 18:36:42 aaomc48as.aao.gov.au panoptes[44451] ERROR Sent command 'in', Birger echoed 'DONE:LA'!\n"
-     ]
-    },
-    {
-     "ename": "IndexError",
-     "evalue": "list index out of range",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-12-a2e8a5d3693e>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mf\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_send_command\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'in'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m/Users/ajh/Documents/git/POCS/pocs/focuser/birger.py\u001b[0m in \u001b[0;36m_send_command\u001b[0;34m(self, command)\u001b[0m\n\u001b[1;32m     46\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mresponse\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0mcommand\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     47\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlogger\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0merror\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"Sent command '{}', Birger echoed '{}'!\"\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcommand\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mresponse\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 48\u001b[0;31m         \u001b[0;32mif\u001b[0m \u001b[0mresponse\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0;34m'OK'\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     49\u001b[0m             \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     50\u001b[0m                 \u001b[0merror_number\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresponse\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m3\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mIndexError\u001b[0m: list index out of range"
-     ]
+     "data": {
+      "text/plain": [
+       "['sf0\\n', 'OK\\n']"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "f._send_command('in')"
+    "f._send_command('sf0', check_response=False)\n",
+    "f._serial_io.readlines()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['la\\n', 'OK\\n', 'DONE:LA\\n']"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f._send_command('la', check_response=False)\n",
+    "f._serial_io.readlines()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['in\\n', 'OK\\n', 'DONE\\n']"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f._send_command('in', check_response=False)\n",
+    "f._serial_io.readlines()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['zz\\n', 'OK\\n', 'ERR1\\n']"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f._send_command('zz', check_response=False)\n",
+    "f._serial_io.readlines()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['mi\\n', 'OK\\n', 'DONE22720,1\\n']"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f._send_command('mi', check_response=False)\n",
+    "f._serial_io.readlines()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['pf\\n', 'OK\\n', '22761\\n']"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f._send_command('pf', check_response=False)\n",
+    "f._serial_io.readlines()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['fa10000\\n', 'OK\\n', 'DONE10000,0\\n']"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f._send_command('fa10000', check_response=False)\n",
+    "f._serial_io.readlines()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['mf-5000\\n', 'OK\\n', 'DONE-5000,0\\n']"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f._send_command('mf-5000', check_response=False)\n",
+    "f._serial_io.readlines()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['pf\\n', 'OK\\n', '5000\\n']"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f._send_command('pf', check_response=False)\n",
+    "f._serial_io.readlines()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['mz\\n', 'OK\\n', 'DONE-4992,1\\n']"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f._send_command('mz', check_response=False)\n",
+    "f._serial_io.readlines()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['pf\\n', 'OK\\n', '8\\n']"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f._send_command('pf', check_response=False)\n",
+    "f._serial_io.readlines()"
    ]
   },
   {

--- a/examples/notebooks/Birger Focuser Control.ipynb
+++ b/examples/notebooks/Birger Focuser Control.ipynb
@@ -31,18 +31,18 @@
    },
    "outputs": [],
    "source": [
-    "from pocs.focuser.simulator import Focuser"
+    "from pocs.focuser.birger import Focuser"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
-    "f = Focuser()"
+    "port = '/dev/tty.USA49WG2P4.4'"
    ]
   },
   {
@@ -51,20 +51,9 @@
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'Simulated Focuser'"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "f.name"
+    "f = Focuser(port=port)"
    ]
   },
   {
@@ -77,7 +66,7 @@
     {
      "data": {
       "text/plain": [
-       "'simulator'"
+       "'Birger Focuser'"
       ]
      },
      "execution_count": 5,
@@ -86,7 +75,7 @@
     }
    ],
    "source": [
-    "f.model"
+    "f.name"
    ]
   },
   {
@@ -99,7 +88,7 @@
     {
      "data": {
       "text/plain": [
-       "'/dev/ttyFAKE'"
+       "'Canon EF-232'"
       ]
      },
      "execution_count": 6,
@@ -108,7 +97,7 @@
     }
    ],
    "source": [
-    "f.port"
+    "f.model"
    ]
   },
   {
@@ -121,7 +110,7 @@
     {
      "data": {
       "text/plain": [
-       "'SF9999'"
+       "'/dev/tty.USA49WG2P4.4'"
       ]
      },
      "execution_count": 7,
@@ -130,7 +119,7 @@
     }
    ],
    "source": [
-    "f.uid"
+    "f.port"
    ]
   },
   {
@@ -143,7 +132,7 @@
     {
      "data": {
       "text/plain": [
-       "0"
+       "'XXXXXX'"
       ]
      },
      "execution_count": 8,
@@ -152,23 +141,12 @@
     }
    ],
    "source": [
-    "f.position"
+    "f.uid"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "f.move_to(100)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
    "metadata": {
     "collapsed": false
    },
@@ -176,16 +154,27 @@
     {
      "data": {
       "text/plain": [
-       "100"
+       "['DONE0,1']"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "f.position"
+    "f._send_command('mz')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "f._send_command('sf0')"
    ]
   },
   {
@@ -196,7 +185,7 @@
    },
    "outputs": [],
    "source": [
-    "f.move_by(-13)"
+    "f._send_command('la')"
    ]
   },
   {
@@ -207,51 +196,27 @@
    },
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "87"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "f.position"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "f.position = -75"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2017-01-12 18:36:42 aaomc48as.aao.gov.au panoptes[44451] ERROR Sent command 'in', Birger echoed 'DONE:LA'!\n"
+     ]
+    },
     {
-     "data": {
-      "text/plain": [
-       "-75"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
+     "ename": "IndexError",
+     "evalue": "list index out of range",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-12-a2e8a5d3693e>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mf\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_send_command\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'in'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m/Users/ajh/Documents/git/POCS/pocs/focuser/birger.py\u001b[0m in \u001b[0;36m_send_command\u001b[0;34m(self, command)\u001b[0m\n\u001b[1;32m     46\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mresponse\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0mcommand\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     47\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlogger\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0merror\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"Sent command '{}', Birger echoed '{}'!\"\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcommand\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mresponse\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 48\u001b[0;31m         \u001b[0;32mif\u001b[0m \u001b[0mresponse\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0;34m'OK'\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     49\u001b[0m             \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     50\u001b[0m                 \u001b[0merror_number\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresponse\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m3\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mIndexError\u001b[0m: list index out of range"
+     ]
     }
    ],
    "source": [
-    "f.position"
+    "f._send_command('in')"
    ]
   },
   {

--- a/examples/notebooks/Birger Focuser Control.ipynb
+++ b/examples/notebooks/Birger Focuser Control.ipynb
@@ -53,7 +53,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2017-01-13 19:27:32 aaomc48as.aao.gov.au panoptes[47163] INFO Birger Focuser(10858) on /dev/tty.USA49WG2P4.4 initialised\n"
+      "2017-01-16 14:11:49 aaomc48as.aao.gov.au panoptes[56822] INFO Birger Focuser (10858) on /dev/tty.USA49WG2P4.4 initialised\n"
      ]
     }
    ],
@@ -69,16 +69,36 @@
    },
    "outputs": [
     {
-     "ename": "TypeError",
-     "evalue": "int() argument must be a string, a bytes-like object or a number, not 'NoneType'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-5-cf206e8d4fe6>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mf\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mposition\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m/Users/ajh/Documents/git/POCS/pocs/focuser/birger.py\u001b[0m in \u001b[0;36mposition\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m     36\u001b[0m         \u001b[0mReturns\u001b[0m \u001b[0mcurrent\u001b[0m \u001b[0mfocus\u001b[0m \u001b[0mposition\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mthe\u001b[0m \u001b[0mlens\u001b[0m \u001b[0mfocus\u001b[0m \u001b[0mencoder\u001b[0m \u001b[0munits\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     37\u001b[0m         \"\"\"\n\u001b[0;32m---> 38\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_send_command\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'pf'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     39\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     40\u001b[0m \u001b[0;31m##################################################################################################\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mTypeError\u001b[0m: int() argument must be a string, a bytes-like object or a number, not 'NoneType'"
-     ]
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f.is_connected"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "22735"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -87,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
@@ -95,40 +115,16 @@
     {
      "data": {
       "text/plain": [
-       "['pf\\n', 'OK\\n', '500\\n']"
+       "10000"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "f._send_command('pf', check_response=False)\n",
-    "f._serial_io.readlines()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['rm1,0\\n', 'OK\\n']"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "f._send_command('rm1,0', check_response=False)\n",
-    "f._serial_io.readlines()"
+    "f.move_to(10000)"
    ]
   },
   {
@@ -141,7 +137,7 @@
     {
      "data": {
       "text/plain": [
-       "True"
+       "10000"
       ]
      },
      "execution_count": 8,
@@ -150,12 +146,23 @@
     }
    ],
    "source": [
-    "f.is_connected"
+    "f.position"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "f.position = 7000"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
    "metadata": {
     "collapsed": false
    },
@@ -163,22 +170,21 @@
     {
      "data": {
       "text/plain": [
-       "['mz\\n', 'OK\\n', 'DONE0,1\\n']"
+       "7001"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "f._send_command('mz', check_response=False)\n",
-    "f._serial_io.readlines()"
+    "f.position"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 11,
    "metadata": {
     "collapsed": false
    },
@@ -186,22 +192,21 @@
     {
      "data": {
       "text/plain": [
-       "['sf0\\n', 'OK\\n']"
+       "-2999"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "f._send_command('sf0', check_response=False)\n",
-    "f._serial_io.readlines()"
+    "f.move_by(-3000)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 12,
    "metadata": {
     "collapsed": false
    },
@@ -209,224 +214,16 @@
     {
      "data": {
       "text/plain": [
-       "['la\\n', 'OK\\n', 'DONE:LA\\n']"
+       "4002"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "f._send_command('la', check_response=False)\n",
-    "f._serial_io.readlines()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['in\\n', 'OK\\n', 'DONE\\n']"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "f._send_command('in', check_response=False)\n",
-    "f._serial_io.readlines()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['zz\\n', 'OK\\n', 'ERR1\\n']"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "f._send_command('zz', check_response=False)\n",
-    "f._serial_io.readlines()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['mi\\n', 'OK\\n', 'DONE22720,1\\n']"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "f._send_command('mi', check_response=False)\n",
-    "f._serial_io.readlines()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['pf\\n', 'OK\\n', '22761\\n']"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "f._send_command('pf', check_response=False)\n",
-    "f._serial_io.readlines()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['fa10000\\n', 'OK\\n', 'DONE10000,0\\n']"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "f._send_command('fa10000', check_response=False)\n",
-    "f._serial_io.readlines()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['mf-5000\\n', 'OK\\n', 'DONE-5000,0\\n']"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "f._send_command('mf-5000', check_response=False)\n",
-    "f._serial_io.readlines()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['pf\\n', 'OK\\n', '5000\\n']"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "f._send_command('pf', check_response=False)\n",
-    "f._serial_io.readlines()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['mz\\n', 'OK\\n', 'DONE-4992,1\\n']"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "f._send_command('mz', check_response=False)\n",
-    "f._serial_io.readlines()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['pf\\n', 'OK\\n', '8\\n']"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "f._send_command('pf', check_response=False)\n",
-    "f._serial_io.readlines()"
+    "f.position"
    ]
   },
   {

--- a/pocs/focuser/birger.py
+++ b/pocs/focuser/birger.py
@@ -1,5 +1,7 @@
 from pocs.focuser.focuser import AbstractFocuser
-from pocs.utils.rs232 import SerialData
+import serial
+import io
+import re
 
 class Focuser(AbstractFocuser):
     """
@@ -11,55 +13,153 @@ class Focuser(AbstractFocuser):
                  *args, **kwargs):
         super().__init__(*args, name=name, model=model, **kwargs)
         self.logger.debug('Initialising Birger focuser')
-        self._serial = SerialData(port=self.port, baudrate=115200, threaded=False, name='Birger')
         self.connect()
-        
+
+##################################################################################################
+# Properties
+##################################################################################################
+
+    @property
+    def is_connected(self):
+        """
+        Checks status of serial port to determine if connected.
+        """
+        connected = False
+        if self._serial_port:
+            connected = self._serial_port.isOpen()
+
+        return connected
+
+    @property
+    def position(self):
+        """
+        Returns current focus position in the lens focus encoder units
+        """
+        return int(self._send_command('pf'))
 
 ##################################################################################################
 # Public Methods
 ##################################################################################################
 
     def connect(self):
-        if not self._serial.connect():
-            self.logger.error('Could not connect to {}!'.format(self))
-            return
+        try:
+            # Configure serial port.
+            # Settings copied from Bob Abraham's birger.c 
+            self._serial_port = serial.Serial()
+            self._serial_port.port = self.port
+            self._serial_port.baudrate = 115200
+            self._serial_port.bytesize = serial.EIGHTBITS
+            self._serial_port.parity = serial.PARITY_NONE
+            self._serial_port.stopbits = serial.STOPBITS_ONE
+            self._serial_port.timeout = 2.0
+            self._serial_port.xonxoff = False
+            self._serial_port.rtscts = False
+            self._serial_port.dsrdtr = False
+            self._serial_port.write_timeout = None
+            self._inter_byte_timeout = None
 
-        self._connected = True
-        
+            # Establish connection
+            self._serial_port.open()
+            
+        except serial.SerialException as err:
+            self._serial_port = None
+            self.logger.critical('Could not connect to {}!'.format(self))
+
+        # Want to use a io.TextWrapper in order to have a readline() method with universal newlines
+        # (Birger sends '\r', not '\n'). The line_buffering options causes an automatic flush()
+        # of the output buffer when writing a newline, i.e. after each command.
+        self._serial_io = io.TextIOWrapper(io.BufferedRWPair(self._serial_port, self._serial_port),
+                                           encoding='ascii', line_buffering=True)
+        self.logger.debug('Established serial connection to {}.'.format(self))
+
+        # Set 'terse' and 'new' response modes. The response from this depends on
+        # what the current mode is. For now just discard it.
+        self._send_command('rm0,0', check_response=False)
+
+        # Get serial number. Note, this is the serial number of the Birger adaptor,
+        # *not* the attached lens (which would be more useful).
+        self._serial_number = self._send_command('sn')
+
+        # Initialise the aperture motor. This also has the side effect of fully opening the iris.
+        self.logger.debug('Initialising aperture motor')
+        self._send_command('in')
+
+        # Initalise focus. First move the focus to the close stop.
+        self.logger.debug('Moving focus to close stop')
+        self._send_command('mz')
+        # The reset the focus encoder counts to 0
+        self.logger.debug('Setting focus encoder zero point')
+        self._send_command('sf0')
+        # Calibrate the focus with the 'Learn Absolute Focus Range' command
+        self.logger.debug('Learning absolute focus range')
+        self._send_command('la')
+
+        # Finally move the focus to the far stop.
+        self.logger.debug('Moving focus to far stop')
+        self._send_command('mi')
+
+        self.logger.info('{} initialised'.format(self))
 
     def move_to(self, position):
-        pass
+        """
+        Move the focus to a specific position in lens encoder units.
+        Does not do any checking of the requested position but will warn if the lens reports hitting a stop.
+        Returns the actual position moved to in lens encoder units.
+        """
+        self.logger.debug('Moving {} focus to {}'.format(self, position))
+        response = self._send_command('fa{:d}'.format(position)) 
+        if response[-1] == '1':
+            self.logger.warning('{} reported hitting a focus stop'.format(self))
+        return int(response[4:-2])
 
-    def move_by(self, position):
-        pass
+    def move_by(self, increment):
+        """
+        """
+        self.logger.debug('Moving {} focus by {}'.format(self, increment))
+        response = self._send_command('mf{:d}'.format(increment))
+        if response[-1] == '1':
+            self.logger.warning('{} reporting hitting a focus stop'.format(self))
+        return int(response[4:-2])
 
 ##################################################################################################
 # Private Methods
 ##################################################################################################
 
-    def _send_command(self, command):
-        if not self._connected:
-            self.logger.error("{} not connected, cannot send command '{}'!".format(self, command))
+    def _send_command(self, command, check_response=True):
+        if not self.is_connected:
+            self.logger.critical("Attempt to send command to {} when not connected!".format(self))
             return
 
-        self._serial.write(command + '\r')
-        response = self._serial.read().split()
-        if response[0] != command:
-            self.logger.error("Sent command '{}', Birger echoed '{}'!".format(command, response[0]))
-        if response[1] != 'OK':
-            try:
-                error_number = int(response[1][3:])
-                message = error_messages[error_number]
-                self.logger.error("Sent command '{}', got error message '{}'!".format(command, message))
-            except IndexError:
-                self.logger.error("Sent command '{}', got unrecognised error message '{}'!".format(command,
-                                                                                                   response[1]))
-        if len(response) > 2:
-            return response[2:]
-        else:
-            return
+        # Clear the input buffer in case there's anything left over in there.
+        self._serial_port.reset_input_buffer()
+
+        # Send command
+        self._serial_io.write(command + '\r')
+
+        if check_response:
+            # Get response
+            response = self._serial_io.readline().rstrip()
+            # Response will begin with either 0 (success) or some other number
+            if response.startswith('0'):
+                # All OK, return the rest of the response (if any)
+                if len(response) > 1:
+                    return response[1:]
+            else:
+                # Something has gone wrong. Response should start with a 1-2 digit
+                # error code. Parse it and return the rest of the response (if any).
+                try:
+                    error_match = error_pattern.match(response)
+                    error_message = error_messages[int(error_match.group())]
+                    self.logger.error("{} returned error message '{}'!".format(self, error_message))
+                    if len(response) > error_match.end():
+                        self.logger.error("In addition {} returned'{}'".format(self, response[error_match.end():]))
+                except:
+                    self.logger.error("Could not parse response '{}' from {}!".format(response, self))
 
 
+# Error codes should be 1-2 digits
+error_pattern = re.compile('\d{1,2}')
+                                       
 error_messages = ('No error',
                   'Unrecognised command',
                   'Lens is in manual focus mode',

--- a/pocs/focuser/birger.py
+++ b/pocs/focuser/birger.py
@@ -1,0 +1,88 @@
+from pocs.focuser.focuser import AbstractFocuser
+from pocs.utils.rs232 import SerialData
+
+class Focuser(AbstractFocuser):
+    """
+    Focuser class for control of a Canon DSLR lens via a Birger Engineering Canon EF-232 adapter
+    """
+    def __init__(self,
+                 name='Birger Focuser',
+                 model='Canon EF-232',
+                 *args, **kwargs):
+        super().__init__(*args, name=name, model=model, **kwargs)
+        self.logger.debug('Initialising Birger focuser')
+        self._serial = SerialData(port=self.port, baudrate=115200, threaded=False, name='Birger')
+        self.connect()
+        
+
+##################################################################################################
+# Public Methods
+##################################################################################################
+
+    def connect(self):
+        if not self._serial.connect():
+            self.logger.error('Could not connect to {}!'.format(self))
+            return
+
+        self._connected = True
+        
+
+    def move_to(self, position):
+        pass
+
+    def move_by(self, position):
+        pass
+
+##################################################################################################
+# Private Methods
+##################################################################################################
+
+    def _send_command(self, command):
+        if not self._connected:
+            self.logger.error("{} not connected, cannot send command '{}'!".format(self, command))
+            return
+
+        self._serial.write(command + '\r')
+        response = self._serial.read().split()
+        if response[0] != command:
+            self.logger.error("Sent command '{}', Birger echoed '{}'!".format(command, response[0]))
+        if response[1] != 'OK':
+            try:
+                error_number = int(response[1][3:])
+                message = error_messages[error_number]
+                self.logger.error("Sent command '{}', got error message '{}'!".format(command, message))
+            except IndexError:
+                self.logger.error("Sent command '{}', got unrecognised error message '{}'!".format(command,
+                                                                                                   response[1]))
+        if len(response) > 2:
+            return response[2:]
+        else:
+            return
+
+
+error_messages = ('No error',
+                  'Unrecognised command',
+                  'Lens is in manual focus mode',
+                  'No lens connected',
+                  'Lens distance stop error',
+                  'Aperture not initialised',
+                  'Invalid baud rate specified',
+                  'Reserved',
+                  'Reserved',
+                  'A bad parameter was supplied to the command',
+                  'XModem timeout',
+                  'XModem error',
+                  'XModem unlock code incorrect',
+                  'Not used',
+                  'Invalid port',
+                  'Licence unlock failure',
+                  'Invalid licence file',
+                  'Invalid library file',
+                  'Reserved',
+                  'Reserved',
+                  'Not used',
+                  'Library not ready for lens communications',
+                  'Library not ready for commands',
+                  'Command not licensed',
+                  'Invalid focus range in memory. Try relearning the range',
+                  'Distance stops not supported by the lens')                                  

--- a/pocs/focuser/focuser.py
+++ b/pocs/focuser/focuser.py
@@ -1,0 +1,62 @@
+from .. import PanBase
+
+
+class AbstractFocuser(PanBase):
+    """
+    Base class for all focusers
+    """
+    def __init__(self,
+                 name='Generic Focuser',
+                 model='simulator',
+                 port=None,
+                 *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.model = model
+        self.port = port
+        self.name = name
+
+        self._connected = False
+        self._serial_number = 'XXXXXX'
+        self._position = None
+
+        self.logger.debug('Focuser created: {}'.format(self))
+
+##################################################################################################
+# Properties
+##################################################################################################
+
+    @property
+    def uid(self):
+        """ A serial number for the focuser """
+        return self._serial_number
+
+    @property
+    def is_connected(self):
+        """ Is the focuser available """
+        return self._connected
+
+    @property
+    def position(self):
+        """ Current encoder position of the focuser """
+        return self._position
+
+    @position.setter
+    def position(self, position):
+        """ Move focusser to new encoder position """
+        self.move_to(position)
+
+##################################################################################################
+# Methods
+##################################################################################################
+
+def move_to(self, position):
+    """ Move focusser to new encoder position """
+    raise NotImplementedError
+
+def move_by(self, increment):
+    """ Move focusser by a given amount """
+    raise NotImplementedError
+
+def __str__(self):
+    return "{}({}) on {}".format(self.name, self.uid, self.port)

--- a/pocs/focuser/focuser.py
+++ b/pocs/focuser/focuser.py
@@ -50,13 +50,13 @@ class AbstractFocuser(PanBase):
 # Methods
 ##################################################################################################
 
-def move_to(self, position):
-    """ Move focusser to new encoder position """
-    raise NotImplementedError
+    def move_to(self, position):
+        """ Move focusser to new encoder position """
+        raise NotImplementedError
 
-def move_by(self, increment):
-    """ Move focusser by a given amount """
-    raise NotImplementedError
+    def move_by(self, increment):
+        """ Move focusser by a given amount """
+        raise NotImplementedError
 
-def __str__(self):
-    return "{}({}) on {}".format(self.name, self.uid, self.port)
+    def __str__(self):
+        return "{}({}) on {}".format(self.name, self.uid, self.port)

--- a/pocs/focuser/focuser.py
+++ b/pocs/focuser/focuser.py
@@ -20,7 +20,7 @@ class AbstractFocuser(PanBase):
         self._serial_number = 'XXXXXX'
         self._position = None
 
-        self.logger.debug('Focuser created: {}'.format(self))
+        self.logger.debug('Focuser created: {} on {}'.format(self.name, self.port))
 
 ##################################################################################################
 # Properties
@@ -59,4 +59,4 @@ class AbstractFocuser(PanBase):
         raise NotImplementedError
 
     def __str__(self):
-        return "{}({}) on {}".format(self.name, self.uid, self.port)
+        return "{} ({}) on {}".format(self.name, self.uid, self.port)

--- a/pocs/focuser/simulator.py
+++ b/pocs/focuser/simulator.py
@@ -3,6 +3,7 @@ from .focuser import AbstractFocuser
 
 import time
 
+
 class Focuser(AbstractFocuser):
     """
     Simple focuser simulator
@@ -15,7 +16,7 @@ class Focuser(AbstractFocuser):
         self.logger.debug("Initialising simulator focuser")
 
         self.connect()
-    
+
 ##################################################################################################
 # Methods
 ##################################################################################################

--- a/pocs/focuser/simulator.py
+++ b/pocs/focuser/simulator.py
@@ -14,7 +14,6 @@ class Focuser(AbstractFocuser):
                  *args, **kwargs):
         super().__init__(*args, name=name, port=port, **kwargs)
         self.logger.debug("Initialising simulator focuser")
-
         self.connect()
 
 ##################################################################################################

--- a/pocs/focuser/simulator.py
+++ b/pocs/focuser/simulator.py
@@ -1,0 +1,43 @@
+from .. import PanBase
+from .focuser import AbstractFocuser
+
+import time
+
+class Focuser(AbstractFocuser):
+    """
+    Simple focuser simulator
+    """
+    def __init__(self,
+                 name='Simulated Focuser',
+                 port='/dev/ttyFAKE',
+                 *args, **kwargs):
+        super().__init__(*args, name=name, port=port, **kwargs)
+        self.logger.debug("Initialising simulator focuser")
+
+        self.connect()
+    
+##################################################################################################
+# Methods
+##################################################################################################
+
+    def connect(self):
+        """
+        Simulator pretends to connect a focuser and obtain details, current state.
+        """
+        time.sleep(1)
+        self._connected = True
+        self._serial_number = 'SF9999'
+        self._position = 0
+        self.logger.debug("Connected to focuser {}".format(self.uid))
+
+    def move_to(self, position):
+        """ Move focuser to a new encorder position """
+        self.logger.debug('Moving focuser {} to {}'.format(self.uid, position))
+        time.sleep(1)
+        self._position = position
+
+    def move_by(self, increment):
+        """ Move focuser by a given amount """
+        self.logger.debug('Moving focuser {} by {}'.format(self.uid, increment))
+        time.sleep(1)
+        self._position += increment

--- a/pocs/tests/test_focuser.py
+++ b/pocs/tests/test_focuser.py
@@ -1,37 +1,81 @@
 import pytest
 
-from pocs.focuser.simulator import Focuser
+from pocs.focuser.simulator import Focuser as SimFocuser
+from pocs.focuser.birger import Focuser as BirgerFocuser
+
+from serial import SerialException
+
+
+@pytest.fixture(scope='module', params=[SimFocuser, BirgerFocuser], ids=['simulator', 'birger'])
+def focuser(request):
+    if request.param == SimFocuser:
+        return request.param()
+    elif request.param == BirgerFocuser:
+        # No automatic way to find ports for Birger Focusers, need to specify manually
+        try:
+            focuser = request.param(port='/dev/tty.USA49WG2P4.4')
+            return focuser
+        except SerialException:
+            # Error opening the serial port, probably because the specified port doesn't exist.
+            # Can't tell if this is expected, have to assume that it is.
+            pytest.xfail("Couldn't open serial port, assuming there's no Birger Focuser to test")
+        except AssertionError:
+            # Error in communucating with the Birger adaptor. Probably means there isn't one on
+            # this port, or it hasn't got power. Can't tell if this is expected, assume it is.
+            pytest.xfail("Couldn't commuicate with Birger Focuser, assuming there isn't one to test")
+    else:
+        pytest.fail("Don't know what to do with this Focuser subclass!")
 
 
 @pytest.fixture(scope='module')
-def focuser():
-    return Focuser()
+def uid(focuser):
+    """
+    Expected serial numbers. No way of predicting this for Birger Focusers, this will need
+    to be changed manually.
+    """
+    if isinstance(focuser, SimFocuser):
+        return 'SF9999'
+    elif isinstance(focuser, BirgerFocuser):
+        return '10858'
+    else:
+        pytest.fail("Don't know what to do with this Focuser subclass!")
 
 
-def test_focuser_init(focuser):
+@pytest.fixture(scope='module')
+def tolerance(focuser):
+    """
+    Tolerance for confirming focuser has moved to the requested position. The Birger may be
+    1 or 2 encoder steps off.
+    """
+    if isinstance(focuser, SimFocuser):
+        return 0
+    elif isinstance(focuser, BirgerFocuser):
+        return 2
+
+
+def test_focuser_init(focuser, uid):
     """
     Confirm proper init & exercise some of the property getters
     """
     assert focuser.is_connected
-    assert focuser.uid == 'SF9999'
-    assert focuser.position == 0
+    assert focuser.uid == uid
 
 
-def test_focuser_move_to(focuser):
+def test_focuser_move_to(focuser, tolerance):
     focuser.move_to(100)
-    assert focuser.position == 100
+    assert abs(focuser.position - 100) <= tolerance
 
 
-def test_focuser_move_by(focuser):
+def test_focuser_move_by(focuser, tolerance):
     previous_position = focuser.position
     increment = -13
     focuser.move_by(increment)
-    assert focuser.position == previous_position + increment
+    assert abs(focuser.position - (previous_position + increment)) <= tolerance
 
 
-def test_position_setter(focuser):
+def test_position_setter(focuser, tolerance):
     """
     Can assign to position property as an alternative to move_to() method
     """
-    focuser.position = -75
-    assert focuser.position == -75
+    focuser.position = 75
+    assert abs(focuser.position - 75) <= tolerance

--- a/pocs/tests/test_focuser.py
+++ b/pocs/tests/test_focuser.py
@@ -1,0 +1,37 @@
+import pytest
+
+from pocs.focuser.simulator import Focuser
+
+
+@pytest.fixture(scope='module')
+def focuser():
+    return Focuser()
+
+
+def test_focuser_init(focuser):
+    """
+    Confirm proper init & exercise some of the property getters
+    """
+    assert focuser.is_connected
+    assert focuser.uid == 'SF9999'
+    assert focuser.position == 0
+
+
+def test_focuser_move_to(focuser):
+    focuser.move_to(100)
+    assert focuser.position == 100
+
+
+def test_focuser_move_by(focuser):
+    previous_position = focuser.position
+    increment = -13
+    focuser.move_by(increment)
+    assert focuser.position == previous_position + increment
+
+
+def test_position_setter(focuser):
+    """
+    Can assign to position property as an alternative to move_to() method
+    """
+    focuser.position = -75
+    assert focuser.position == -75


### PR DESCRIPTION
Adds support for focus control via Birger Engineering Canon EF-232 camera lens adaptors.

http://www.birger.com/downloads.aspx

Includes an base class for focusers, a focuser simulator class, a Birger focuser class, an example notebook and unit tests covering both the simulator and Birger focusers.

As with the SBIG camera support there's no reliable way to do hardware detection in order to determine whether the Birger focuser tests should run, the tests will simply xfail if there is a failure to open the serial port or communicate with the adaptor. This could mask genuine problems.