### PR TITLE
gphoto2 cameras

### DIFF
--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -311,6 +311,22 @@ class AbstractGPhotoCamera(AbstractCamera):  # pragma: no cover
         # Forces the command to wait
         self.get_command_result()
 
+    def set_property_values(self, prop_vals):
+        """ Sets a number of properties all at once
+
+        Args:
+            prop_vals (dict): A dict with keys corresponding to the property to
+            be set and values corresponding to the index option
+        """
+        set_cmd = list()
+        for prop, val in prop_vals.items():
+            set_cmd.append('--set-config-index {}={}'.format(prop, val))
+
+        self.command(set_cmd)
+
+        # Forces the command to wait
+        self.get_command_result()
+
     def get_property(self, prop):
         """ Gets a property from the camera """
         set_cmd = ['--get-config', '{}'.format(prop)]

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -311,16 +311,32 @@ class AbstractGPhotoCamera(AbstractCamera):  # pragma: no cover
         # Forces the command to wait
         self.get_command_result()
 
-    def set_property_values(self, prop_vals):
-        """ Sets a number of properties all at once
+    def set_properties_by_index(self, prop_indices):
+        """ Sets a number of properties all at once by index
 
         Args:
-            prop_vals (dict): A dict with keys corresponding to the property to
+            prop_indices (dict): A dict with keys corresponding to the property to
             be set and values corresponding to the index option
         """
         set_cmd = list()
+        for prop, val in prop_indices.items():
+            set_cmd.extend(["--set-config-index", "{}={}".format(prop, val)])
+
+        self.command(set_cmd)
+
+        # Forces the command to wait
+        self.get_command_result()
+
+    def set_properties_by_value(self, prop_vals):
+        """ Sets a number of properties all at once by value
+
+        Args:
+            prop_vals (dict): A dict with keys corresponding to the property to
+            be set and values corresponding to the value
+        """
+        set_cmd = list()
         for prop, val in prop_vals.items():
-            set_cmd.append('--set-config-index {}={}'.format(prop, val))
+            set_cmd.extend(["--set-config-value", "{}='{}'".format(prop, val)])
 
         self.command(set_cmd)
 

--- a/pocs/camera/canon_gphoto2.py
+++ b/pocs/camera/canon_gphoto2.py
@@ -34,28 +34,30 @@ class Camera(AbstractGPhotoCamera):
             self._serial_number = _serial_number
 
         # Properties to be set upon init.
-        properties = {
-            '/main/actions/viewfinder': 1,
-            '/main/settings/autopoweroff': 0,
-            '/main/settings/reviewtime': 0,
-            '/main/settings/capturetarget': 0,
-            '/main/imgsettings/imageformat': 9,
-            '/main/imgsettings/imageformatsd': 9,
-            '/main/imgsettings/imageformatcf': 9,
-            '/main/imgsettings/iso': 9,
-            '/main/capturesettings/focusmode': 0,
-            '/main/capturesettings/continuousaf': 0,
-            '/main/capturesettings/autoexposuremode': 3,
-            '/main/capturesettings/drivemode': 0,
-            '/main/capturesettings/shutterspeed': 0,
+        index_dict = {
+            '/main/actions/viewfinder': 1,                # Screen off
+            '/main/settings/autopoweroff': 0,             # No auto power down
+            '/main/settings/reviewtime': 0,               # No preview after image
+            '/main/settings/capturetarget': 0,            # Internal RAM
+            '/main/imgsettings/imageformat': 9,           # RAW images
+            '/main/imgsettings/imageformatsd': 9,         # RAW images
+            '/main/imgsettings/imageformatcf': 9,         # RAW images
+            '/main/imgsettings/iso': 1,                   # ISO 100
+            '/main/capturesettings/focusmode': 0,         # Manual focus
+            '/main/capturesettings/continuousaf': 0,      # No auto-focus
+            '/main/capturesettings/autoexposuremode': 3,  # 3 - Manual; 4 - Bulb
+            '/main/capturesettings/drivemode': 0,         # Single exposure
+            '/main/capturesettings/shutterspeed': 0,      # Bulb
         }
+        self.set_properties_by_index(index_dict)
 
-        self.set_property_values(properties)
+        value_dict = {
+            '/main/settings/artist': 'Project PANOPTES',
+            '/main/settings/ownername': 'Project PANOPTES',
+            '/main/settings/copyright': 'Project PANOPTES {}'.format(current_time().datetime.year),
 
-        if first_init:
-            self.set_property('/main/settings/artist', 'Project PANOPTES')
-            self.set_property('/main/settings/ownername', 'Project PANOPTES')
-            self.set_property('/main/settings/copyright', 'Project PANOPTES 2016')
+        }
+        self.set_properties_by_value(value_dict)
 
         self._connected = True
 

--- a/pocs/camera/canon_gphoto2.py
+++ b/pocs/camera/canon_gphoto2.py
@@ -21,7 +21,7 @@ class Camera(AbstractGPhotoCamera):
         self.connect()
         self.logger.debug("{} connected".format(self.name))
 
-    def connect(self):
+    def connect(self, first_init=False):
         """Connect to Canon DSLR
 
         Gets the serial number from the camera and sets various settings
@@ -33,24 +33,29 @@ class Camera(AbstractGPhotoCamera):
         if _serial_number > '':
             self._serial_number = _serial_number
 
-        self.set_property('/main/actions/viewfinder', 1)       # Screen off
-        self.set_property('/main/settings/autopoweroff', 0)     # Don't power off
-        self.set_property('/main/settings/reviewtime', 0)       # Screen off
-        self.set_property('/main/settings/capturetarget', 0)    # Internal RAM (for download)
-        self.set_property('/main/settings/artist', 'Project PANOPTES')
-        self.set_property('/main/settings/ownername', 'Project PANOPTES')
-        self.set_property('/main/settings/copyright', 'Project PANOPTES 2016')
-        self.set_property('/main/imgsettings/imageformat', 9)       # RAW
-        self.set_property('/main/imgsettings/imageformatsd', 9)     # RAW
-        self.set_property('/main/imgsettings/imageformatcf', 9)     # RAW
-        self.set_property('/main/imgsettings/iso', 1)               # ISO 100
-        self.set_property('/main/capturesettings/focusmode', 0)         # Manual
-        self.set_property('/main/capturesettings/continuousaf', 0)         # No AF
-        self.set_property('/main/capturesettings/autoexposuremode', 3)  # 3 - Manual; 4 - Bulb
-        self.set_property('/main/capturesettings/drivemode', 0)         # Single exposure
-        self.set_property('/main/capturesettings/shutterspeed', 0)      # Bulb
-        # self.set_property('/main/actions/syncdatetime', 1)  # Sync date and time to computer
-        # self.set_property('/main/actions/uilock', 1)        # Don't let the UI change
+        # Properties to be set upon init.
+        properties = {
+            '/main/actions/viewfinder': 1,
+            '/main/settings/autopoweroff': 0,
+            '/main/settings/reviewtime': 0,
+            '/main/settings/capturetarget': 0,
+            '/main/imgsettings/imageformat': 9,
+            '/main/imgsettings/imageformatsd': 9,
+            '/main/imgsettings/imageformatcf': 9,
+            '/main/imgsettings/iso': 9,
+            '/main/capturesettings/focusmode': 0,
+            '/main/capturesettings/continuousaf': 0,
+            '/main/capturesettings/autoexposuremode': 3,
+            '/main/capturesettings/drivemode': 0,
+            '/main/capturesettings/shutterspeed': 0,
+        }
+
+        self.set_property_values(properties)
+
+        if first_init:
+            self.set_property('/main/settings/artist', 'Project PANOPTES')
+            self.set_property('/main/settings/ownername', 'Project PANOPTES')
+            self.set_property('/main/settings/copyright', 'Project PANOPTES 2016')
 
         self._connected = True
 


### PR DESCRIPTION
* Add a method to set a number of properties (by index) all at once
* Do not set the `artist` and `copyright` every time we start (will probably
need to work out how best to incorporate `first_init` into overall unit setup)

Part of #108 

:warning: This has been minimally tested with hardware but did work without problems during limited testing.