### PR TITLE
Remove output of temp sensor device info.

### DIFF
--- a/resources/arduino_files/telemetry_board/telemetry_board.ino
+++ b/resources/arduino_files/telemetry_board/telemetry_board.ino
@@ -46,7 +46,7 @@
 // make changes to this code. The value needs to
 // be in JSON format (i.e. quoted and escaped if
 // a string).
-#define JSON_VERSION_ID "\"2018-01-07\""
+#define JSON_VERSION_ID "\"2018-01-14\""
 
 // How often, in milliseconds, to emit a report.
 #define REPORT_INTERVAL_MS 2000
@@ -367,7 +367,6 @@ void setup() {
   // Setup communications with the sensors.
   dht_handler.Init();
   dt_handler.Init();
-  // dt_handler.PrintDeviceInfo();
 
   pinMode(AC_PIN, INPUT);
 }
@@ -388,7 +387,6 @@ void loop() {
   static IntervalTimer report_timer(REPORT_INTERVAL_MS);
   if (report_timer.HasExpired()) {
     digitalWrite(LED_BUILTIN, HIGH);
-    dt_handler.PrintDeviceInfo();
     Report(millis());
     digitalWrite(LED_BUILTIN, LOW);
   } else if (!Serial) {


### PR DESCRIPTION
Remove call to PrintDeviceInfo.

Change DallasTemperatureHandler::PrintDeviceInfo to output JSON.
Extract DeviceInfo out into a top-level struct, just to make things a
bit easier to manage.