### PR TITLE
Observatory Dependency Injection

### DIFF
--- a/bin/pocs_shell
+++ b/bin/pocs_shell
@@ -15,6 +15,7 @@ from astropy.io import fits
 from astropy.utils import console
 
 from pocs import POCS
+from pocs.observatory import Observatory
 from pocs.scheduler.field import Field
 from pocs.scheduler.observation import Observation
 from pocs.utils import current_time
@@ -125,7 +126,8 @@ class PocsShell(Cmd):
             simulator = []
 
         try:
-            self.pocs = POCS(simulator=simulator, messaging=True)
+            observatory = Observatory(simulator=simulator)
+            self.pocs = POCS(observatory, messaging=True)
             self.pocs.initialize()
         except error.PanError:
             pass

--- a/pocs/core.py
+++ b/pocs/core.py
@@ -8,7 +8,6 @@ from multiprocessing import Queue
 from astropy import units as u
 
 from . import PanBase
-from .observatory import Observatory
 from .state.machine import PanStateMachine
 from .utils import current_time
 from .utils import get_free_space
@@ -25,6 +24,7 @@ class POCS(PanStateMachine, PanBase):
     the `get_ready()` method the transition that is responsible for moving to the initial state.
 
     Args:
+        observatory(Observatory): An instance of a `pocs.observatory.Observatory` class
         state_machine_file(str): Filename of the state machine to use, defaults to
             'simple_state_table'
         messaging(bool): If messaging should be included, defaults to False
@@ -38,7 +38,12 @@ class POCS(PanStateMachine, PanBase):
 
     """
 
-    def __init__(self, state_machine_file='simple_state_table', messaging=False, **kwargs):
+    def __init__(
+            self,
+            observatory,
+            state_machine_file='simple_state_table',
+            messaging=False,
+            **kwargs):
 
         # Explicitly call the base classes in the order we want
         PanBase.__init__(self, **kwargs)
@@ -61,7 +66,7 @@ class POCS(PanStateMachine, PanBase):
         PanStateMachine.__init__(self, state_machine_file, **kwargs)
 
         # Create our observatory, which does the bulk of the work
-        self.observatory = Observatory(**kwargs)
+        self.observatory = observatory
 
         self._connected = True
         self._initialized = False

--- a/pocs/tests/test_pocs.py
+++ b/pocs/tests/test_pocs.py
@@ -9,14 +9,24 @@ from astropy import units as u
 from pocs import POCS
 from pocs import _check_config
 from pocs import _check_environment
+from pocs.observatory import Observatory
 from pocs.utils import error
 from pocs.utils.messaging import PanMessaging
 
 
 @pytest.fixture
-def pocs(config):
+def observatory():
+    observatory = Observatory(simulator=['all'])
+
+    yield observatory
+
+
+@pytest.fixture
+def pocs(config, observatory):
     os.environ['POCSTIME'] = '2016-08-13 13:00:00'
-    pocs = POCS(simulator=['all'], run_once=True,
+
+    pocs = POCS(observatory,
+                run_once=True,
                 config=config,
                 ignore_local_config=True, db='panoptes_testing')
 
@@ -177,11 +187,13 @@ def test_is_weather_safe_no_simulator(pocs, db):
     assert pocs.is_weather_safe() is False
 
 
-def test_run_wait_until_safe(db):
+def test_run_wait_until_safe(db, observatory):
     os.environ['POCSTIME'] = '2016-08-13 23:00:00'
 
     def start_pocs():
-        pocs = POCS(simulator=['camera', 'mount', 'night'],
+        observatory.config['simulator'] = ['camera', 'mount', 'night']
+
+        pocs = POCS(observatory,
                     messaging=True, safe_delay=15)
         pocs.db.current.remove({})
         pocs.initialize()
@@ -286,9 +298,9 @@ def test_run(pocs):
     assert pocs.state == 'sleeping'
 
 
-def test_run_interrupt_with_reschedule_of_target():
+def test_run_interrupt_with_reschedule_of_target(observatory):
     def start_pocs():
-        pocs = POCS(simulator=['all'], messaging=True)
+        pocs = POCS(observatory, messaging=True)
         pocs.logger.info('Before initialize')
         pocs.initialize()
         pocs.logger.info('POCS initialized, back in test')
@@ -321,9 +333,9 @@ def test_run_interrupt_with_reschedule_of_target():
     assert pocs_process.is_alive() is False
 
 
-def test_run_power_down_interrupt():
+def test_run_power_down_interrupt(observatory):
     def start_pocs():
-        pocs = POCS(simulator=['all'], messaging=True)
+        pocs = POCS(observatory, messaging=True)
         pocs.initialize()
         pocs.observatory.scheduler.fields_list = [{'name': 'KIC 8462852',
                                                    'position': '20h06m15.4536s +44d27m24.75s',


### PR DESCRIPTION
Simple change to create the `Observatory` outside of POCS and require it as a first parameter.

This will allow for a lot easier use by Huntsman and other observatories.