### PR TITLE
Fix mongo db name.

### DIFF
--- a/pocs/utils/database.py
+++ b/pocs/utils/database.py
@@ -57,7 +57,7 @@ class PanMongo(object):
             'weather',
         ]
 
-        db_handle = self._client.db
+        db_handle = getattr(self._client, db)
 
         # Setup static connections to the collections we want
         for collection in self.collections:


### PR DESCRIPTION
Get the attribute that is assigned to the `db` variable, not the `db` attribute (which will be auto-created if doesn't exist)

Closes #324 