### PR TITLE
Fix open_dome command so that it doesn't require that it be dark,

### DIFF
--- a/bin/pocs_shell
+++ b/bin/pocs_shell
@@ -291,7 +291,7 @@ Hardware names: {}   (or all for all hardware)'''.format(
         if not self.pocs.observatory.has_dome:
             print_warning('There is no dome.')
             return
-        if not self.is_safe:
+        if not self.pocs.is_weather_safe():
             print_warning('Weather conditions are not good, not opening dome.')
             return
         try:


### PR DESCRIPTION
just that the weather be safe.

Re-write loop in AstrohavenDome._full_move so that it doesn't wait long
when reading from the dome. The old code was too slow, so the dome moved
in a little then stopped, then repeated that, but not fast enough for
closing to occur.

Fix a flakiness problem: once a limit has been reached (i.e. one shutter
all the way opened or all the way closed), the PLC will likely output
more than one of the corresponding limit characters before then
outputting the new stable character. So added code for reading the
state until it has reached a stable value.