### PR TITLE
Wait for tracking adjustment

### DIFF
--- a/pocs/mount/mount.py
+++ b/pocs/mount/mount.py
@@ -504,7 +504,7 @@ class AbstractMount(PanBase):
             offset (astropy.units.Angle): Offset in arcseconds
 
         Returns:
-             astropy.units.Second: Offset in milliseconds at current speed
+             astropy.units.Quantity: Offset in milliseconds at current speed
         """
 
         rates = {

--- a/pocs/mount/mount.py
+++ b/pocs/mount/mount.py
@@ -501,10 +501,10 @@ class AbstractMount(PanBase):
         """ Get offset in milliseconds at current speed
 
         Args:
-            offset (float): Offset in arcseconds
+            offset (astropy.units.Angle): Offset in arcseconds
 
         Returns:
-            float: Offset in milliseconds at current speed
+             astropy.units.Second: Offset in milliseconds at current speed
         """
 
         rates = {

--- a/pocs/mount/simulator.py
+++ b/pocs/mount/simulator.py
@@ -100,7 +100,7 @@ class Mount(AbstractMount):
             offset (astropy.units.Angle): Offset in arcseconds
 
         Returns:
-             astropy.units.Second: Offset in milliseconds at current speed
+             astropy.units.Quantity: Offset in milliseconds at current speed
         """
 
         offset = 25 * u.arcsecond  # Fake value

--- a/pocs/mount/simulator.py
+++ b/pocs/mount/simulator.py
@@ -1,5 +1,7 @@
 import time
 
+from astropy import units as u
+
 from pocs.utils import current_time
 from pocs.mount import AbstractMount
 
@@ -90,6 +92,27 @@ class Mount(AbstractMount):
         """
         self.logger.debug("Mount simulator moving {} for {} seconds".format(direction, seconds))
         time.sleep(seconds)
+
+    def get_ms_offset(self, offset, axis='ra'):
+        """ Fake offset in milliseconds
+
+        Args:
+            offset (astropy.units.Angle): Offset in arcseconds
+
+        Returns:
+             astropy.units.Second: Offset in milliseconds at current speed
+        """
+
+        offset = 25 * u.arcsecond  # Fake value
+
+        rates = {
+            'ra': self.ra_guide_rate,
+            'dec': self.dec_guide_rate,
+        }
+
+        guide_rate = rates[axis]
+
+        return (offset / (self.sidereal_rate * guide_rate)).to(u.ms)
 
     def slew_to_target(self):
         success = False

--- a/pocs/mount/simulator.py
+++ b/pocs/mount/simulator.py
@@ -105,14 +105,7 @@ class Mount(AbstractMount):
 
         offset = 25 * u.arcsecond  # Fake value
 
-        rates = {
-            'ra': self.ra_guide_rate,
-            'dec': self.dec_guide_rate,
-        }
-
-        guide_rate = rates[axis]
-
-        return (offset / (self.sidereal_rate * guide_rate)).to(u.ms)
+        return super().get_ms_offset(offset, axis=axis)
 
     def slew_to_target(self):
         success = False

--- a/pocs/observatory.py
+++ b/pocs/observatory.py
@@ -338,7 +338,14 @@ class Observatory(PanBase):
                 self.mount.query('move_ms_{}'.format(
                     ra_direction), '{:05.0f}'.format(ra_correction))
 
-            return ((ra_direction, ra_offset), (dec_direction, dec_offset))
+            # Adjust tracking for up to 30 seconds then fail if not done.
+            start_tracking_time = current_time()
+            while self.mount.is_tracking is False:
+                if (current_time() - start_tracking_time).sec > 30:
+                    raise Exception("Trying to adjust tracking for more than 30 seconds")
+
+                self.logger.debug("Waiting for tracking adjustment")
+                self.sleep(delay=0.5)
 
     def get_standard_headers(self, observation=None):
         """Get a set of standard headers

--- a/pocs/observatory.py
+++ b/pocs/observatory.py
@@ -300,16 +300,17 @@ class Observatory(PanBase):
         Uses the `rate_adjustment` key from the `self.current_offset_info`
         """
         if self.current_offset_info is not None:
+            self.logger.debug("Updating the tracking")
 
             dec_offset = self.current_offset_info.delta_dec
-            dec_ms = self.mount.get_ms_offset(dec_offset)
+            dec_ms = self.mount.get_ms_offset(dec_offset, axis='dec')
             if dec_offset >= 0:
                 dec_direction = 'north'
             else:
                 dec_direction = 'south'
 
             ra_offset = self.current_offset_info.delta_ra
-            ra_ms = self.mount.get_ms_offset(ra_offset)
+            ra_ms = self.mount.get_ms_offset(ra_offset, axis='ra')
             if ra_offset >= 0:
                 ra_direction = 'west'
             else:

--- a/pocs/state/states/default/tracking.py
+++ b/pocs/state/states/default/tracking.py
@@ -1,14 +1,27 @@
+from pocs.utils import current_time
+
+
 def on_enter(event_data):
     """ The unit is tracking the target. Proceed to observations. """
     pocs = event_data.model
+    pocs.next_state = 'parking'
     pocs.say("Checking our tracking")
 
     try:
         ra_info, dec_info = pocs.observatory.update_tracking()
         pocs.say("Correcting drift: RA {} {:.02f}".format(ra_info[0], ra_info[1]))
         pocs.say("Correcting drift: Dec {} {:.02f}".format(dec_info[0], dec_info[1]))
+
+        # Adjust tracking for up to 30 seconds then fail if not done.
+        start_tracking_time = current_time()
+        while pocs.observatory.mount.is_tracking is False:
+            if (current_time() - start_tracking_time).sec > 30:
+                raise Exception("Trying to adjust tracking for more than 30 seconds")
+
+            pocs.logger.debug("Waiting for tracking adjustment")
+            pocs.sleep(delay=0.5)
+
+        pocs.say("Done with tracking adjustment, going to observe")
+        pocs.next_state = 'observing'
     except Exception as e:
         pocs.logger.warning("Problem adjusting tracking: {}".format(e))
-
-    pocs.say("Done with tracking adjustment, going to observe")
-    pocs.next_state = 'observing'

--- a/pocs/state/states/default/tracking.py
+++ b/pocs/state/states/default/tracking.py
@@ -7,21 +7,23 @@ def on_enter(event_data):
     pocs.next_state = 'parking'
     pocs.say("Checking our tracking")
 
-    try:
-        ra_info, dec_info = pocs.observatory.update_tracking()
-        pocs.say("Correcting drift: RA {} {:.02f}".format(ra_info[0], ra_info[1]))
-        pocs.say("Correcting drift: Dec {} {:.02f}".format(dec_info[0], dec_info[1]))
+    # If we came from pointing then don't try to adjust
+    if event_data.transition.source != 'pointing':
+        try:
+            ra_info, dec_info = pocs.observatory.update_tracking()
+            pocs.say("Correcting drift: RA {} {:.02f}".format(ra_info[0], ra_info[1]))
+            pocs.say("Correcting drift: Dec {} {:.02f}".format(dec_info[0], dec_info[1]))
 
-        # Adjust tracking for up to 30 seconds then fail if not done.
-        start_tracking_time = current_time()
-        while pocs.observatory.mount.is_tracking is False:
-            if (current_time() - start_tracking_time).sec > 30:
-                raise Exception("Trying to adjust tracking for more than 30 seconds")
+            # Adjust tracking for up to 30 seconds then fail if not done.
+            start_tracking_time = current_time()
+            while pocs.observatory.mount.is_tracking is False:
+                if (current_time() - start_tracking_time).sec > 30:
+                    raise Exception("Trying to adjust tracking for more than 30 seconds")
 
-            pocs.logger.debug("Waiting for tracking adjustment")
-            pocs.sleep(delay=0.5)
+                pocs.logger.debug("Waiting for tracking adjustment")
+                pocs.sleep(delay=0.5)
 
-        pocs.say("Done with tracking adjustment, going to observe")
-        pocs.next_state = 'observing'
-    except Exception as e:
-        pocs.logger.warning("Problem adjusting tracking: {}".format(e))
+            pocs.say("Done with tracking adjustment, going to observe")
+            pocs.next_state = 'observing'
+        except Exception as e:
+            pocs.logger.warning("Problem adjusting tracking: {}".format(e))

--- a/pocs/state/states/default/tracking.py
+++ b/pocs/state/states/default/tracking.py
@@ -1,5 +1,3 @@
-from pocs.utils import current_time
-
 
 def on_enter(event_data):
     """ The unit is tracking the target. Proceed to observations. """
@@ -10,19 +8,7 @@ def on_enter(event_data):
     if event_data.transition.source != 'pointing':
         pocs.say("Checking our tracking")
         try:
-            ra_info, dec_info = pocs.observatory.update_tracking()
-            pocs.say("Correcting drift: RA {} {:.02f}".format(ra_info[0], ra_info[1]))
-            pocs.say("Correcting drift: Dec {} {:.02f}".format(dec_info[0], dec_info[1]))
-
-            # Adjust tracking for up to 30 seconds then fail if not done.
-            start_tracking_time = current_time()
-            while pocs.observatory.mount.is_tracking is False:
-                if (current_time() - start_tracking_time).sec > 30:
-                    raise Exception("Trying to adjust tracking for more than 30 seconds")
-
-                pocs.logger.debug("Waiting for tracking adjustment")
-                pocs.sleep(delay=0.5)
-
+            pocs.observatory.update_tracking()
             pocs.say("Done with tracking adjustment, going to observe")
             pocs.next_state = 'observing'
         except Exception as e:

--- a/pocs/state/states/default/tracking.py
+++ b/pocs/state/states/default/tracking.py
@@ -5,10 +5,10 @@ def on_enter(event_data):
     """ The unit is tracking the target. Proceed to observations. """
     pocs = event_data.model
     pocs.next_state = 'parking'
-    pocs.say("Checking our tracking")
 
     # If we came from pointing then don't try to adjust
     if event_data.transition.source != 'pointing':
+        pocs.say("Checking our tracking")
         try:
             ra_info, dec_info = pocs.observatory.update_tracking()
             pocs.say("Correcting drift: RA {} {:.02f}".format(ra_info[0], ra_info[1]))

--- a/pocs/state/states/default/tracking.py
+++ b/pocs/state/states/default/tracking.py
@@ -27,3 +27,5 @@ def on_enter(event_data):
             pocs.next_state = 'observing'
         except Exception as e:
             pocs.logger.warning("Problem adjusting tracking: {}".format(e))
+    else:
+        pocs.next_state = 'observing'

--- a/pocs/tests/test_pocs.py
+++ b/pocs/tests/test_pocs.py
@@ -291,7 +291,7 @@ def test_run_no_targets_and_exit(pocs):
     assert pocs.state == 'sleeping'
 
 
-def test_run(pocs):
+def test_run_complete(pocs):
     os.environ['POCSTIME'] = '2016-09-09 08:00:00'
     pocs.config['simulator'] = ['camera', 'mount', 'weather', 'night']
     pocs.state = 'sleeping'


### PR DESCRIPTION
The tracking adjustment for ioptron uses `move_ms_<direction>`, which places
the mount in `guide` mode (as indicated by the status) but is non-blocking.
If the tracking adjustment is too long (~ > 4-5 seconds) and no blocking
is done the machine will try to transition to next state. There is a
condition on the state machine that the mount must be in `tracking`
to `observe` so it gets stuck and then tries again. After 5 iterations
of same state without successful transition the machine will give up
and park the mount.

Here we just wait out for up to 30 seconds until back in `tracking`
mode.

Note: Ideally we should never have to have an adjustment of 4-5 seconds,
so not entirely sure what is going on there. Seems to happen most on
first adjustment after pointing but also depends on where mount is poining.
This is a problem with PAN001 that we have had and might not be an issue
on other units.