### PR TITLE
Mount serial fixes

### DIFF
--- a/conf_files/pocs.yaml
+++ b/conf_files/pocs.yaml
@@ -27,7 +27,9 @@ mount:
     brand: ioptron
     model: 30
     driver: ioptron
-    port: /dev/ttyUSB0
+    serial:
+        port: /dev/ttyUSB0
+        timeout: 0.
     non_sidereal_available: True
 pointing:
     threshold: 0.05

--- a/pocs/mount/ioptron.py
+++ b/pocs/mount/ioptron.py
@@ -216,14 +216,16 @@ class Mount(AbstractSerialMount):
         guide_rate = self.query('get_guide_rate')
         self.ra_guide_rate = int(guide_rate[0:2]) / 100
         self.dec_guide_rate = int(guide_rate[2:]) / 100
-        self.logger.debug("Mount guide rate: {} {}".format(self.ra_guide_rate, self.dec_guide_rate))
+        self.logger.debug("Mount guide rate: {} {}".format(
+            self.ra_guide_rate, self.dec_guide_rate))
 
     def _setup_location_for_mount(self):
         """
         Sets the mount up to the current location. Mount must be initialized first.
 
-        This uses mount.location (an astropy.coords.EarthLocation) to set most of the params and the rest is
-        read from a config file.  Users should not call this directly.
+        This uses mount.location (an astropy.coords.EarthLocation) to set
+        most of the params and the rest is read from a config file.  Users
+        should not call this directly.
 
         Includes:
         * Latitude set_long
@@ -243,8 +245,8 @@ class Mount(AbstractSerialMount):
 
         # Location
         # Adjust the lat/long for format expected by iOptron
-        lat = '{:+07.0f}'.format(self.location.latitude.to(u.arcsecond).value)
-        lon = '{:+07.0f}'.format(self.location.longitude.to(u.arcsecond).value)
+        lat = '{:+07.0f}'.format(self.location.lat.to(u.arcsecond).value)
+        lon = '{:+07.0f}'.format(self.location.lon.to(u.arcsecond).value)
 
         self.query('set_long', lon)
         self.query('set_lat', lat)
@@ -301,12 +303,12 @@ class Mount(AbstractSerialMount):
             XXXXX(XXX) milliseconds
 
             Command: “:SrXXXXXXXX#”
-            Defines the commanded right ascension, RA. Slew, calibrate and park commands operate on the
-            most recently defined right ascension.
+            Defines the commanded right ascension, RA. Slew, calibrate and
+            park commands operate on the most recently defined right ascension.
 
             Command: “:SdsTTTTTTTT#”
-            Defines the commanded declination, Dec. Slew, calibrate and park commands operate on the most
-            recently defined declination.
+            Defines the commanded declination, Dec. Slew, calibrate and
+            park commands operate on the most recently defined declination.
             `
 
         @param  coords  astropy.coordinates.SkyCoord

--- a/pocs/mount/serial.py
+++ b/pocs/mount/serial.py
@@ -18,13 +18,17 @@ class AbstractSerialMount(AbstractMount):
 
         # Setup our serial connection at the given port
         try:
-            self._port = self.config['mount']['port']
+            serial_config = self.config['mount']['serial']
+            self.serial = rs232.SerialData(**serial_config)
         except KeyError:
-            self.logger.error(
-                'No mount port specified, cannot create mount\n {}'.format(
-                    self.config['mount']))
+            self.logger.critical(
+                'No serial config specified, cannot create mount\n {}', self.config['mount'])
+        except ValueError as e:
+            self.logger.critical(e)
 
-        self.serial = rs232.SerialData(port=self._port, baudrate=9600)
+    @property
+    def _port(self):
+        return self.serial.ser.port
 
 
 ##################################################################################################

--- a/pocs/mount/serial.py
+++ b/pocs/mount/serial.py
@@ -20,10 +20,12 @@ class AbstractSerialMount(AbstractMount):
         try:
             serial_config = self.config['mount']['serial']
             self.serial = rs232.SerialData(**serial_config)
+            if self.serial.is_connected is False:
+                raise error.MountNotFound("Can't open mount")
         except KeyError:
             self.logger.critical(
                 'No serial config specified, cannot create mount\n {}', self.config['mount'])
-        except ValueError as e:
+        except Exception as e:
             self.logger.critical(e)
 
     @property

--- a/pocs/observatory.py
+++ b/pocs/observatory.py
@@ -610,7 +610,7 @@ class Observatory(PanBase):
                 if port is None or len(glob(port)) == 0:
                     msg = "Mount port({}) not available. ".format(port) \
                         + "Use - -simulator = mount for simulator. Exiting."
-                    raise error.PanError(msg=msg, exit=True)
+                    raise error.MountNotFound(msg=msg)
 
         self.logger.debug('Creating mount: {}'.format(model))
 
@@ -618,6 +618,7 @@ class Observatory(PanBase):
 
         # Make the mount include site information
         self.mount = module.Mount(location=self.earth_location)
+
         self.logger.debug('Mount created')
 
     def _create_cameras(self, **kwargs):

--- a/pocs/observatory.py
+++ b/pocs/observatory.py
@@ -591,7 +591,8 @@ class Observatory(PanBase):
             mount_info = self.config.get('mount')
 
         model = mount_info.get('model')
-        port = mount_info.get('port')
+        serial_info = mount_info['serial']
+        port = serial_info['port']
 
         if 'mount' in self.config.get('simulator', []):
             model = 'simulator'
@@ -606,9 +607,9 @@ class Observatory(PanBase):
             # definition of this method to return a validated but not fully initialized mount
             # driver.
             if model != 'bisque':
-                port = mount_info.get('port')
                 if port is None or len(glob(port)) == 0:
-                    msg = "Mount port ({}) not available. Use --simulator=mount for simulator. Exiting.".format(port)
+                    msg = "Mount port({}) not available. ".format(port) \
+                        + "Use - -simulator = mount for simulator. Exiting."
                     raise error.PanError(msg=msg, exit=True)
 
         self.logger.debug('Creating mount: {}'.format(model))

--- a/pocs/tests/test_ioptron.py
+++ b/pocs/tests/test_ioptron.py
@@ -53,6 +53,7 @@ class TestMount(object):
         self.mount.set_park_coordinates()
         assert self.mount._park_coordinates is not None
 
+        # These are the empirically determined coordinates for PAN001
         assert self.mount._park_coordinates.dec.value == -10.0
         assert self.mount._park_coordinates.ra.value - 322.98 <= 1.0
 

--- a/pocs/tests/test_ioptron.py
+++ b/pocs/tests/test_ioptron.py
@@ -3,9 +3,9 @@ import pytest
 from astropy.coordinates import EarthLocation
 
 from pocs.mount.ioptron import Mount
-from pocs.utils.config import load_config
 
 
+@pytest.mark.with_mount
 def test_loading_without_config():
     """ Tests the basic loading of a mount """
     with pytest.raises(TypeError):
@@ -13,14 +13,15 @@ def test_loading_without_config():
         assert isinstance(mount, Mount)
 
 
+@pytest.mark.with_mount
 class TestMount(object):
 
     """ Test the mount """
 
     @pytest.fixture(autouse=True)
-    def setup(self):
+    def setup(self, config):
 
-        self.config = load_config(ignore_local=True)
+        self.config = config
 
         location = self.config['location']
 
@@ -34,3 +35,31 @@ class TestMount(object):
 
         mount = Mount(loc)
         assert mount is not None
+
+        self.mount = mount
+
+        with pytest.raises(AssertionError):
+            assert self.mount.query('version') == 'V1.00'
+        assert self.mount.is_initialized is False
+        assert self.mount.initialize() is True
+
+    def test_version(self):
+        assert self.mount.query('version') == 'V1.00'
+
+    def test_set_park_coords(self):
+        self.mount.initialize()
+        assert self.mount._park_coordinates is None
+
+        self.mount.set_park_coordinates()
+        assert self.mount._park_coordinates is not None
+
+        assert self.mount._park_coordinates.dec.value == -10.0
+        assert self.mount._park_coordinates.ra.value - 322.98 <= 1.0
+
+    def test_unpark_park(self):
+        assert self.mount.is_parked is True
+        self.mount.initialize()
+        self.mount.unpark()
+        assert self.mount.is_parked is False
+        self.mount.home_and_park()
+        assert self.mount.is_parked is True

--- a/pocs/tests/test_observatory.py
+++ b/pocs/tests/test_observatory.py
@@ -47,12 +47,19 @@ def test_bad_site(simulator, config):
         Observatory(simulator=simulator, config=conf, ignore_local_config=True)
 
 
-def test_bad_mount(config):
+def test_bad_mount_port(config):
     conf = config.copy()
     simulator = hardware.get_all_names(without=['mount'])
-    conf['mount']['port'] = '/dev/'
+    conf['mount']['serial']['port'] = '/dev/'
+    with pytest.raises(SystemExit):
+        Observatory(simulator=simulator, config=conf, ignore_local_config=True)
+
+
+def test_bad_mount_driver(config):
+    conf = config.copy()
+    simulator = hardware.get_all_names(without=['mount'])
     conf['mount']['driver'] = 'foobar'
-    with pytest.raises(error.NotFound):
+    with pytest.raises(SystemExit):
         Observatory(simulator=simulator, config=conf, ignore_local_config=True)
 
 

--- a/pocs/utils/rs232.py
+++ b/pocs/utils/rs232.py
@@ -40,6 +40,7 @@ class SerialData(PanBase):
                  port=None,
                  baudrate=115200,
                  name=None,
+                 timeout=2.0,
                  open_delay=0.0,
                  retry_limit=5,
                  retry_delay=0.5):
@@ -54,9 +55,12 @@ class SerialData(PanBase):
             baudrate: For true serial lines (e.g. RS-232), sets the baud rate of
                 the device.
             name: Name of this object. Defaults to the name of the port.
+            timeout (float, optional): Timeout in seconds for both read and write.
+                Defaults to 2.0.
             open_delay: Seconds to wait after opening the port.
             retry_limit: Number of times to try readline() calls in read().
             retry_delay: Delay between readline() calls in read().
+
         Raises:
             ValueError: If the serial parameters are invalid (e.g. a negative baudrate).
 
@@ -77,11 +81,11 @@ class SerialData(PanBase):
         self.ser.bytesize = serial.EIGHTBITS
         self.ser.parity = serial.PARITY_NONE
         self.ser.stopbits = serial.STOPBITS_ONE
-        self.ser.timeout = 2.0  # TODO(jamessynge): Allow caller or config to set.
+        self.ser.timeout = timeout
+        self.ser.write_timeout = timeout
         self.ser.xonxoff = False
         self.ser.rtscts = False
         self.ser.dsrdtr = False
-        self.ser.write_timeout = False
 
         self.logger.debug('SerialData for {} created', self.name)
 


### PR DESCRIPTION
This starts to support serial from config (#181) although only has that option for the mount at this point.

Sets a default timeout of 2.0s for serial devices. Sets 0.0 for the serial mounts.

Adds a far-from-complete hardware test for ioptron.

Fixes #376 