### PR TITLE
Expect an AttributeError, not NameError, when property ser is not defined.

### DIFF
--- a/pocs/utils/rs232.py
+++ b/pocs/utils/rs232.py
@@ -208,9 +208,9 @@ class SerialData(PanBase):
         """
         try:
             # If an exception is thrown when running __init__, then self.ser may not have
-            # been set, in which case reading that field will generate a NameError.
+            # been set, in which case reading that field will generate a AttributeError.
             ser = self.ser
-        except NameError:
+        except AttributeError:
             return
         if ser and ser.is_open:
             self.ser.close()


### PR DESCRIPTION
Fixes #194.