### PR TITLE
Adding some docstrings for the config loaded and save

### DIFF
--- a/pocs/utils/config.py
+++ b/pocs/utils/config.py
@@ -8,7 +8,46 @@ from warnings import warn
 
 
 def load_config(config_files=None, simulator=None, parse=True, ignore_local=False):
-    """ Load configuation information """
+    """Load configuation information
+
+    This function supports loading of a number of different files. If no options
+    are passed to `config_files` then the default `$POCS/conf_files/pocs.yaml`
+    will be loaded. See Notes for additional information.
+
+    Notes:
+        `config_files` supports a number of options:
+        * `config_files` is a list and loaded in order, so the first entry
+            will have any values overwritten by similarly named keys in
+            the second entry.
+        * Entries can be placed in the `$POCS/conf_files` folder and
+            should be passed as just the file name, e.g.
+            [`weather.yaml`, `email.yaml`] for loading
+            `$POCS/conf_files/weather.yaml` and `$POCS/conf_files/email.yaml`
+        * The `.yaml` extension will be added if not present, so list can
+            be writen as just ['weather', 'email']
+        * `config_files` can also be specified by an absolute path, which
+            can exist anywhere on the filesystem
+        * Local versions of files can override built-in versions and are
+            automatically loaded if placed in the `$POCS/conf_files` folder.
+            The files have a `<>_local.yaml` name, where `<>` is the built-in
+            file. So a `$POCS/conf_files/pocs_local.yaml` will override any
+            setting in the default `pocs.yaml` file.
+        * Local files can be ignored (mostly for testing purposes) with the
+            `ignore_local` parameter.
+
+    Args:
+        config_files (list, optional): A list of files to load as config,
+            see Notes for details of how to specify files.
+        simulator (list, optional): A list of hardware items that should be
+            used as a simulator.
+        parse (bool, optional): If the config file should attempt to create
+            objects such as dates, astropy units, etc.
+        ignore_local (bool, optional): If local files should be ignore, see
+            Notes for details.
+
+    Returns:
+        dict: A dictionary of config items
+    """
 
     # Default to the pocs.yaml file
     if config_files is None:
@@ -46,12 +85,37 @@ def load_config(config_files=None, simulator=None, parse=True, ignore_local=Fals
         config['simulator'] = hardware.get_simulator_names(simulator=simulator)
 
     if parse:
-        config = parse_config(config)
+        config = _parse_config(config)
 
     return config
 
 
-def parse_config(config):
+def save_config(path, config, clobber=True):
+    """Save config to yaml file
+
+    Args:
+        path (str): Path to save, can be relative or absolute. See Notes
+            in `load_config`.
+        config (dict): Config to save.
+        clobber (bool, optional): True if file should be updated, False
+            to generate a warning for existing config. Defaults to True
+            for updates.
+    """
+    if not path.endswith('.yaml'):
+        path = '{}.yaml'.format(path)
+
+    if not path.startswith('/'):
+        config_dir = '{}/conf_files'.format(os.getenv('POCS'))
+        path = os.path.join(config_dir, path)
+
+    if os.path.exists(path) and not clobber:
+        warn("Path exists and clobber=False: {}".format(path))
+    else:
+        with open(path, 'w') as f:
+            f.write(yaml.dump(config))
+
+
+def _parse_config(config):
     # Add units to our location
     if 'location' in config:
         loc = config['location']
@@ -70,21 +134,6 @@ def parse_config(config):
                 config['directories'][dir_name] = '{}/{}'.format(base_dir, rel_dir)
 
     return config
-
-
-def save_config(path, config, clobber=True):
-    if not path.endswith('.yaml'):
-        path = '{}.yaml'.format(path)
-
-    if not path.startswith('/'):
-        config_dir = '{}/conf_files'.format(os.getenv('POCS'))
-        path = os.path.join(config_dir, path)
-
-    if os.path.exists(path) and not clobber:
-        warn("Path exists and clobber=False: {}".format(path))
-    else:
-        with open(path, 'w') as f:
-            f.write(yaml.dump(config))
 
 
 def _add_to_conf(config, fn):

--- a/pocs/utils/config.py
+++ b/pocs/utils/config.py
@@ -24,9 +24,9 @@ def load_config(config_files=None, simulator=None, parse=True, ignore_local=Fals
             [`weather.yaml`, `email.yaml`] for loading
             `$POCS/conf_files/weather.yaml` and `$POCS/conf_files/email.yaml`
         * The `.yaml` extension will be added if not present, so list can
-            be writen as just ['weather', 'email']
+            be writen as just ['weather', 'email'].
         * `config_files` can also be specified by an absolute path, which
-            can exist anywhere on the filesystem
+            can exist anywhere on the filesystem.
         * Local versions of files can override built-in versions and are
             automatically loaded if placed in the `$POCS/conf_files` folder.
             The files have a `<>_local.yaml` name, where `<>` is the built-in

--- a/pocs/utils/config.py
+++ b/pocs/utils/config.py
@@ -15,7 +15,7 @@ def load_config(config_files=None, simulator=None, parse=True, ignore_local=Fals
     will be loaded. See Notes for additional information.
 
     Notes:
-        `config_files` supports a number of options:
+        The `config_files` parameter supports a number of options:
         * `config_files` is a list and loaded in order, so the first entry
             will have any values overwritten by similarly named keys in
             the second entry.
@@ -24,7 +24,7 @@ def load_config(config_files=None, simulator=None, parse=True, ignore_local=Fals
             [`weather.yaml`, `email.yaml`] for loading
             `$POCS/conf_files/weather.yaml` and `$POCS/conf_files/email.yaml`
         * The `.yaml` extension will be added if not present, so list can
-            be writen as just ['weather', 'email'].
+            be written as just ['weather', 'email'].
         * `config_files` can also be specified by an absolute path, which
             can exist anywhere on the filesystem.
         * Local versions of files can override built-in versions and are


### PR DESCRIPTION
Also makes `_parse_config` private. `save_config` hasn't changed, just added docstring and moved it above private `_parse_config`.