### PR TITLE
Remove download_all call from tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,7 @@ install:
   - cd $TRAVIS_BUILD_DIR
   - pip install -r requirements.txt
   - python setup.py install
+  - python pocs/utils/data.py
 script:
   - coverage run setup.py test
   - coverage combine .coverage*

--- a/pocs/tests/conftest.py
+++ b/pocs/tests/conftest.py
@@ -5,11 +5,6 @@ from pocs.utils.config import load_config
 from pocs.utils.data import download_all_files
 from pocs.utils.database import PanMongo
 
-try:
-    download_all_files()
-except Exception as e:
-    pass
-
 
 def pytest_addoption(parser):
     parser.addoption("--hardware-test", action="store_true", default=False, help="Test with hardware attached")


### PR DESCRIPTION
Instead do it in the travis.yml file before running the tests.

Fixes #121 