### PR TITLE
Log file updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,5 +46,15 @@ playground rules and follow them during all your contributions.
       + WARNING (i.e. `self.logger.warning()`) should alert when something does not go as expected but operation of unit can continue.
       + ERROR (i.e. `self.logger.error()`) should be used at critical levels when operation cannot continue.
    + The logger support variable information without the use of the `format` method. Examples:
-      * `self.logger.info("Welcome {}", self.config['name'])`
-      * `self.logger.debug("Connection to camera {} on {}", cam_num, cam_port)`
+      
+```
+self.logger.info("Starting Exposure {} of {}", i, num_exposures)
+self.logger.debug("Taking {} second exposure", num_seconds)
+self.logger.debug("Observation: {}: {} exposures in blocks of {}, minimum {}, priority {}",
+   obs_name,
+   exp_time,
+   block_size,
+   block_min_size,
+   priority   
+)
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,17 +38,36 @@ playground rules and follow them during all your contributions.
 - Do not leave in commented-out code or unnecessary whitespace.
 - Variable/function/class and file names should be meaningful and descriptive.
 - File names should be underscored, not contain spaces ex. my_file.py.
-- Define any project specific terminology or abbreviations you use in the file you use them.
+- Define any project specific terminology or abbreviations you use in the file where you use them.
 
 # Log Messages
 
 Use appropriate logging:
 - Log level:
-   - INFO (i.e. `self.logger.info()`) should be used sparingly and meant to convey information to a person actively watching a running unit.
    - DEBUG (i.e. `self.logger.debug()`) should attempt to capture all run-time information.
+   - INFO (i.e. `self.logger.info()`) should be used sparingly and meant to convey information to a person actively watching a running unit.
    - WARNING (i.e. `self.logger.warning()`) should alert when something does not go as expected but operation of unit can continue.
    - ERROR (i.e. `self.logger.error()`) should be used at critical levels when operation cannot continue.
-- The logger supports variable information without the use of the `format` method. See examples in screenshot below.
+- The logger supports variable information without the use of the `format` method.
+- There is a `say` method that is meant to be used in friendly manner to convey information to a user. This should be used only for personable output and is typically displayed in the "chat box" of the PAWS website. These messages are also sent to the INFO level logger
+
+Logging examples:
+__Note__ These are meant to illustrate the logging calls and are not necessarily indicative of real operation
+
+```
+self.logger.info("PANOPTES unit initialized: {}", self.config['name'])
+self.say("I'm all ready to go, first checking the weather")
+self.logger.debug("Setting up weather station")
+self.logger.warning('Problem getting wind safety: {}'.format(e))
+self.logger.debug("Rain: {} Clouds: {} Dark: {}",
+   is_raining,
+   is_cloudy,
+   is_dark
+)
+self.logger.error('Unable to connect to AAG Cloud Sensor, cannot continue')
+```
+
+
 - The [`grc`](https://github.com/garabik/grc) (generic colouriser) can be used with `tail` to get pretty log files. The following screenshot shows commands entered into a `jupyter-console` in the top panel and the log file in the bottom panel.
 
 <p align="center">

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,22 +39,18 @@ playground rules and follow them during all your contributions.
 - Variable/function/class and file names should be meaningful and descriptive.
 - File names should be underscored, not contain spaces ex. my_file.py.
 - Define any project specific terminology or abbreviations you use in the file you use them.
-- Use appropriate logging:
-   + Log level:
-      + INFO (i.e. `self.logger.info()`) should be used sparingly and meant to convey information to a person actively watching a running unit.
-      + DEBUG (i.e. `self.logger.debug()`) should attempt to capture all run-time information.
-      + WARNING (i.e. `self.logger.warning()`) should alert when something does not go as expected but operation of unit can continue.
-      + ERROR (i.e. `self.logger.error()`) should be used at critical levels when operation cannot continue.
-   + The logger support variable information without the use of the `format` method. Examples:
-      
-```
-self.logger.info("Starting Exposure {} of {}", i, num_exposures)
-self.logger.debug("Taking {} second exposure", num_seconds)
-self.logger.debug("Observation: {}: {} exposures in blocks of {}, minimum {}, priority {}",
-   obs_name,
-   exp_time,
-   block_size,
-   block_min_size,
-   priority   
-)
-```
+
+# Log Messages
+
+Use appropriate logging:
+- Log level:
+   - INFO (i.e. `self.logger.info()`) should be used sparingly and meant to convey information to a person actively watching a running unit.
+   - DEBUG (i.e. `self.logger.debug()`) should attempt to capture all run-time information.
+   - WARNING (i.e. `self.logger.warning()`) should alert when something does not go as expected but operation of unit can continue.
+   - ERROR (i.e. `self.logger.error()`) should be used at critical levels when operation cannot continue.
+- The logger supports variable information without the use of the `format` method. See examples in screenshot below.
+- The [`grc`](https://github.com/garabik/grc) (generic colouriser) can be used with `tail` to get pretty log files. The following screenshot shows commands entered into a `jupyter-console` in the top panel and the log file in the bottom panel.
+
+<p align="center">
+   <img src="http://www.projectpanoptes.org/images/log-example.png" width="600">
+</p>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,17 @@ playground rules and follow them during all your contributions.
 
 - All Python should use [PEP 8 Standards](https://www.python.org/dev/peps/pep-0008/)
    - Line length is set at 120 characters instead of 80
+   - It is recommended to have your editor auto-format code whenever you save a file rather than attempt to go back and change an entire file all at once. 
 - Do not leave in commented-out code or unnecessary whitespace.
-- Variable/function/class and file names should be meaningful and descriptive
-- File names should be underscored, not contain spaces ex. my_file.py
-- Define any project specific terminology or abbreviations you use in the file you use them
+- Variable/function/class and file names should be meaningful and descriptive.
+- File names should be underscored, not contain spaces ex. my_file.py.
+- Define any project specific terminology or abbreviations you use in the file you use them.
+- Use appropriate logging:
+   + Log level:
+      + INFO (i.e. `self.logger.info()`) should be used sparingly and meant to convey information to a person actively watching a running unit.
+      + DEBUG (i.e. `self.logger.debug()`) should attempt to capture all run-time information.
+      + WARNING (i.e. `self.logger.warning()`) should alert when something does not go as expected but operation of unit can continue.
+      + ERROR (i.e. `self.logger.error()`) should be used at critical levels when operation cannot continue.
+   + The logger support variable information without the use of the `format` method. Examples:
+      * `self.logger.info("Welcome {}", self.config['name'])`
+      * `self.logger.debug("Connection to camera {} on {}", cam_num, cam_port)`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,8 @@ Use appropriate logging:
 - There is a `say` method that is meant to be used in friendly manner to convey information to a user. This should be used only for personable output and is typically displayed in the "chat box" of the PAWS website. These messages are also sent to the INFO level logger
 
 Logging examples:
-__Note__ These are meant to illustrate the logging calls and are not necessarily indicative of real operation
+
+_Note: These are meant to illustrate the logging calls and are not necessarily indicative of real operation_
 
 ```
 self.logger.info("PANOPTES unit initialized: {}", self.config['name'])

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,25 +51,38 @@ Use appropriate logging:
 - The logger supports variable information without the use of the `format` method.
 - There is a `say` method that is meant to be used in friendly manner to convey information to a user. This should be used only for personable output and is typically displayed in the "chat box" of the PAWS website. These messages are also sent to the INFO level logger
 
-Logging examples:
+#### Logging examples:
 
 _Note: These are meant to illustrate the logging calls and are not necessarily indicative of real operation_
 
 ```
 self.logger.info("PANOPTES unit initialized: {}", self.config['name'])
+
 self.say("I'm all ready to go, first checking the weather")
+
 self.logger.debug("Setting up weather station")
+
 self.logger.warning('Problem getting wind safety: {}'.format(e))
+
 self.logger.debug("Rain: {} Clouds: {} Dark: {}",
    is_raining,
    is_cloudy,
    is_dark
 )
+
 self.logger.error('Unable to connect to AAG Cloud Sensor, cannot continue')
 ```
 
+#### Viewing log files
 
-- The [`grc`](https://github.com/garabik/grc) (generic colouriser) can be used with `tail` to get pretty log files. The following screenshot shows commands entered into a `jupyter-console` in the top panel and the log file in the bottom panel.
+- You typically want to follow an active log file by using `tail -f` on the command line.
+- The [`grc`](https://github.com/garabik/grc) (generic colouriser) can be used with `tail` to get pretty log files. 
+
+```
+(panoptes-env) $ grc tail -f $PANDIR/logs/pocs_shell.log
+```
+
+The following screenshot shows commands entered into a `jupyter-console` in the top panel and the log file in the bottom panel.
 
 <p align="center">
    <img src="http://www.projectpanoptes.org/images/log-example.png" width="600">

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,10 +64,11 @@ self.logger.debug("Setting up weather station")
 
 self.logger.warning('Problem getting wind safety: {}'.format(e))
 
-self.logger.debug("Rain: {} Clouds: {} Dark: {}",
+self.logger.debug("Rain: {} Clouds: {} Dark: {} Temp: {:.02f}",
    is_raining,
    is_cloudy,
-   is_dark
+   is_dark,
+   temp_celsius
 )
 
 self.logger.error('Unable to connect to AAG Cloud Sensor, cannot continue')

--- a/conf_files/log.yaml
+++ b/conf_files/log.yaml
@@ -8,6 +8,7 @@ logger:
       detail:
         format: '%(processName)s(%(process)d) %(threadName)s %(asctime)14s UTC %(levelname)8s %(filename)20s:%(lineno)4d:%(funcName)-25s %(message)s'
         datefmt: '%Y%m%d%H%M%S'
+        style: '%'
 
     loggers:
       all:

--- a/conf_files/log.yaml
+++ b/conf_files/log.yaml
@@ -13,14 +13,26 @@ logger:
       all:
         handlers: [all]
         propagate: true
+      info:
+        handlers: [info]
+        propagate: true
       warn:
         handlers: [warn]
         propagate: true
+      error:
+        handlers: [error]
+        propagate: true        
 
     handlers:
       all:
         class: logging.handlers.TimedRotatingFileHandler
         level: DEBUG
+        formatter: detail
+        when: W6
+        backupCount: 4
+      info:
+        class: logging.handlers.TimedRotatingFileHandler
+        level: INFO
         formatter: detail
         when: W6
         backupCount: 4
@@ -30,6 +42,12 @@ logger:
         formatter: detail
         when: W6
         backupCount: 4
+      error:
+        class: logging.handlers.TimedRotatingFileHandler
+        level: ERROR
+        formatter: detail
+        when: W6
+        backupCount: 4        
 
     root:
       level: DEBUG

--- a/conf_files/log.yaml
+++ b/conf_files/log.yaml
@@ -8,7 +8,6 @@ logger:
       detail:
         format: '%(processName)s(%(process)d) %(threadName)s %(asctime)14s UTC %(levelname)8s %(filename)20s:%(lineno)4d:%(funcName)-25s %(message)s'
         datefmt: '%Y%m%d%H%M%S'
-        style: '%'
 
     loggers:
       all:

--- a/pocs/core.py
+++ b/pocs/core.py
@@ -42,7 +42,8 @@ class POCS(PanStateMachine, PanBase):
         # Explicitly call the base classes in the order we want
         PanBase.__init__(self, **kwargs)
 
-        self.logger.info('Initializing PANOPTES unit - {} - {}', self.config['name'], self.config['location']['name'])
+        self.name = self.config.get('name', 'Generic PANOPTES Unit')
+        self.logger.info('Initializing PANOPTES unit - {} - {}', self.name, self.config['location']['name'])
 
         self._processes = {}
 
@@ -67,8 +68,6 @@ class POCS(PanStateMachine, PanBase):
 
         self.status()
 
-        self.name = self.config.get('name', 'Generic PANOPTES Unit')
-        self.logger.info('Welcome {}!'.format(self.name))
         self.say("Hi there!")
 
     @property
@@ -156,6 +155,7 @@ class POCS(PanStateMachine, PanBase):
             msg(str): Message to be sent
         """
         self.send_message(msg, channel='PANCHAT')
+        self.logger.info("Unit says: {}", msg)
 
     def send_message(self, msg, channel='POCS'):
         """ Send a message

--- a/pocs/core.py
+++ b/pocs/core.py
@@ -42,7 +42,7 @@ class POCS(PanStateMachine, PanBase):
         # Explicitly call the base classes in the order we want
         PanBase.__init__(self, **kwargs)
 
-        self.logger.info('Initializing PANOPTES unit')
+        self.logger.info('Initializing PANOPTES unit - %s - %s', self.config['name'], self.config['location']['name'])
 
         self._processes = {}
 

--- a/pocs/core.py
+++ b/pocs/core.py
@@ -42,7 +42,7 @@ class POCS(PanStateMachine, PanBase):
         # Explicitly call the base classes in the order we want
         PanBase.__init__(self, **kwargs)
 
-        self.logger.info('Initializing PANOPTES unit - %s - %s', self.config['name'], self.config['location']['name'])
+        self.logger.info('Initializing PANOPTES unit - {} - {}', self.config['name'], self.config['location']['name'])
 
         self._processes = {}
 

--- a/pocs/images.py
+++ b/pocs/images.py
@@ -112,7 +112,7 @@ class Image(PanBase):
             namedtuple: Pointing error information
         """
         if self._pointing_error is None:
-            assert self.pointing is not None, self.logger.warn("No WCS, can't get pointing_error")
+            assert self.pointing is not None, self.logger.warning("No WCS, can't get pointing_error")
             assert self.header_pointing is not None
 
             if self.wcs is None:

--- a/pocs/mount/bisque.py
+++ b/pocs/mount/bisque.py
@@ -123,7 +123,7 @@ class Mount(AbstractMount):
         target_set = False
 
         if self.is_parked:
-            self.logger.warning("Mount is parked")
+            self.logger.info("Mount is parked")
         else:
             # Save the skycoord coordinates
             self.logger.debug("Setting target coordinates: {}".format(coords))
@@ -172,9 +172,9 @@ class Mount(AbstractMount):
         success = False
 
         if self.is_parked:
-            self.logger.warning("Mount is parked")
+            self.logger.info("Mount is parked")
         elif self._target_coordinates is None:
-            self.logger.warning("Target Coordinates not set")
+            self.logger.info("Target Coordinates not set")
         else:
             # Get coordinate format from mount specific class
             mount_coords = self._skycoord_to_mount_coord(self._target_coordinates)

--- a/pocs/mount/mount.py
+++ b/pocs/mount/mount.py
@@ -358,9 +358,9 @@ class AbstractMount(PanBase):
         success = False
 
         if self.is_parked:
-            self.logger.warning("Mount is parked")
+            self.logger.info("Mount is parked")
         elif not self.has_target:
-            self.logger.warning("Target Coordinates not set")
+            self.logger.info("Target Coordinates not set")
         else:
             success = self.query('slew_to_target')
 

--- a/pocs/mount/simulator.py
+++ b/pocs/mount/simulator.py
@@ -95,9 +95,9 @@ class Mount(AbstractMount):
         success = False
 
         if self.is_parked:
-            self.logger.warning("Mount is parked")
+            self.logger.info("Mount is parked")
         elif not self.has_target:
-            self.logger.warning("Target Coordinates not set")
+            self.logger.info("Target Coordinates not set")
         else:
 
             self._is_slewing = True

--- a/pocs/utils/logger.py
+++ b/pocs/utils/logger.py
@@ -4,7 +4,7 @@ import time
 import datetime
 import logging
 import logging.config
-
+from tempfile import gettempdir
 
 from .config import load_config
 
@@ -47,7 +47,7 @@ def get_root_logger(profile='panoptes', log_config=None):
     log_config = log_config if log_config else load_config('log').get('logger', {})
 
     invoked_script = os.path.basename(sys.argv[0])
-    log_dir = '{}/logs'.format(os.getenv('PANDIR', '/var/panoptes/'))
+    log_dir = '{}/logs'.format(os.getenv('PANDIR', gettempdir()))
     log_fname = '{}-{}-{}'.format(invoked_script, os.getpid(),
                                   datetime.datetime.utcnow().strftime('%Y%m%dT%H%M%SZ'))
     log_fname_generic = invoked_script

--- a/pocs/utils/logger.py
+++ b/pocs/utils/logger.py
@@ -50,7 +50,7 @@ def get_root_logger(profile='panoptes', log_config=None):
     log_dir = '{}/logs'.format(os.getenv('PANDIR', '/var/panoptes/'))
     log_fname = '{}-{}-{}'.format(invoked_script, os.getpid(),
                                   datetime.datetime.utcnow().strftime('%Y%m%dT%H%M%SZ'))
-    log_fname_generic = '{}'.format(invoked_script)
+    log_fname_generic = invoked_script
 
     # Alter the log_config to use UTC times
     if log_config.get('use_utc', True):

--- a/pocs/utils/logger.py
+++ b/pocs/utils/logger.py
@@ -1,8 +1,9 @@
+import os
+import sys
+import time
 import datetime
 import logging
 import logging.config
-import os
-import time
 
 
 from .config import load_config
@@ -45,9 +46,11 @@ def get_root_logger(profile='panoptes', log_config=None):
     # Get log info from config
     log_config = log_config if log_config else load_config('log').get('logger', {})
 
+    invoked_script = os.path.basename(sys.argv[0])
     log_dir = '{}/logs'.format(os.getenv('PANDIR', '/var/panoptes/'))
-    log_fname = 'panoptes-{}-{}.log'.format(os.getpid(), datetime.datetime.utcnow().strftime('%Y%m%dT%H%M%SZ'))
-    log_fname_generic = 'panoptes.log'
+    log_fname = '{}-{}-{}.log'.format(invoked_script, os.getpid(),
+                                      datetime.datetime.utcnow().strftime('%Y%m%dT%H%M%SZ'))
+    log_fname_generic = '{}.log'.format(invoked_script)
 
     # Alter the log_config to use UTC times
     if log_config.get('use_utc', True):

--- a/pocs/utils/logger.py
+++ b/pocs/utils/logger.py
@@ -40,6 +40,7 @@ def get_root_logger(profile='panoptes', log_config=None):
     # Get the logger and set as attribute to class
     logger = logging.getLogger(profile)
 
+    # Don't want log messages from state machine library
     logging.getLogger('transitions.core').setLevel(logging.WARNING)
 
     try:

--- a/pocs/utils/logger.py
+++ b/pocs/utils/logger.py
@@ -8,6 +8,33 @@ import time
 from .config import load_config
 
 
+class PanLogger(object):
+    """ Logger for PANOPTES with format style strings """
+
+    def __init__(self, logger):
+        super(PanLogger, self).__init__()
+        self.logger = logger
+
+    def _process_str(self, fmt, *args, **kwargs):
+        log_str = fmt
+        if len(args) > 0:
+            log_str = fmt.format(*args, **kwargs)
+
+        return log_str
+
+    def debug(self, fmt, *args, **kwargs):
+        self.logger.debug(self._process_str(fmt, *args, **kwargs))
+
+    def info(self, fmt, *args, **kwargs):
+        self.logger.info(self._process_str(fmt, *args, **kwargs))
+
+    def warning(self, fmt, *args, **kwargs):
+        self.logger.warning(self._process_str(fmt, *args, **kwargs))
+
+    def error(self, fmt, *args, **kwargs):
+        self.logger.error(self._process_str(fmt, *args, **kwargs))
+
+
 def get_root_logger(profile='panoptes', log_config=None):
     """ Creates a root logger for PANOPTES used by the PanBase object
 
@@ -61,7 +88,7 @@ def get_root_logger(profile='panoptes', log_config=None):
     except Exception:  # pragma: no cover
         pass
 
-    return logger
+    return PanLogger(logger)
 
 
 class _UTCFormatter(logging.Formatter):


### PR DESCRIPTION
* Support use of `{}` in logger statements so we can avoid superfluous `format` calls
* Update CONTRIBUTING doc for logging
* Update log file name (#96)

Will probably need to do something in the future to clean up old log files.

Long-running (i.e. multi-day) programs will still be rotated daily at 11:30 am local. These will carry an additional day stamp.

Generates log files with current PID and a utc timestamp:
```
$ ls /var/panoptes/logs
panoptes.log -> /var/panoptes/logs/panoptes-26947-20171128T035245Z.log
panoptes-26947-20171128T035245Z.log
```

Note that this is being merged against `1.0-beta`.

Closes #96 