### PR TITLE
Replace file-relative imports with root-relative imports

### DIFF
--- a/pocs/__init__.py
+++ b/pocs/__init__.py
@@ -2,7 +2,7 @@
 """
 Panoptes Observatory Control System (POCS) is a library for controlling a
 PANOPTES hardware unit. POCS provides complete automation of all observing
-processes and is inteded to be run in an automated fashion.
+processes and is intended to be run in an automated fashion.
 """
 
 from __future__ import absolute_import

--- a/pocs/camera/__init__.py
+++ b/pocs/camera/__init__.py
@@ -1,0 +1,2 @@
+from pocs.camera.camera import AbstractCamera
+from pocs.camera.camera import AbstractGPhotoCamera

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -1,11 +1,11 @@
-from .. import PanBase
+from pocs import PanBase
 
-from ..utils import error
-from ..utils import listify
-from ..utils import load_module
-from ..utils import images
+from pocs.utils import error
+from pocs.utils import listify
+from pocs.utils import load_module
+from pocs.utils import images
 
-from ..focuser.focuser import AbstractFocuser
+from pocs.focuser import AbstractFocuser
 
 from astropy.io import fits
 

--- a/pocs/camera/canon_gphoto2.py
+++ b/pocs/camera/canon_gphoto2.py
@@ -5,10 +5,10 @@ from astropy import units as u
 from threading import Event
 from threading import Timer
 
-from ..utils import current_time
-from ..utils import error
-from ..utils import images
-from .camera import AbstractGPhotoCamera
+from pocs.utils import current_time
+from pocs.utils import error
+from pocs.utils import images
+from pocs.camera import AbstractGPhotoCamera
 
 
 class Camera(AbstractGPhotoCamera):

--- a/pocs/camera/sbig.py
+++ b/pocs/camera/sbig.py
@@ -4,11 +4,11 @@ from threading import Thread
 from astropy import units as u
 from astropy.io import fits
 
-from ..utils import current_time
-from ..utils import images
-from .camera import AbstractCamera
-from .sbigudrv import INVALID_HANDLE_VALUE
-from .sbigudrv import SBIGDriver
+from pocs.utils import current_time
+from pocs.utils import images
+from pocs.camera import AbstractCamera
+from pocs.camera.sbigudrv import INVALID_HANDLE_VALUE
+from pocs.camera.sbigudrv import SBIGDriver
 from pocs.focuser.birger import Focuser as BirgerFocuser
 
 

--- a/pocs/camera/sbigudrv.py
+++ b/pocs/camera/sbigudrv.py
@@ -22,7 +22,7 @@ from astropy import units as u
 from astropy.io import fits
 from astropy.time import Time
 
-from .. import PanBase
+from pocs import PanBase
 
 
 ################################################################################

--- a/pocs/camera/simulator.py
+++ b/pocs/camera/simulator.py
@@ -10,9 +10,9 @@ from astropy import units as u
 from astropy.io import fits
 from astropy.time import Time
 
-from ..utils import current_time
+from pocs.utils import current_time
 
-from .camera import AbstractCamera
+from pocs.camera import AbstractCamera
 
 
 class Camera(AbstractCamera):

--- a/pocs/focuser/__init__.py
+++ b/pocs/focuser/__init__.py
@@ -1,0 +1,1 @@
+from pocs.focuser.focuser import AbstractFocuser

--- a/pocs/focuser/birger.py
+++ b/pocs/focuser/birger.py
@@ -4,7 +4,7 @@ import serial
 import time
 import glob
 
-from pocs.focuser.focuser import AbstractFocuser
+from pocs.focuser import AbstractFocuser
 
 # Birger adaptor serial numbers should be 5 digits
 serial_number_pattern = re.compile('^\d{5}$')

--- a/pocs/focuser/focuser.py
+++ b/pocs/focuser/focuser.py
@@ -10,9 +10,9 @@ from threading import Event
 from threading import Thread
 
 
-from .. import PanBase
-from ..utils import current_time
-from ..utils import images
+from pocs import PanBase
+from pocs.utils import current_time
+from pocs.utils import images
 
 palette = copy(plt.cm.cubehelix)
 palette.set_over('w', 1.0)

--- a/pocs/focuser/simulator.py
+++ b/pocs/focuser/simulator.py
@@ -1,4 +1,4 @@
-from .focuser import AbstractFocuser
+from pocs.focuser import AbstractFocuser
 
 import time
 import random

--- a/pocs/images.py
+++ b/pocs/images.py
@@ -9,8 +9,8 @@ from astropy.io import fits
 from astropy.time import Time
 from collections import namedtuple
 
-from . import PanBase
-from .utils import images as img_utils
+from pocs import PanBase
+from pocs.utils import images as img_utils
 
 OffsetError = namedtuple('OffsetError', ['delta_ra', 'delta_dec', 'magnitude'])
 

--- a/pocs/mount/__init__.py
+++ b/pocs/mount/__init__.py
@@ -1,0 +1,1 @@
+from pocs.mount.mount import AbstractMount

--- a/pocs/mount/bisque.py
+++ b/pocs/mount/bisque.py
@@ -7,10 +7,10 @@ from astropy import units as u
 from astropy.coordinates import SkyCoord
 from string import Template
 
-from ..utils import error
-from ..utils import theskyx
+from pocs.utils import error
+from pocs.utils import theskyx
 
-from .mount import AbstractMount
+from pocs.mount import AbstractMount
 
 
 class Mount(AbstractMount):

--- a/pocs/mount/ioptron.py
+++ b/pocs/mount/ioptron.py
@@ -4,9 +4,9 @@ import time
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 
-from ..utils import current_time
-from ..utils import error as error
-from .serial import AbstractSerialMount
+from pocs.utils import current_time
+from pocs.utils import error as error
+from pocs.mount.serial import AbstractSerialMount
 
 
 class Mount(AbstractSerialMount):

--- a/pocs/mount/mount.py
+++ b/pocs/mount/mount.py
@@ -6,8 +6,8 @@ from astropy.coordinates import SkyCoord
 
 from pocs import PanBase
 
-from ..utils import current_time
-from ..utils import error
+from pocs.utils import current_time
+from pocs.utils import error
 
 
 class AbstractMount(PanBase):

--- a/pocs/mount/serial.py
+++ b/pocs/mount/serial.py
@@ -1,10 +1,10 @@
 import os
 import yaml
 
-from ..utils import error
-from ..utils import rs232
+from pocs.utils import error
+from pocs.utils import rs232
 
-from .mount import AbstractMount
+from pocs.mount import AbstractMount
 
 
 class AbstractSerialMount(AbstractMount):

--- a/pocs/mount/simulator.py
+++ b/pocs/mount/simulator.py
@@ -1,7 +1,7 @@
 import time
 
-from ..utils import current_time
-from .mount import AbstractMount
+from pocs.utils import current_time
+from pocs.mount import AbstractMount
 
 
 class Mount(AbstractMount):

--- a/pocs/observatory.py
+++ b/pocs/observatory.py
@@ -11,16 +11,16 @@ from astropy.coordinates import EarthLocation
 from astropy.coordinates import get_moon
 from astropy.coordinates import get_sun
 
-from . import PanBase
+from pocs import PanBase
 import pocs.dome
-from .images import Image
-from .scheduler.constraint import Duration
-from .scheduler.constraint import MoonAvoidance
-from .utils import current_time
-from .utils import error
-from .utils import images as img_utils
-from .utils import list_connected_cameras
-from .utils import load_module
+from pocs.images import Image
+from pocs.scheduler.constraint import Duration
+from pocs.scheduler.constraint import MoonAvoidance
+from pocs.utils import current_time
+from pocs.utils import error
+from pocs.utils import images as img_utils
+from pocs.utils import list_connected_cameras
+from pocs.utils import load_module
 
 
 class Observatory(PanBase):

--- a/pocs/scheduler/__init__.py
+++ b/pocs/scheduler/__init__.py
@@ -1,0 +1,1 @@
+from pocs.scheduler.scheduler import BaseScheduler

--- a/pocs/scheduler/constraint.py
+++ b/pocs/scheduler/constraint.py
@@ -1,6 +1,6 @@
 from astropy import units as u
 
-from .. import PanBase
+from pocs import PanBase
 
 
 class BaseConstraint(PanBase):

--- a/pocs/scheduler/dispatch.py
+++ b/pocs/scheduler/dispatch.py
@@ -2,9 +2,9 @@ from astropy import units as u
 
 from astropy.coordinates import get_moon
 
-from ..utils import current_time
-from ..utils import listify
-from .scheduler import BaseScheduler
+from pocs.utils import current_time
+from pocs.utils import listify
+from pocs.scheduler import BaseScheduler
 
 
 class Scheduler(BaseScheduler):

--- a/pocs/scheduler/observation.py
+++ b/pocs/scheduler/observation.py
@@ -1,8 +1,8 @@
 from astropy import units as u
 from collections import OrderedDict
 
-from .. import PanBase
-from .field import Field
+from pocs import PanBase
+from pocs.scheduler.field import Field
 
 
 class Observation(PanBase):

--- a/pocs/scheduler/scheduler.py
+++ b/pocs/scheduler/scheduler.py
@@ -6,10 +6,10 @@ from collections import OrderedDict
 from astroplan import Observer
 from astropy import units as u
 
-from .. import PanBase
-from ..utils import current_time
-from .field import Field
-from .observation import Observation
+from pocs import PanBase
+from pocs.utils import current_time
+from pocs.scheduler.field import Field
+from pocs.scheduler.observation import Observation
 
 
 class BaseScheduler(PanBase):

--- a/pocs/state/machine.py
+++ b/pocs/state/machine.py
@@ -3,9 +3,9 @@ import yaml
 
 from transitions import State
 
-from ..utils import error
-from ..utils import listify
-from ..utils import load_module
+from pocs.utils import error
+from pocs.utils import listify
+from pocs.utils import load_module
 
 can_graph = False
 try:  # pragma: no cover

--- a/pocs/state/states/default/observing.py
+++ b/pocs/state/states/default/observing.py
@@ -1,4 +1,4 @@
-from ....utils import error
+from pocs.utils import error
 from time import sleep
 
 wait_interval = 15.

--- a/pocs/state/states/default/pointing.py
+++ b/pocs/state/states/default/pointing.py
@@ -1,7 +1,7 @@
 from time import sleep
 
-from ....images import Image
-from ....utils import error
+from pocs.images import Image
+from pocs.utils import error
 
 wait_interval = 3.
 timeout = 150.

--- a/pocs/tests/test_base_scheduler.py
+++ b/pocs/tests/test_base_scheduler.py
@@ -6,7 +6,7 @@ from astropy.coordinates import EarthLocation
 
 from astroplan import Observer
 
-from pocs.scheduler.scheduler import BaseScheduler as Scheduler
+from pocs.scheduler import BaseScheduler as Scheduler
 
 from pocs.scheduler.constraint import Duration
 from pocs.scheduler.constraint import MoonAvoidance

--- a/pocs/utils/__init__.py
+++ b/pocs/utils/__init__.py
@@ -99,7 +99,7 @@ def load_module(module_name):
     Returns:
         module: an imported module name
     """
-    from ..utils import error
+    from pocs.utils import error
     try:
         module = resolve_name(module_name)
     except ImportError:

--- a/pocs/utils/error.py
+++ b/pocs/utils/error.py
@@ -2,7 +2,7 @@ import sys
 
 from astropy.utils.exceptions import AstropyWarning
 
-from .. import PanBase
+from pocs import PanBase
 
 
 class PanError(AstropyWarning, PanBase):

--- a/pocs/utils/logger.py
+++ b/pocs/utils/logger.py
@@ -7,7 +7,7 @@ import logging
 import logging.config
 from tempfile import gettempdir
 
-from .config import load_config
+from pocs.utils.config import load_config
 
 
 class PanLogger(object):

--- a/pocs/utils/rs232.py
+++ b/pocs/utils/rs232.py
@@ -3,8 +3,8 @@
 import serial as serial
 import time
 
-from .. import PanBase
-from .error import BadSerialConnection
+from pocs import PanBase
+from pocs.utils.error import BadSerialConnection
 
 
 class SerialData(PanBase):


### PR DESCRIPTION
Add some imports to __init__.py files so that the root-relative imports of the typical AbstractBaseClass don't look like:
   from pocs.foo.foo import AbstractFoo.
Fix a typo.