### PR TITLE
Only the primary camera should have images saved in list

### DIFF
--- a/pocs/camera/canon_gphoto2.py
+++ b/pocs/camera/canon_gphoto2.py
@@ -143,7 +143,8 @@ class Camera(AbstractGPhotoCamera):
         proc = self.take_exposure(seconds=exp_time, filename=file_path)
 
         # Add most recent exposure to list
-        observation.exposure_list[image_id] = file_path.replace('.cr2', '.fits')
+        if self.is_primary:
+            observation.exposure_list[image_id] = file_path.replace('.cr2', '.fits')
 
         # Process the image after a set amount of time
         wait_time = exp_time + self.readout_time


### PR DESCRIPTION
The `expsoure_list` is used to get the `last_exposure`, which is then used for pointing comparisons. We only want to track the primary camera for this.