### PR TITLE
Remove pygraphviz dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ ccdproc
 astroplan
 codecov
 ffmpy
-pygraphviz
 google-cloud-storage
 dateparser
 coveralls


### PR DESCRIPTION
Creates install problems in some scenarios and is not required.

#196 filed