### PR TITLE
Set gphoto2 faster

### DIFF
--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -331,22 +331,6 @@ class AbstractGPhotoCamera(AbstractCamera):  # pragma: no cover
         # Forces the command to wait
         self.get_command_result()
 
-    def set_property_values(self, prop_vals):
-        """ Sets a number of properties all at once
-
-        Args:
-            prop_vals (dict): A dict with keys corresponding to the property to
-            be set and values corresponding to the index option
-        """
-        set_cmd = list()
-        for prop, val in prop_vals.items():
-            set_cmd.append('--set-config-index {}={}'.format(prop, val))
-
-        self.command(set_cmd)
-
-        # Forces the command to wait
-        self.get_command_result()
-
     def get_property(self, prop):
         """ Gets a property from the camera """
         set_cmd = ['--get-config', '{}'.format(prop)]

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -263,7 +263,7 @@ class AbstractGPhotoCamera(AbstractCamera):  # pragma: no cover
 
             try:
                 self._proc = subprocess.Popen(
-                    run_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True)
+                    run_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True, shell=False)
             except OSError as e:
                 raise error.InvalidCommand("Can't send command to gphoto2. {} \t {}".format(e, run_cmd))
             except ValueError as e:
@@ -311,6 +311,42 @@ class AbstractGPhotoCamera(AbstractCamera):  # pragma: no cover
         # Forces the command to wait
         self.get_command_result()
 
+    def set_properties(self, prop2index, prop2value):
+        """ Sets a number of properties all at once, by index or value.
+
+        Args:
+            prop2index (dict): A dict with keys corresponding to the property to
+            be set and values corresponding to the index option
+            prop2value (dict): A dict with keys corresponding to the property to
+            be set and values corresponding to the literal value
+        """
+        set_cmd = list()
+        for prop, val in prop2index.items():
+            set_cmd.extend(['--set-config-index', '{}={}'.format(prop, val)])
+        for prop, val in prop2value.items():
+            set_cmd.extend(['--set-config-value', '{}={}'.format(prop, val)])
+
+        self.command(set_cmd)
+
+        # Forces the command to wait
+        self.get_command_result()
+
+    def set_property_values(self, prop_vals):
+        """ Sets a number of properties all at once
+
+        Args:
+            prop_vals (dict): A dict with keys corresponding to the property to
+            be set and values corresponding to the index option
+        """
+        set_cmd = list()
+        for prop, val in prop_vals.items():
+            set_cmd.append('--set-config-index {}={}'.format(prop, val))
+
+        self.command(set_cmd)
+
+        # Forces the command to wait
+        self.get_command_result()
+
     def get_property(self, prop):
         """ Gets a property from the camera """
         set_cmd = ['--get-config', '{}'.format(prop)]
@@ -320,7 +356,7 @@ class AbstractGPhotoCamera(AbstractCamera):  # pragma: no cover
 
         output = ''
         for line in result.split('\n'):
-            match = re.match('Current:\s(.*)', line)
+            match = re.match(r'Current:\s*(.*)', line)
             if match:
                 output = match.group(1)
 
@@ -345,12 +381,12 @@ class AbstractGPhotoCamera(AbstractCamera):  # pragma: no cover
         yaml_string = ''
         for line in lines:
             IsID = len(line.split('/')) > 1
-            IsLabel = re.match('^Label:\s(.*)', line)
-            IsType = re.match('^Type:\s(.*)', line)
-            IsCurrent = re.match('^Current:\s(.*)', line)
-            IsChoice = re.match('^Choice:\s(\d+)\s(.*)', line)
-            IsPrintable = re.match('^Printable:\s(.*)', line)
-            IsHelp = re.match('^Help:\s(.*)', line)
+            IsLabel = re.match(r'^Label:\s*(.*)', line)
+            IsType = re.match(r'^Type:\s*(.*)', line)
+            IsCurrent = re.match(r'^Current:\s*(.*)', line)
+            IsChoice = re.match(r'^Choice:\s*(\d+)\s*(.*)', line)
+            IsPrintable = re.match(r'^Printable:\s*(.*)', line)
+            IsHelp = re.match(r'^Help:\s*(.*)', line)
             if IsLabel:
                 line = '  {}'.format(line)
             elif IsType:

--- a/pocs/camera/canon_gphoto2.py
+++ b/pocs/camera/canon_gphoto2.py
@@ -42,7 +42,7 @@ class Camera(AbstractGPhotoCamera):
             '/main/imgsettings/imageformat': 9,           # RAW
             '/main/imgsettings/imageformatsd': 9,         # RAW
             '/main/imgsettings/imageformatcf': 9,         # RAW
-            '/main/imgsettings/iso': 1,                   # ISO 100 
+            '/main/imgsettings/iso': 1,                   # ISO 100
             '/main/capturesettings/focusmode': 0,         # Manual (don't try to focus)
             '/main/capturesettings/continuousaf': 0,      # No auto-focus
             '/main/capturesettings/autoexposuremode': 3,  # 3 - Manual; 4 - Bulb

--- a/pocs/camera/canon_gphoto2.py
+++ b/pocs/camera/canon_gphoto2.py
@@ -1,4 +1,3 @@
-import datetime
 import os
 import subprocess
 
@@ -53,7 +52,7 @@ class Camera(AbstractGPhotoCamera):
         prop2value = {
             '/main/settings/artist': 'Project PANOPTES',
             '/main/settings/ownername': 'Project PANOPTES',
-            '/main/settings/copyright': 'Project PANOPTES {}'.format(datetime.datetime.today().year),
+            '/main/settings/copyright': 'Project PANOPTES {}'.format(current_time().datetime.year),
         }
 
         self.set_properties(prop2index, prop2value)

--- a/pocs/camera/canon_gphoto2.py
+++ b/pocs/camera/canon_gphoto2.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import subprocess
 
@@ -33,25 +34,29 @@ class Camera(AbstractGPhotoCamera):
         if _serial_number > '':
             self._serial_number = _serial_number
 
-        self.set_property('/main/actions/viewfinder', 1)       # Screen off
-        self.set_property('/main/settings/autopoweroff', 0)     # Don't power off
-        self.set_property('/main/settings/reviewtime', 0)       # Screen off
-        self.set_property('/main/settings/capturetarget', 0)    # Internal RAM (for download)
-        self.set_property('/main/settings/artist', 'Project PANOPTES')
-        self.set_property('/main/settings/ownername', 'Project PANOPTES')
-        self.set_property('/main/settings/copyright', 'Project PANOPTES 2016')
-        self.set_property('/main/imgsettings/imageformat', 9)       # RAW
-        self.set_property('/main/imgsettings/imageformatsd', 9)     # RAW
-        self.set_property('/main/imgsettings/imageformatcf', 9)     # RAW
-        self.set_property('/main/imgsettings/iso', 1)               # ISO 100
-        self.set_property('/main/capturesettings/focusmode', 0)         # Manual
-        self.set_property('/main/capturesettings/continuousaf', 0)         # No AF
-        self.set_property('/main/capturesettings/autoexposuremode', 3)  # 3 - Manual; 4 - Bulb
-        self.set_property('/main/capturesettings/drivemode', 0)         # Single exposure
-        self.set_property('/main/capturesettings/shutterspeed', 0)      # Bulb
-        # self.set_property('/main/actions/syncdatetime', 1)  # Sync date and time to computer
-        # self.set_property('/main/actions/uilock', 1)        # Don't let the UI change
+        # Properties to be set upon init.
+        prop2index = {
+            '/main/actions/viewfinder': 1,                # Screen off
+            '/main/settings/autopoweroff': 0,             # Don't power off
+            '/main/settings/reviewtime': 0,               # Screen off after taking pictures
+            '/main/settings/capturetarget': 0,            # Capture to RAM, for download
+            '/main/imgsettings/imageformat': 9,           # RAW
+            '/main/imgsettings/imageformatsd': 9,         # RAW
+            '/main/imgsettings/imageformatcf': 9,         # RAW
+            '/main/imgsettings/iso': 1,                   # ISO 100 
+            '/main/capturesettings/focusmode': 0,         # Manual (don't try to focus)
+            '/main/capturesettings/continuousaf': 0,      # No auto-focus
+            '/main/capturesettings/autoexposuremode': 3,  # 3 - Manual; 4 - Bulb
+            '/main/capturesettings/drivemode': 0,         # Single exposure
+            '/main/capturesettings/shutterspeed': 0,      # Bulb
+        }
+        prop2value = {
+            '/main/settings/artist': 'Project PANOPTES',
+            '/main/settings/ownername': 'Project PANOPTES',
+            '/main/settings/copyright': 'Project PANOPTES {}'.format(datetime.datetime.today().year),
+        }
 
+        self.set_properties(prop2index, prop2value)
         self._connected = True
 
     def take_observation(self, observation, headers=None, filename=None, **kwargs):

--- a/scripts/solve_field.sh
+++ b/scripts/solve_field.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+SOLVE_FIELD="${PANDIR}/astrometry/bin/solve-field"
+
 if [[ $# == 1 ]]; then
     echo "Using options: --guess-scale --no-plots --downsample 3 --overwrite"
-    solve-field --guess-scale --no-plots --downsample 3 --overwrite $1
+    ${SOLVE_FIELD} --guess-scale --no-plots --downsample 3 --overwrite $1
 else
-    solve-field $@
+    ${SOLVE_FIELD} $@
 fi


### PR DESCRIPTION
Set multiple gphoto2 properties in a single command, and support setting by both index or value.
Fix regular expression literals that should have been raw-string-literals (i.e. needed r prefix).