### PR TITLE
Logging updates

### DIFF
--- a/conf_files/log.yaml
+++ b/conf_files/log.yaml
@@ -3,26 +3,12 @@ logger:
     use_utc: True
     formatters:
       simple:
-        format: '%(asctime)s UTC - %(message)s'
+        format: '%(asctime)s - %(message)s'
         datefmt: '%H:%M:%S'
       detail:
-        format: '%(processName)s(%(process)d) %(threadName)s %(asctime)14s UTC %(levelname)8s %(filename)20s:%(lineno)4d:%(funcName)-25s %(message)s'
-        datefmt: '%Y%m%d%H%M%S'
-
-    loggers:
-      all:
-        handlers: [all]
-        propagate: true
-      info:
-        handlers: [info]
-        propagate: true
-      warn:
-        handlers: [warn]
-        propagate: true
-      error:
-        handlers: [error]
-        propagate: true        
-
+        style: '{'
+        format: '{processName}({process:d}) {threadName} {asctime:14s} {levelname:8s} {filename:20s}:{lineno:4d}:{funcName:25s} {message}'
+        datefmt: '%Y%m%d%H%M%S%Z'
     handlers:
       all:
         class: logging.handlers.TimedRotatingFileHandler
@@ -48,8 +34,19 @@ logger:
         formatter: detail
         when: W6
         backupCount: 4        
-
+    loggers:
+      all:
+        handlers: [all]
+        propagate: true
+      info:
+        handlers: [info]
+        propagate: true
+      warn:
+        handlers: [warn]
+        propagate: true
+      error:
+        handlers: [error]
+        propagate: true 
     root:
       level: DEBUG
       handlers: [all, warn]
-      propagate: true

--- a/conf_files/log.yaml
+++ b/conf_files/log.yaml
@@ -7,8 +7,9 @@ logger:
         datefmt: '%H:%M:%S'
       detail:
         style: '{'
-        format: '{processName}({process:d}) {threadName} {asctime:14s} {levelname:8s} {filename:20s}:{lineno:4d}:{funcName:25s} {message}'
-        datefmt: '%Y%m%d%H%M%S%Z'
+        # See FilenameLineFilter in logger.py for fileline description
+        format: '{levelname:.1s}{asctime}.{msecs:03.0f} {fileline:20s} {message}'
+        datefmt: '%m%d %H:%M:%S'
     handlers:
       all:
         class: logging.handlers.TimedRotatingFileHandler

--- a/pocs/utils/logger.py
+++ b/pocs/utils/logger.py
@@ -9,47 +9,28 @@ from tempfile import gettempdir
 
 from pocs.utils.config import load_config
 
-
-class PanLogger(object):
-    """ Logger for PANOPTES with format style strings """
-
-    def __init__(self, logger):
-        super(PanLogger, self).__init__()
-        self.logger = logger
-
-    def _process_str(self, fmt, *args, **kwargs):
-        """ Pre-process the log string
-
-        This allows for `format` style specifiers, e.g. `{:02f}` and
-        `{:40s}`, which otherwise aren't supported by python's default
-        log formatting.
-        """
-        log_str = fmt
-        if len(args) > 0 or len(kwargs) > 0:
-            log_str = fmt.format(*args, **kwargs)
-
-        return log_str
-
-    def debug(self, fmt, *args, **kwargs):
-        self.logger.debug(self._process_str(fmt, *args, **kwargs))
-
-    def info(self, fmt, *args, **kwargs):
-        self.logger.info(self._process_str(fmt, *args, **kwargs))
-
-    def warning(self, fmt, *args, **kwargs):
-        self.logger.warning(self._process_str(fmt, *args, **kwargs))
-
-    def error(self, fmt, *args, **kwargs):
-        self.logger.error(self._process_str(fmt, *args, **kwargs))
-
-    def critical(self, fmt, *args, **kwargs):
-        self.logger.critical(self._process_str(fmt, *args, **kwargs))
-
-
 # We don't want to create multiple root loggers that are "identical",
 # so track the loggers in a dict keyed by a tuple of:
 #    (profile, json_serialized_logger_config).
 all_loggers = {}
+
+
+class StrFormatLogRecord(logging.LogRecord):
+    """
+    Even though you can select '{' as the style for the formatter class,
+    you still can't use {} formatting for your message.
+
+    From: https://goo.gl/Cyt5NH
+    """
+
+    def getMessage(self):
+        msg = str(self.msg)
+        if self.args:
+            try:
+                msg = msg % self.args
+            except (TypeError, ValueError):
+                msg = msg.format(*self.args)
+        return msg
 
 
 def get_root_logger(profile='panoptes', log_config=None):
@@ -87,11 +68,11 @@ def get_root_logger(profile='panoptes', log_config=None):
         full_log_fname = '{}/{}-{}.log'.format(log_dir, log_fname, handler)
         log_config['handlers'][handler].setdefault('filename', full_log_fname)
 
-        # Setup the TimeedRotatingFileHandler for middle of day
+        # Setup the TimedRotatingFileHandler for middle of day
         log_config['handlers'][handler].setdefault('atTime', datetime.time(hour=11, minute=30))
 
         if handler == 'all':
-            # Symlink the log file to $PANDIR/logs/panoptes.log
+            # Symlink the log file to log_symlink
             try:
                 os.unlink(log_symlink)
             except FileNotFoundError:
@@ -109,13 +90,15 @@ def get_root_logger(profile='panoptes', log_config=None):
     # we have our own way of logging state transitions
     logging.getLogger('transitions.core').setLevel(logging.WARNING)
 
+    # Set out custom LogRecord
+    logging.setLogRecordFactory(StrFormatLogRecord)
+
     try:
         import coloredlogs
         coloredlogs.install()
     except Exception:  # pragma: no cover
         pass
 
-    logger = PanLogger(logger)
     logger.info('{:*^80}'.format(' Starting PanLogger '))
     all_loggers[logger_key] = logger
     return logger

--- a/pocs/utils/logger.py
+++ b/pocs/utils/logger.py
@@ -88,7 +88,7 @@ def get_root_logger(profile='panoptes', log_config=None):
             # not the date and pid, as this makes it easier to find the latest file.
             try:
                 os.unlink(log_symlink)
-            except FileNotFoundError:
+            except FileNotFoundError:  # pragma: no cover
                 pass
             finally:
                 os.symlink(full_log_fname, log_symlink)

--- a/pocs/utils/logger.py
+++ b/pocs/utils/logger.py
@@ -16,9 +16,11 @@ all_loggers = {}
 
 
 class StrFormatLogRecord(logging.LogRecord):
-    """
+    """ Allow for `str.format` style log messages
+
     Even though you can select '{' as the style for the formatter class,
-    you still can't use {} formatting for your message.
+    you still can't use {} formatting for your message. The custom
+    `getMessage` tries legacy format and then tries new format.
 
     From: https://goo.gl/Cyt5NH
     """

--- a/pocs/utils/messaging.py
+++ b/pocs/utils/messaging.py
@@ -1,5 +1,4 @@
 import datetime
-import logging
 import zmq
 
 import yaml
@@ -11,6 +10,7 @@ from json import dumps
 from json import loads
 
 from pocs.utils import current_time
+from pocs.utils.logger import get_root_logger
 
 
 class PanMessaging(object):
@@ -19,7 +19,7 @@ class PanMessaging(object):
     context that can be shared across parent application.
 
     """
-    logger = logging
+    logger = get_root_logger()
 
     def __init__(self, **kwargs):
         # Create a new context

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 astropy >= 2.0.0
 pymongo >= 3.2.2
-coloredlogs >= 5.0
 matplotlib >= 2.0.0
 pytest >= 2.8.5
 scikit_image >= 0.12.3


### PR DESCRIPTION
* Replace PanLogger with custom `LogRecord` class
	* Allow logger to use either `%` or `{}` (str.format) style for actual
log messages.
* Log messages show correct file/lineno
* Add timezone info to log line
* Reorder log.yaml

Fixes #253

Now you can:
```
pocs.logger.debug("Hello {}", 42)        # Hello 42
pocs.logger.debug("Hello {:.02f}", 42)   # Hello 42.00
pocs.logger.debug("Hello %f", 42)        # Hello 42.00000
pocs.logger.debug("Hello {:.02f}%", 42)  # Hello 42.00%
pocs.logger.debug("Hello {:.02f}%f", 42) # Hello {:.02f}42.000000 - See below
```

For the last example we could double-interpolate it, but I don't think it is too large of an issue.

Note that this performs legacy interpolation first (via `%`) and catches exceptions and then tries the `str.format`. Might be more efficient to reverse order but I don't think the impact is large.

Full log output example:
```
MainProcess(19834) MainThread 20171227015442GMT INFO     messaging.py        : 122:send_message              PANCHAT Hi there!
```