### PR TITLE
Clear existing offset info when parking

### DIFF
--- a/pocs/state/states/default/parking.py
+++ b/pocs/state/states/default/parking.py
@@ -4,13 +4,14 @@ def on_enter(event_data):
 
     # Clear any current observation
     pocs.observatory.current_observation = None
+    pocs.observatory.current_offset_info = None
 
     pocs.next_state = 'parked'
 
     if pocs.observatory.has_dome:
         pocs.say('Closing dome')
         if not pocs.observatory.close_dome():
-            self.logger.critical('Unable to close dome!')
+            pocs.logger.critical('Unable to close dome!')
             pocs.say('Unable to close dome!')
 
     pocs.say("I'm takin' it on home and then parking.")


### PR DESCRIPTION
This is only an issue if the system temporarily parks because of bad weather then starts back up and selects the same target. Without this the mount will try to adjust tracking after taking a pointing picture.

Fix a bad log call