### PR TITLE
Fix IntervalTimer so that it doesn't screw up the remainder; I found

### DIFF
--- a/resources/arduino_files/shared/CharBuffer.h
+++ b/resources/arduino_files/shared/CharBuffer.h
@@ -1,3 +1,6 @@
+#ifndef RESOURCES_ARDUINO_FILES_SHARED_CHAR_BUFFER_H
+#define RESOURCES_ARDUINO_FILES_SHARED_CHAR_BUFFER_H
+
 // CharBuffer stores characters and supports (minimal) parsing of
 // the buffered characters.
 template <uint8_t kBufferSize>
@@ -48,6 +51,25 @@ class CharBuffer {
       *output = static_cast<uint8_t>(v);
       return true;
     }
+    bool ParseName(char** name, uint8_t* name_len) {
+      if (Empty() || !islower(Peek())) {
+        return false;
+      }
+      *name = buf_ + read_cursor_;
+      Next();
+      uint8_t len = 1;
+      while (!Empty()) {
+        char c = Peek();
+        if (islower(c) || isdigit(c) || c == '_') {
+          Next();
+          len++;
+          continue;
+        }
+        break;
+      }
+      *name_len = len;
+      return true;
+    }
     bool MatchAndConsume(char c) {
       if (Empty() || Peek() != c) {
         return false;
@@ -55,9 +77,14 @@ class CharBuffer {
       Next();
       return true;
     }
+    void WriteBuffer() {
+      Serial.write(buf_, write_cursor_);
+    }
 
   private:
     char buf_[kBufferSize];
     uint8_t write_cursor_;
     uint8_t read_cursor_;
 };
+
+#endif  // RESOURCES_ARDUINO_FILES_SHARED_CHAR_BUFFER_H

--- a/resources/arduino_files/shared/PinUtils.cpp
+++ b/resources/arduino_files/shared/PinUtils.cpp
@@ -1,4 +1,7 @@
 #include "PinUtils.h"
+
+#include <stdlib.h>
+
 #include "Arduino.h"
 
 void turn_pin_on(int pin_num) {
@@ -19,4 +22,17 @@ void toggle_pin(int pin_num) {
 
 void toggle_led() {
   toggle_pin(LED_BUILTIN);
+}
+
+// pinMode copied from https://github.com/arduino/Arduino/issues/4606.
+int pinMode(int pin) {
+  if (pin >= NUM_DIGITAL_PINS) return (-1);
+
+  uint8_t bit = digitalPinToBitMask(pin);
+  uint8_t port = digitalPinToPort(pin);
+  volatile uint8_t *reg = portModeRegister(port);
+  if (*reg & bit) return (OUTPUT);
+
+  volatile uint8_t *out = portOutputRegister(port);
+  return ((*out & bit) ? INPUT_PULLUP : INPUT);
 }

--- a/resources/arduino_files/shared/PinUtils.h
+++ b/resources/arduino_files/shared/PinUtils.h
@@ -9,4 +9,7 @@ bool is_pin_on(int pin_num);
 void toggle_pin(int pin_num);
 void toggle_led();
 
+// Read the mode (INPUT, OUTPUT, or INPUT_PULLUP) for a pin.
+int pinMode(int pin);
+
 #endif  // RESOURCES_ARDUINO_FILES_SHARED_PIN_UTILS_H

--- a/resources/arduino_files/shared/PinUtils.h
+++ b/resources/arduino_files/shared/PinUtils.h
@@ -9,7 +9,7 @@ bool is_pin_on(int pin_num);
 void toggle_pin(int pin_num);
 void toggle_led();
 
-// Read the mode (INPUT, OUTPUT, or INPUT_PULLUP) for a pin.
+// Returns the mode (INPUT, OUTPUT, or INPUT_PULLUP) for a pin.
 int pinMode(int pin);
 
 #endif  // RESOURCES_ARDUINO_FILES_SHARED_PIN_UTILS_H

--- a/resources/arduino_files/shared/interval_timer.cpp
+++ b/resources/arduino_files/shared/interval_timer.cpp
@@ -1,0 +1,41 @@
+#include "interval_timer.h"
+
+#include "Arduino.h"
+
+IntervalTimer::IntervalTimer(millis_t interval_ms)
+    : IntervalTimer(interval_ms, interval_ms) {}
+
+IntervalTimer::IntervalTimer(millis_t interval_ms, millis_t remaining_ms)
+    : last_time_(millis()), remaining_(remaining_ms), interval_(interval_ms) {}
+
+void IntervalTimer::Reset() {
+  last_time_ = millis();
+  remaining_ = interval_;
+}
+
+bool IntervalTimer::HasExpired() {
+  millis_t now = millis();
+  millis_t elapsed;
+  if (now < last_time_) {
+    // We've had wrap around of the millisecond clock. When we do so, we keep things simple by
+    // NOT tracking the time up to the wrap around (i.e. static_cast<millis_t>(-1LL) - last_time_).
+    elapsed = now;
+  } else {
+    elapsed = now - last_time_;
+  }
+  last_time_ = now;
+
+  if (remaining_ <= elapsed) {
+    // All done. Compute amount of time in next interval that has been consumed.
+    elapsed -= remaining_;
+    if (elapsed >= interval_) {
+      remaining_ = 1;
+    } else {
+      remaining_ = interval_ - elapsed;
+    }
+    return true;
+  } else {
+    remaining_ -= elapsed;
+    return false;
+  }
+}

--- a/resources/arduino_files/shared/interval_timer.h
+++ b/resources/arduino_files/shared/interval_timer.h
@@ -1,0 +1,31 @@
+#ifndef RESOURCES_ARDUINO_FILES_SHARED_INTERVAL_TIMER_H
+#define RESOURCES_ARDUINO_FILES_SHARED_INTERVAL_TIMER_H
+
+// A simple repeating, count-down timer. Avoids problems with wrap-around
+// by tracking the remaining time left rather than the absolute time.
+class IntervalTimer {
+  public:
+    // The type returned by millis().
+    typedef unsigned long millis_t;
+
+    // Constructs a timer where the first expiration is in interval_ms, and
+    // then every interval_ms after that.
+    IntervalTimer(millis_t interval_ms);
+
+    // Constructs a timer where the first expiration is in remaining_ms, and
+    // then every interval_ms after that.
+    IntervalTimer(millis_t interval_ms, millis_t remaining_ms);
+
+    // Starts a new interval at the current time.
+    void Reset();
+
+    // Returns true if the current interval has expired, in which case a new interval is started.
+    bool HasExpired();
+
+  private:
+    millis_t last_time_;
+    millis_t remaining_;
+    const millis_t interval_;
+};
+
+#endif  // RESOURCES_ARDUINO_FILES_SHARED_INTERVAL_TIMER_H

--- a/resources/arduino_files/shared/serial_input_handler.h
+++ b/resources/arduino_files/shared/serial_input_handler.h
@@ -1,0 +1,112 @@
+#ifndef RESOURCES_ARDUINO_FILES_SHARED_SERIAL_INPUT_HANDLER_H
+#define RESOURCES_ARDUINO_FILES_SHARED_SERIAL_INPUT_HANDLER_H
+
+#include <ctype.h>
+
+// Support for accumulating a line of text input to be parsed by the sub-class.
+// Only characters satisfying IsNewLine() or isprint() are acceptable.
+template <uint8_t kBufferSize>
+class SerialInputHandler {
+  public:
+    typedef void (*ProcessNumEqNumFn)(uint8_t pin_num, uint8_t value);
+    typedef void (*ProcessNameEqNumFn)(char* name, uint8_t name_len, uint8_t value);
+    SerialInputHandler(ProcessNumEqNumFn num_num_fn, ProcessNameEqNumFn name_num_fn)
+        : num_num_fn_(num_num_fn), name_num_fn_(name_num_fn) {}
+
+    void Handle() {
+      while (AccumulateLine()) {
+        wait_for_new_line_ = false;
+        has_line_ = false;
+        uint8_t pin_num;
+        if (input_buffer_.ParseUInt8(&pin_num)) {
+          uint8_t pin_status;
+          if (input_buffer_.MatchAndConsume(',') &&
+              input_buffer_.ParseUInt8(&pin_status) &&
+              input_buffer_.Empty()) {
+            num_num_fn_(pin_num, pin_status);
+          } else {
+            LineNotMatched(1);
+          }
+          input_buffer_.Reset();
+          continue;
+        }
+        char* name = nullptr;
+        uint8_t name_len = 0;
+        if (input_buffer_.ParseName(&name, &name_len)) {
+          uint8_t pin_status;
+          if (input_buffer_.MatchAndConsume('=') &&
+              input_buffer_.ParseUInt8(&pin_status) &&
+              input_buffer_.Empty()) {
+            name_num_fn_(name, name_len, pin_status);
+          } else {
+            LineNotMatched(2);
+          }
+          input_buffer_.Reset();
+          continue;
+        }
+        LineNotMatched(0);
+        input_buffer_.Reset();
+      }
+    }
+
+  protected:
+    bool AccumulateLine() {
+      if (has_line_) {
+        return true;
+      }
+      while (Serial && Serial.available() > 0) {
+        int c = Serial.read();
+        if (wait_for_new_line_) {
+          if (IsNewLine(c)) {
+            wait_for_new_line_ = false;
+            input_buffer_.Reset();
+          }
+        } else if (IsNewLine(c)) {
+          has_line_ = true;
+          return true;
+        } else if (isprint(c)) {
+          if (!input_buffer_.Append(static_cast<char>(c))) {
+            // Too full.
+            wait_for_new_line_ = true;
+          }
+        } else {
+          // Input is not an acceptable character.
+          if (input_buffer_.Empty()) {
+            // Ignore unacceptable characters at the start of a line. Choosing to do this because
+            // we sometimes see garbage when first connecting.
+          } else {
+            wait_for_new_line_ = true;
+          }
+        }
+      }
+      return false;
+    }
+
+    // Allow the input line to end with NL, CR NL or CR.
+    bool IsNewLine(int c) {
+      return c == '\n' || c == '\r';
+    }
+
+    void LineNotMatched(int reason) {
+      Serial.print("LINE NOT MATCHED, reason=");
+      Serial.println(reason);
+      Serial.print("LINE: \"");
+      input_buffer_.WriteBuffer();
+      Serial.println("\"");
+    }
+
+    // Buffer in which we're accumulating
+    CharBuffer<kBufferSize> input_buffer_;
+
+    const ProcessNumEqNumFn num_num_fn_;
+    const ProcessNameEqNumFn name_num_fn_;
+
+    // Has a line been accumulated but not yet processed?
+    bool has_line_{false};
+
+    // Has invalid input been received, and we're now waiting for a new line before restarting
+    // the process of accumulating a line?
+    bool wait_for_new_line_{false};
+};
+
+#endif  // RESOURCES_ARDUINO_FILES_SHARED_SERIAL_INPUT_HANDLER_H

--- a/resources/arduino_files/shared/serial_input_handler.h
+++ b/resources/arduino_files/shared/serial_input_handler.h
@@ -8,9 +8,9 @@
 template <uint8_t kBufferSize>
 class SerialInputHandler {
   public:
-    typedef void (*ProcessNumEqNumFn)(uint8_t pin_num, uint8_t value);
+    typedef void (*ProcessNumCommaNumFn)(uint8_t pin_num, uint8_t value);
     typedef void (*ProcessNameEqNumFn)(char* name, uint8_t name_len, uint8_t value);
-    SerialInputHandler(ProcessNumEqNumFn num_num_fn, ProcessNameEqNumFn name_num_fn)
+    SerialInputHandler(ProcessNumCommaNumFn num_num_fn, ProcessNameEqNumFn name_num_fn)
         : num_num_fn_(num_num_fn), name_num_fn_(name_num_fn) {}
 
     void Handle() {
@@ -62,8 +62,12 @@ class SerialInputHandler {
             input_buffer_.Reset();
           }
         } else if (IsNewLine(c)) {
-          has_line_ = true;
-          return true;
+          if (!input_buffer_.Empty()) {
+            has_line_ = true;
+            return true;
+          }
+        } else if (isblank(c)) {
+          // Ignore space and tabs.
         } else if (isprint(c)) {
           if (!input_buffer_.Append(static_cast<char>(c))) {
             // Too full.
@@ -98,7 +102,7 @@ class SerialInputHandler {
     // Buffer in which we're accumulating
     CharBuffer<kBufferSize> input_buffer_;
 
-    const ProcessNumEqNumFn num_num_fn_;
+    const ProcessNumCommaNumFn num_num_fn_;
     const ProcessNameEqNumFn name_num_fn_;
 
     // Has a line been accumulated but not yet processed?

--- a/resources/arduino_files/telemetry_board/interval_timer.cpp
+++ b/resources/arduino_files/telemetry_board/interval_timer.cpp
@@ -1,0 +1,1 @@
+../shared/interval_timer.cpp

--- a/resources/arduino_files/telemetry_board/interval_timer.h
+++ b/resources/arduino_files/telemetry_board/interval_timer.h
@@ -1,0 +1,1 @@
+../shared/interval_timer.h

--- a/resources/arduino_files/telemetry_board/serial_input_handler.h
+++ b/resources/arduino_files/telemetry_board/serial_input_handler.h
@@ -1,0 +1,1 @@
+../shared/serial_input_handler.h

--- a/resources/arduino_files/telemetry_board/telemetry_board.ino
+++ b/resources/arduino_files/telemetry_board/telemetry_board.ino
@@ -29,6 +29,8 @@
 #include "dht_handler.h"
 #include "CharBuffer.h"
 #include "PinUtils.h"
+#include "interval_timer.h"
+#include "serial_input_handler.h"
 
 ////////////////////////////////////////////////
 // __      __               _                 //
@@ -44,10 +46,14 @@
 // make changes to this code. The value needs to
 // be in JSON format (i.e. quoted and escaped if
 // a string).
-#define JSON_VERSION_ID "\"2018-01-03\""
+#define JSON_VERSION_ID "\"2018-01-07\""
 
 // How often, in milliseconds, to emit a report.
 #define REPORT_INTERVAL_MS 2000
+
+// How long, in milliseconds, to shutoff the computer when
+// requested to power-cycle the computer.
+#define POWER_CYCLE_MS 30000
 
 // Type of Digital Humidity and Temperature (DHT) Sensor
 #define DHTTYPE DHT22   // DHT 22  (AM2302)
@@ -97,8 +103,7 @@ DallasTemperatureHandler<3> dt_handler(&ds);
 // Base class of handlers below which emit a different name for each
 // instance of a sub-class.
 class BaseNameHandler {
-  protected:
-    BaseNameHandler(const char* name) : name_(name) {}
+  public:
     void PrintName() {
       // Print quoted name for JSON dictionary key. The decision of
       // whether to add a comma before this is made by the caller.
@@ -106,6 +111,22 @@ class BaseNameHandler {
       Serial.print(name_);
       Serial.print("\":");
     }
+
+    bool NameEquals(const char* s, uint8_t len) {
+      const char* p = name_;
+      while (len > 0 && *p != '\0') {
+        if (*s != *p) {
+          return false;
+        }
+        --len;
+        ++s;
+        ++p;
+      }
+      return len == 0 && *p == '\0';
+    }
+
+  protected:
+    BaseNameHandler(const char* name) : name_(name) {}
 
   private:
     const char* const name_;
@@ -144,9 +165,9 @@ CurrentHandler current_handlers[] = {
   {"cameras", I_CAMERAS, cameras_amps_mult},
 };
 
-class DigitalInputHandler : public BaseNameHandler {
+class DigitalPinHandler : public BaseNameHandler {
   public:
-    DigitalInputHandler(const char* name, int pin)
+    DigitalPinHandler(const char* name, int pin)
       : BaseNameHandler(name), pin_(pin) {}
     void Collect() {
       reading_ = digitalRead(pin_);
@@ -155,15 +176,19 @@ class DigitalInputHandler : public BaseNameHandler {
       PrintName();
       Serial.print(reading_);
     }
+    int pin() const {
+      return pin_;
+    }
+
   private:
     const int pin_;
     int reading_;
 };
 
-// One DigitalInputHandler for each of the GPIO pins for which we report the value.
+// One DigitalPinHandler for each of the GPIO pins for which we report the value.
 // Most are actually output pins, but the Arduino API allows us to read the value
 // that is being output.
-DigitalInputHandler di_handlers[] = {
+DigitalPinHandler dp_handlers[] = {
   {"computer", COMP_RELAY},
   {"fan", FAN_RELAY},
   {"mount", MOUNT_RELAY},
@@ -216,27 +241,27 @@ template<class T, int size> void PrintCollection(const char* name, T(&handlers)[
 // Produce a single JSON line with the current values reported by
 // the sensors and the settings of the relays.
 void Report(unsigned long now) {
-  static unsigned long report_num = 0;
+  static uint32_t report_num = 0;
 
   // Collect values from all of the sensors & replays.
   dht_handler.Collect();
   dt_handler.Collect();
-  for (auto& di_handler : di_handlers) {
-    di_handler.Collect();
+  for (auto& handler : dp_handlers) {
+    handler.Collect();
   }
   for (auto& handler : current_handlers) {
     handler.Collect();
   }
 
   // Print the collected values as JSON.
-  Serial.print("{\"name\":\"telemetry_board\", \"count\":");
+  Serial.print("{\"name\":\"telemetry_board\", \"millis\":");
   Serial.print(millis());
-  Serial.print(", \"num\":");
+  Serial.print(", \"report_num\":");
   Serial.print(++report_num);
   Serial.print(", \"ver\":");
   Serial.print(JSON_VERSION_ID);
 
-  ReportCollection("power", di_handlers);
+  ReportCollection("power", dp_handlers);
   PrintCollection("current", current_handlers, &CurrentHandler::ReportReading);
   PrintCollection("amps", current_handlers, &CurrentHandler::ReportAmps);
   dht_handler.Report();
@@ -248,104 +273,66 @@ void Report(unsigned long now) {
 //////////////////////////////////////////////////////////////////////////////////
 // Serial input support
 
-// Accumulates a line, parses it and takes the requested action if it is valid.
-class SerialInputHandler {
-  public:
-    void Handle() {
-      while (Serial && Serial.available() > 0) {
-        int c = Serial.read();
-        if (wait_for_new_line_) {
-          if (IsNewLine(c)) {
-            wait_for_new_line_ = false;
-            input_buffer_.Reset();
-          }
-        } else if (IsNewLine(c)) {
-          ProcessInputBuffer();
-          wait_for_new_line_ = false;
-          input_buffer_.Reset();
-        } else if (isprint(c)) {
-          if (!input_buffer_.Append(static_cast<char>(c))) {
-            wait_for_new_line_ = true;
-          }
-        } else {
-          // Input is not an acceptable character.
-          wait_for_new_line_ = true;
+bool restarting_computer = false;
+IntervalTimer restart_computer_timer(POWER_CYCLE_MS);
+
+void HandleNumEqNum(uint8_t pin_num, uint8_t pin_status) {
+  switch (pin_num) {
+    case COMP_RELAY:
+      /* The computer shutting itself off:
+          - Power down
+          - Wait 30 seconds
+          - Power up
+      */
+      if (pin_status == 0) {
+        if (restarting_computer) {
+          Serial.println("ALREADY restarting_computer!!");
+          return;
         }
+        Serial.print("Turning off the computer relay for .");
+        Serial.print(POWER_CYCLE_MS);
+        Serial.println("ms.");
+        turn_pin_off(COMP_RELAY);
+        restart_computer_timer.Reset();
+        restarting_computer = true;
+        return;
       }
-    }
-
-  private:
-    // Allow the input line to end with NL, CR NL or CR.
-    bool IsNewLine(int c) {
-      return c == '\n' || c == '\r';
-    }
-
-    void ProcessInputBuffer() {
-      uint8_t pin_num, pin_status;
-      if (input_buffer_.ParseUInt8(&pin_num) &&
-          input_buffer_.MatchAndConsume(',') &&
-          input_buffer_.ParseUInt8(&pin_status) &&
-          input_buffer_.Empty()) {
-        switch (pin_num) {
-          case COMP_RELAY:
-            /* The computer shutting itself off:
-                - Power down
-                - Wait 30 seconds
-                - Power up
-            */
-            if (pin_status == 0) {
-              turn_pin_off(COMP_RELAY);
-              delay(1000 * 30);
-              turn_pin_on(COMP_RELAY);
-            }
-            break;
-          case CAMERAS_RELAY:
-          case FAN_RELAY:
-          case WEATHER_RELAY:
-          case MOUNT_RELAY:
-            if (pin_status == 1) {
-              turn_pin_on(pin_num);
-            } else if (pin_status == 0) {
-              turn_pin_off(pin_num);
-            } else if (pin_status == 9) {
-              toggle_pin(pin_num);
-            }
-            break;
-        }
+      break;
+    case CAMERAS_RELAY:
+    case FAN_RELAY:
+    case WEATHER_RELAY:
+    case MOUNT_RELAY:
+      if (pin_status == 1) {
+        turn_pin_on(pin_num);
+        return;
+      } else if (pin_status == 0) {
+        turn_pin_off(pin_num);
+        return;
+      } else if (pin_status == 9) {
+        toggle_pin(pin_num);
+        return;
       }
+  }
+  Serial.print("NO MATCH FOUND FOR pin_num=");
+  Serial.print(static_cast<int>(pin_num));
+  Serial.print("         pin_status=");
+  Serial.println(static_cast<int>(pin_status));
+}
+
+void HandleNumEqNum(char* name, uint8_t name_len, uint8_t pin_status) {
+  for (auto& handler : dp_handlers) {
+    if (handler.NameEquals(name, name_len)) {
+      HandleNumEqNum(handler.pin(), pin_status);
+      return;
     }
+  }
+  Serial.print("NO MATCH FOUND FOR name=\"");
+  Serial.write(name, name_len);
+  Serial.print("\"         pin_status=");
+  Serial.println(static_cast<int>(pin_status));
+}
 
-    CharBuffer<8> input_buffer_;
-    bool wait_for_new_line_{false};
-} serial_input_handler;
-
-// A simple count-down timer.
-class IntervalTimer {
-  public:
-    IntervalTimer(unsigned int interval_ms)
-      : interval_(interval_ms), remaining_(interval_ms) {}
-    bool HasExpired() {
-      unsigned long now = millis();
-      unsigned long elapsed = now - last_time_;
-      last_time_ = now;
-      // Note: not checking for elapsed being so large that it
-      // exceeds the ability to be represented in remaining_.
-      remaining_ -= elapsed;
-      if (remaining_ <= 0) {
-        remaining_ += interval_;
-        if (remaining_ < 0) {
-          remaining_ = interval_;
-        }
-        return true;
-      }
-      return false;
-    }
-
-  private:
-    unsigned long last_time_{0};
-    long remaining_;
-    const unsigned int interval_;
-};
+SerialInputHandler<16> serial_input_handler(HandleNumEqNum, HandleNumEqNum);
 
 //////////////////////////////////////////////////////////////////////////////////
 // Primary Arduino defined methods: setup(), called once at start, and loop(),
@@ -380,13 +367,22 @@ void setup() {
 }
 
 void loop() {
-  serial_input_handler.Handle();
+  if (restarting_computer) {
+    if (restart_computer_timer.HasExpired()) {
+      restarting_computer = false;
+      turn_pin_on(COMP_RELAY);
+      Serial.println("Turned on the computer relay.");
+    }
+  } else {
+    serial_input_handler.Handle();
+  }
 
   // Every REPORT_INTERVAL_MS we want to produce a report on sensor values,
   // and relay settings.
   static IntervalTimer report_timer(REPORT_INTERVAL_MS);
   if (report_timer.HasExpired()) {
     digitalWrite(LED_BUILTIN, HIGH);
+    dt_handler.PrintDeviceInfo();
     Report(millis());
     digitalWrite(LED_BUILTIN, LOW);
   } else if (!Serial) {

--- a/resources/arduino_files/telemetry_board/telemetry_board.ino
+++ b/resources/arduino_files/telemetry_board/telemetry_board.ino
@@ -104,14 +104,16 @@ DallasTemperatureHandler<3> dt_handler(&ds);
 // instance of a sub-class.
 class BaseNameHandler {
   public:
+    // Print quoted name for JSON dictionary key. The decision of
+    // whether to add a comma before this is made by the caller.
     void PrintName() {
-      // Print quoted name for JSON dictionary key. The decision of
-      // whether to add a comma before this is made by the caller.
       Serial.print('"');
       Serial.print(name_);
       Serial.print("\":");
     }
 
+    // Returns true if name_ is a string of length len and equals the
+    // string starting at *s.
     bool NameEquals(const char* s, uint8_t len) {
       const char* p = name_;
       while (len > 0 && *p != '\0') {
@@ -276,7 +278,9 @@ void Report(unsigned long now) {
 bool restarting_computer = false;
 IntervalTimer restart_computer_timer(POWER_CYCLE_MS);
 
-void HandleNumEqNum(uint8_t pin_num, uint8_t pin_status) {
+// Handle an input from the computer or user.
+// Changes the specified pin based on pin_status.
+void HandleNumNum(uint8_t pin_num, uint8_t pin_status) {
   switch (pin_num) {
     case COMP_RELAY:
       /* The computer shutting itself off:
@@ -319,10 +323,12 @@ void HandleNumEqNum(uint8_t pin_num, uint8_t pin_status) {
   Serial.println(static_cast<int>(pin_status));
 }
 
-void HandleNumEqNum(char* name, uint8_t name_len, uint8_t pin_status) {
+// Handle an input from the computer or user.
+// Changes the pin specified by name based on pin_status.
+void HandleNameNum(char* name, uint8_t name_len, uint8_t pin_status) {
   for (auto& handler : dp_handlers) {
     if (handler.NameEquals(name, name_len)) {
-      HandleNumEqNum(handler.pin(), pin_status);
+      HandleNumNum(handler.pin(), pin_status);
       return;
     }
   }
@@ -332,7 +338,7 @@ void HandleNumEqNum(char* name, uint8_t name_len, uint8_t pin_status) {
   Serial.println(static_cast<int>(pin_status));
 }
 
-SerialInputHandler<16> serial_input_handler(HandleNumEqNum, HandleNumEqNum);
+SerialInputHandler<16> serial_input_handler(HandleNumNum, HandleNameNum);
 
 //////////////////////////////////////////////////////////////////////////////////
 // Primary Arduino defined methods: setup(), called once at start, and loop(),


### PR DESCRIPTION
this happened when we paused for 30 seconds for a computer power-cycle.
It is possible this is also why PAN006's telemetry board is not
responding.

Extract SerialInputHandler out of telemetry_board.ino, adding the
ability to specify the pin to be changed by name.

If power-cycling the computer, continue printing reports, which
makes debugging easier.