### PR TITLE
Filter out (hide) an expected warning when running tests

### DIFF
--- a/pocs/tests/test_database.py
+++ b/pocs/tests/test_database.py
@@ -34,6 +34,8 @@ def test_insert_and_no_collection(db):
     db.current.remove({'type': 'config'})
 
 
+# Filter out (hide) "UserWarning: Collection not available"
+@pytest.mark.filterwarnings('ignore')
 def test_bad_collection(db):
     with pytest.raises(AssertionError):
         db.insert_current('foobar', {'test': 'insert'})


### PR DESCRIPTION
test_database.py deliberately triggers an assertion failure that emits a warning. This change hides that warning from the pytest output.