### PR TITLE
Add dome opening to state machine, and dome control to pocs_shell

### DIFF
--- a/bin/pocs_shell
+++ b/bin/pocs_shell
@@ -302,19 +302,6 @@ Hardware names: {}   (or all for all hardware)'''.format(
         except Exception as e:
             print_warning('Problem closing the dome: {}'.format(e))
 
-    def do_dome_status(self, *arg):
-        """Print the satus of the dome, if there is one."""
-        if not self.is_setup:
-            return
-        if not self.pocs.observatory.has_dome:
-            print_warning('There is no dome.')
-            return
-        try:
-            status = self.pocs.observatory.dome.status
-            print_info('Dome status: {}'.format(status))
-        except Exception as e:
-            print_warning('Problem getting dome status: {}'.format(e))
-
     def do_power_down(self, *arg):
         print_info("Shutting down POCS instance, please wait")
         self.pocs.power_down()

--- a/bin/pocs_shell
+++ b/bin/pocs_shell
@@ -15,6 +15,7 @@ from astropy.io import fits
 from astropy.utils import console
 
 from pocs import POCS
+from pocs import hardware
 from pocs.observatory import Observatory
 from pocs.scheduler.field import Field
 from pocs.scheduler.observation import Observation
@@ -48,9 +49,22 @@ class PocsShell(Cmd):
     msg_sub_port = 6511
 
     @property
-    def ready(self):
+    def is_setup(self):
+        """True if POCS is setup, False otherwise."""
         if self.pocs is None:
             print_warning('POCS has not been setup. Please run `setup_pocs`')
+            return False
+        return True
+
+    @property
+    def is_safe(self):
+        """True if POCS is setup and weather conditions are safe, False otherwise."""
+        return self.is_setup and self.pocs.is_safe()
+
+    @property
+    def ready(self):
+        """True if POCS is ready to observe, False otherwise."""
+        if not self.is_setup:
             return False
 
         if self.pocs.observatory.mount.is_parked:
@@ -119,8 +133,8 @@ class PocsShell(Cmd):
             print_warning("Can't start message publisher: {}".format(e))
 
     def do_setup_pocs(self, *arg):
-        """ Setup and initialize a POCS instance """
-        simulator = listify(arg[0].split('=')[-1])
+        """Setup and initialize a POCS instance."""
+        simulator = listify(arg[0].split())
 
         if simulator is None:
             simulator = []
@@ -131,6 +145,15 @@ class PocsShell(Cmd):
             self.pocs.initialize()
         except error.PanError:
             pass
+
+    def help_setup_pocs(self):
+        print('''Setup and initialize a POCS instance.
+
+    setup_pocs [simulate]
+
+simulate is a space-separated list of hardware to simulate.
+Hardware names: {}   (or all for all hardware)'''.format(
+','.join(hardware.get_all_names())))
 
     def do_reset_pocs(self, *arg):
         self.pocs = None
@@ -245,6 +268,52 @@ class PocsShell(Cmd):
             self.pocs.observatory.mount.slew_to_home()
         except Exception as e:
             print_warning('Problem slewing to home: {}'.format(e))
+
+    def do_open_dome(self, *arg):
+        """Open the dome, if there is one."""
+        if not self.is_setup:
+            return
+        if not self.pocs.observatory.has_dome:
+            print_warning('There is no dome.')
+            return
+        if not self.is_safe:
+            print_warning('Weather conditions are not good, not opening dome.')
+            return
+        try:
+            if self.pocs.observatory.open_dome():
+                print_info('Opened the dome.')
+            else:
+                print_warning('Failed to open the dome.')
+        except Exception as e:
+            print_warning('Problem opening the dome: {}'.format(e))
+
+    def do_close_dome(self, *arg):
+        """Close the dome, if there is one."""
+        if not self.is_setup:
+            return
+        if not self.pocs.observatory.has_dome:
+            print_warning('There is no dome.')
+            return
+        try:
+            if self.pocs.observatory.close_dome():
+                print_info('Closed the dome.')
+            else:
+                print_warning('Failed to close the dome.')
+        except Exception as e:
+            print_warning('Problem closing the dome: {}'.format(e))
+
+    def do_dome_status(self, *arg):
+        """Print the satus of the dome, if there is one."""
+        if not self.is_setup:
+            return
+        if not self.pocs.observatory.has_dome:
+            print_warning('There is no dome.')
+            return
+        try:
+            status = self.pocs.observatory.dome.status
+            print_info('Dome status: {}'.format(status))
+        except Exception as e:
+            print_warning('Problem getting dome status: {}'.format(e))
 
     def do_power_down(self, *arg):
         print_info("Shutting down POCS instance, please wait")
@@ -804,4 +873,13 @@ if __name__ == '__main__':
     if not os.getenv('POCS'):
         sys.exit("Please set the POCS environment variable.")
 
+    invoked_script = os.path.basename(sys.argv[0])
+    histfile = os.path.expanduser('~/.{}_history'.format(invoked_script))
+    histfile_size = 1000
+    if os.path.exists(histfile):
+        readline.read_history_file(histfile)
+
     PocsShell().cmdloop()
+
+    readline.set_history_length(histfile_size)
+    readline.write_history_file(histfile)

--- a/pocs/core.py
+++ b/pocs/core.py
@@ -198,7 +198,7 @@ class POCS(PanStateMachine, PanBase):
     def check_messages(self):
         """ Check messages for the system
 
-        If `self.has_messaging` is True then there is a separate process runing
+        If `self.has_messaging` is True then there is a separate process running
         responsible for checking incoming zeromq messages. That process will fill
         various `queue.Queue`s with messages depending on their type. This method
         is a thin-wrapper around private methods that are responsible for message

--- a/pocs/state/machine.py
+++ b/pocs/state/machine.py
@@ -172,6 +172,10 @@ class PanStateMachine(Machine):
         self._do_states = False
         self._retry_attemps = 0
 
+    def status(self):
+        """Computes status, a dict, of whole observatory."""
+        return NotImplemented
+
 ##################################################################################################
 # State Conditions
 ##################################################################################################

--- a/pocs/state/states/default/ready.py
+++ b/pocs/state/states/default/ready.py
@@ -7,6 +7,10 @@ def on_enter(event_data):
 
     pocs.say("Ok, I'm all set up and ready to go!")
 
-    pocs.observatory.mount.unpark()
-
-    pocs.next_state = 'scheduling'
+    if pocs.observatory.has_dome and not pocs.observatory.open_dome():
+        pocs.say("Failed to open the dome while entering state 'ready'")
+        pocs.logger.error("Failed to open the dome while entering state 'ready'")
+        pocs.next_state = 'parking'
+    else:
+        pocs.observatory.mount.unpark()
+        pocs.next_state = 'scheduling'

--- a/pocs/tests/conftest.py
+++ b/pocs/tests/conftest.py
@@ -62,6 +62,29 @@ def config():
 
 
 @pytest.fixture
+def config_with_simulated_dome(config):
+    config.update({
+        'dome': {
+            'brand': 'Simulacrum',
+            'driver': 'simulator',
+        },
+    })
+    return config
+
+
+@pytest.fixture
+def config_with_astrohaven_simulator(config):
+    config.update({
+        'dome': {
+            'brand': 'Astrohaven',
+            'driver': 'astrohaven',
+            'port': 'astrohaven_simulator://',
+        },
+    })
+    return config
+
+
+@pytest.fixture
 def db():
     return PanMongo(db='panoptes_testing')
 

--- a/pocs/tests/conftest.py
+++ b/pocs/tests/conftest.py
@@ -73,18 +73,6 @@ def config_with_simulated_dome(config):
 
 
 @pytest.fixture
-def config_with_astrohaven_simulator(config):
-    config.update({
-        'dome': {
-            'brand': 'Astrohaven',
-            'driver': 'astrohaven',
-            'port': 'astrohaven_simulator://',
-        },
-    })
-    return config
-
-
-@pytest.fixture
 def db():
     return PanMongo(db='panoptes_testing')
 

--- a/pocs/tests/test_base.py
+++ b/pocs/tests/test_base.py
@@ -1,0 +1,32 @@
+import pytest
+
+from pocs import PanBase
+
+
+@pytest.fixture(params=[False, True], ids=['config_without_dome', 'config_with_dome'])
+def config_to_check(request, config, config_with_simulated_dome):
+    if request.param:
+        return config_with_simulated_dome
+    else:
+        return config
+
+
+def test_check_config1(config_to_check):
+    del config_to_check['mount']
+    base = PanBase()
+    with pytest.raises(SystemExit):
+        base._check_config(config_to_check)
+
+
+def test_check_config2(config_to_check):
+    del config_to_check['directories']
+    base = PanBase()
+    with pytest.raises(SystemExit):
+        base._check_config(config_to_check)
+
+
+def test_check_config3(config_to_check):
+    del config_to_check['state_machine']
+    base = PanBase()
+    with pytest.raises(SystemExit):
+        base._check_config(config_to_check)

--- a/pocs/tests/test_base.py
+++ b/pocs/tests/test_base.py
@@ -3,30 +3,22 @@ import pytest
 from pocs import PanBase
 
 
-@pytest.fixture(params=[False, True], ids=['config_without_dome', 'config_with_dome'])
-def config_to_check(request, config, config_with_simulated_dome):
-    if request.param:
-        return config_with_simulated_dome
-    else:
-        return config
-
-
-def test_check_config1(config_to_check):
-    del config_to_check['mount']
+def test_check_config1(config):
+    del config['mount']
     base = PanBase()
     with pytest.raises(SystemExit):
-        base._check_config(config_to_check)
+        base._check_config(config)
 
 
-def test_check_config2(config_to_check):
-    del config_to_check['directories']
+def test_check_config2(config):
+    del config['directories']
     base = PanBase()
     with pytest.raises(SystemExit):
-        base._check_config(config_to_check)
+        base._check_config(config)
 
 
-def test_check_config3(config_to_check):
-    del config_to_check['state_machine']
+def test_check_config3(config):
+    del config['state_machine']
     base = PanBase()
     with pytest.raises(SystemExit):
-        base._check_config(config_to_check)
+        base._check_config(config)

--- a/pocs/tests/test_observatory.py
+++ b/pocs/tests/test_observatory.py
@@ -23,10 +23,9 @@ def simulator():
 
 
 @pytest.fixture
-def observatory(simulator):
-    """ Return a valid Observatory instance with a specific config """
-
-    obs = Observatory(simulator=simulator, ignore_local_config=True)
+def observatory(config, simulator):
+    """Return a valid Observatory instance with a specific config."""
+    obs = Observatory(config=config, simulator=simulator, ignore_local_config=True)
     return obs
 
 
@@ -282,3 +281,21 @@ def test_autofocus_no_focusers(observatory):
         camera.focuser = None
     events = observatory.autofocus_cameras()
     assert events == {}
+
+
+def test_no_dome(observatory):
+    # Doesn't have a dome, and dome operations always report success.
+    assert not observatory.has_dome
+    assert observatory.open_dome()
+    assert observatory.close_dome()
+
+
+def test_operate_dome(config_with_simulated_dome):
+    simulator = hardware.get_all_names(without=['dome', 'night'])
+    observatory = Observatory(config=config_with_simulated_dome, simulator=simulator,
+                              ignore_local_config=True)
+    assert observatory.has_dome
+    assert observatory.open_dome()
+    assert observatory.dome.is_open
+    assert observatory.close_dome()
+    assert observatory.dome.is_closed

--- a/pocs/tests/test_pocs.py
+++ b/pocs/tests/test_pocs.py
@@ -6,21 +6,20 @@ from multiprocessing import Process
 
 from astropy import units as u
 
-from pocs import PanBase
+from pocs import hardware
 from pocs import POCS
 from pocs.observatory import Observatory
 from pocs.utils.messaging import PanMessaging
 
 
-@pytest.fixture
-def observatory():
-    observatory = Observatory(simulator=['all'])
+@pytest.fixture(scope='function')
+def observatory(config):
+    observatory = Observatory(config=config, simulator=['all'], ignore_local_config=True)
+    return observatory
 
-    yield observatory
 
-
-@pytest.fixture
-def pocs(config, observatory):
+@pytest.fixture(scope='function')
+def pocs_without_dome(config, observatory):
     os.environ['POCSTIME'] = '2016-08-13 13:00:00'
 
     pocs = POCS(observatory,
@@ -43,25 +42,37 @@ def pocs(config, observatory):
     pocs.power_down()
 
 
-def test_check_config1(config):
-    del config['mount']
-    base = PanBase()
-    with pytest.raises(SystemExit):
-        base._check_config(config)
+@pytest.fixture(scope='function')
+def pocs_with_dome(config_with_simulated_dome):
+    os.environ['POCSTIME'] = '2016-08-13 13:00:00'
+    simulator = hardware.get_all_names(without=['dome'])
+    observatory = Observatory(config=config_with_simulated_dome,
+                              simulator=simulator,
+                              ignore_local_config=True)
+
+    pocs = POCS(observatory,
+                run_once=True,
+                config=config_with_simulated_dome,
+                ignore_local_config=True, db='panoptes_testing')
+
+    pocs.observatory.scheduler.fields_list = [
+        {'name': 'Wasp 33',
+         'position': '02h26m51.0582s +37d33m01.733s',
+         'priority': '100',
+         'exp_time': 2,
+         'min_nexp': 2,
+         'exp_set_size': 2,
+         },
+    ]
+
+    yield pocs
+
+    pocs.power_down()
 
 
-def test_check_config2(config):
-    del config['directories']
-    base = PanBase()
-    with pytest.raises(SystemExit):
-        base._check_config(config)
-
-
-def test_check_config3(config):
-    del config['state_machine']
-    base = PanBase()
-    with pytest.raises(SystemExit):
-        base._check_config(config)
+@pytest.fixture(scope='function')
+def pocs(pocs_with_dome):
+    yield pocs_with_dome
 
 
 def test_bad_pandir_env(pocs):
@@ -246,8 +257,10 @@ def test_unsafe_park(pocs):
     assert pocs.state == 'sleeping'
 
 
-def test_power_down_while_running(pocs):
+def test_power_down_while_running(pocs_without_dome):
+    pocs = pocs_without_dome
     assert pocs.connected is True
+    assert not pocs.observatory.has_dome
     pocs.initialize()
     pocs.get_ready()
     assert pocs.state == 'ready'
@@ -255,6 +268,22 @@ def test_power_down_while_running(pocs):
 
     assert pocs.state == 'parked'
     assert pocs.connected is False
+
+
+def test_power_down_dome_while_running(pocs_with_dome):
+    pocs = pocs_with_dome
+    assert pocs.connected is True
+    assert pocs.observatory.has_dome
+    assert not pocs.observatory.dome.is_connected
+    pocs.initialize()
+    assert pocs.observatory.dome.is_connected
+    pocs.get_ready()
+    assert pocs.state == 'ready'
+    pocs.power_down()
+
+    assert pocs.state == 'parked'
+    assert pocs.connected is False
+    assert not pocs.observatory.dome.is_connected
 
 
 def test_run_no_targets_and_exit(pocs):

--- a/pocs/tests/test_pocs.py
+++ b/pocs/tests/test_pocs.py
@@ -19,7 +19,7 @@ def observatory(config):
 
 
 @pytest.fixture(scope='function')
-def pocs_without_dome(config, observatory):
+def pocs(config, observatory):
     os.environ['POCSTIME'] = '2016-08-13 13:00:00'
 
     pocs = POCS(observatory,
@@ -68,11 +68,6 @@ def pocs_with_dome(config_with_simulated_dome):
     yield pocs
 
     pocs.power_down()
-
-
-@pytest.fixture(scope='function')
-def pocs(pocs_with_dome):
-    yield pocs_with_dome
 
 
 def test_bad_pandir_env(pocs):
@@ -257,8 +252,7 @@ def test_unsafe_park(pocs):
     assert pocs.state == 'sleeping'
 
 
-def test_power_down_while_running(pocs_without_dome):
-    pocs = pocs_without_dome
+def test_power_down_while_running(pocs):
     assert pocs.connected is True
     assert not pocs.observatory.has_dome
     pocs.initialize()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,27 +1,23 @@
-astroplan
 astropy >= 2.0.0
-ccdproc
-codecov
-coloredlogs >= 5.0
-coveralls
-dateparser
-ffmpy
-Flask==0.11.1
-google-cloud-storage
-matplotlib >= 2.0.0
-numpy >= 1.12.1
-photutils
-pycodestyle
 pymongo >= 3.2.2
-pyserial >= 3.1.1
+coloredlogs >= 5.0
+matplotlib >= 2.0.0
 pytest >= 2.8.5
-pytest-cov
+scikit_image >= 0.12.3
+transitions >= 0.4.0
 python_dateutil >= 2.5.3
+numpy >= 1.12.1
+scipy >= 0.17.1
+pyserial >= 3.1.1
 PyYAML >= 3.11
 pyzmq >= 15.3.0
-readline
-scikit_image >= 0.12.3
-scipy >= 0.17.1
-shapely[vectorized]
-transitions >= 0.4.0
+pycodestyle
 wcsaxes
+readline
+ccdproc
+astroplan
+codecov
+ffmpy
+google-cloud-storage
+dateparser
+coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,23 +1,27 @@
+astroplan
 astropy >= 2.0.0
-pymongo >= 3.2.2
+ccdproc
+codecov
 coloredlogs >= 5.0
+coveralls
+dateparser
+ffmpy
+Flask==0.11.1
+google-cloud-storage
 matplotlib >= 2.0.0
-pytest >= 2.8.5
-scikit_image >= 0.12.3
-transitions >= 0.4.0
-python_dateutil >= 2.5.3
 numpy >= 1.12.1
-scipy >= 0.17.1
+photutils
+pycodestyle
+pymongo >= 3.2.2
 pyserial >= 3.1.1
+pytest >= 2.8.5
+pytest-cov
+python_dateutil >= 2.5.3
 PyYAML >= 3.11
 pyzmq >= 15.3.0
-pycodestyle
-wcsaxes
 readline
-ccdproc
-astroplan
-codecov
-ffmpy
-google-cloud-storage
-dateparser
-coveralls
+scikit_image >= 0.12.3
+scipy >= 0.17.1
+shapely[vectorized]
+transitions >= 0.4.0
+wcsaxes


### PR DESCRIPTION
Add opening of the dome to the on_enter method of the ready state.
Add open_dome, close_dome, and dome_status commands to pocs_shell.
Add command history to pocs_shell, stored in ~/.pocs_shell_history.
Add testing with dome to test_pocs.py.
Move some testing of PanBase to test_base.py (a new file) from test_pocs.py.
Add requirements needed for PIAA and PEAS, and put requirements.txt in sorted order.
Experiment with adding help to a command in pocs_shell (setup_pocs, in this case).