### PR TITLE
Fix timeout interval for pointing

### DIFF
--- a/pocs/state/states/default/pointing.py
+++ b/pocs/state/states/default/pointing.py
@@ -59,7 +59,7 @@ def on_enter(event_data):
                 pocs.status()
 
                 if wait_time > timeout:
-                    raise error.Timeout
+                    raise error.Timeout("Timeout waiting for pointing image")
 
                 sleep(wait_interval)
                 wait_time += wait_interval

--- a/pocs/state/states/default/pointing.py
+++ b/pocs/state/states/default/pointing.py
@@ -39,7 +39,11 @@ def on_enter(event_data):
                     try:
                         # Start the exposures
                         camera_event = camera.take_observation(
-                            observation, fits_headers, exp_time=30., filename='pointing{:02d}'.format(img_num))
+                            observation,
+                            fits_headers,
+                            exp_time=30.,
+                            filename='pointing{:02d}'.format(img_num)
+                        )
 
                         camera_events[cam_name] = camera_event
 

--- a/pocs/state/states/default/pointing.py
+++ b/pocs/state/states/default/pointing.py
@@ -34,9 +34,8 @@ def on_enter(event_data):
             camera_events = dict()
 
             for cam_name, camera in pocs.observatory.cameras.items():
-                pocs.logger.debug("Exposing for camera: {}".format(cam_name))
-
                 if camera.is_primary:
+                    pocs.logger.debug("Exposing for camera: {}".format(cam_name))
                     try:
                         # Start the exposures
                         camera_event = camera.take_observation(
@@ -59,7 +58,7 @@ def on_enter(event_data):
                     'Waiting for images: {} seconds'.format(wait_time))
                 pocs.status()
 
-                if wait_interval > timeout:
+                if wait_time > timeout:
                     raise error.Timeout
 
                 sleep(wait_interval)


### PR DESCRIPTION
Also move the log message inside if state. Really the whole for loop
is redundant, could just get the primary camera directly. However if
we ever want to take pointing images with both cameras it's nice to
have this.