### PR TITLE
Version number updates

### DIFF
--- a/pocs/tests/test_observatory.py
+++ b/pocs/tests/test_observatory.py
@@ -8,6 +8,7 @@ from pocs.observatory import Observatory
 from pocs.scheduler.dispatch import Scheduler
 from pocs.scheduler.observation import Observation
 from pocs.utils import error
+from pocs.version import version
 
 has_camera = pytest.mark.skipif(
     not pytest.config.getoption("--camera"),
@@ -168,7 +169,7 @@ def test_standard_headers(observatory):
 
     test_headers = {
         'airmass': 1.091778,
-        'creator': 'POCSv0.5.1',
+        'creator': 'POCSv{}'.format(version),
         'elevation': 3400.0,
         'ha_mnt': 1.6844671878927793,
         'latitude': 19.54,

--- a/pocs/version.py
+++ b/pocs/version.py
@@ -1,4 +1,3 @@
-# this file was automatically generated
 major = 0
 minor = 5
 patch = 1

--- a/pocs/version.py
+++ b/pocs/version.py
@@ -1,6 +1,6 @@
 # this file was automatically generated
 major = 0
 minor = 5
-release = 1
+patch = 1
 
-version = '{}.{}.{}'.format(major, minor, release)
+version = '{}.{}.{}'.format(major, minor, patch)


### PR DESCRIPTION
* Change terminology to match semantic versioning
* Don't hard-code version number in test (closes #154)