### PR TITLE
Create the timelapse directory explicitly.

### DIFF
--- a/pocs/utils/images/__init__.py
+++ b/pocs/utils/images/__init__.py
@@ -53,8 +53,8 @@ def crop_data(data, box_width=200, center=None, verbose=False):
         print("Using center: {} {}".format(x_center, y_center))
         print("Box width: {}".format(box_width))
 
-    center = data[x_center - box_width: x_center + box_width,
-                  y_center - box_width: y_center + box_width]
+    center = data[x_center - box_width:x_center + box_width, y_center - box_width:
+                  y_center + box_width]
 
     return center
 
@@ -98,8 +98,7 @@ def _make_pretty_from_fits(fname, **kwargs):
 
     title = '{} {}'.format(title, date_time)
 
-    norm = ImageNormalize(interval=PercentileInterval(percent_value),
-                          stretch=LogStretch())
+    norm = ImageNormalize(interval=PercentileInterval(percent_value), stretch=LogStretch())
 
     wcs = WCS(fname)
 
@@ -146,18 +145,15 @@ def _make_pretty_from_cr2(fname, timeout=15, **kwargs):  # pragma: no cover
         print(cmd)
 
     try:
-        proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL,
-                                stderr=subprocess.DEVNULL)
+        proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         if verbose:
             print(proc)
     except OSError as e:
-        raise error.InvalidCommand("Can't send command to gphoto2."
-                                   " {} \t {}".format(e, cmd))
+        raise error.InvalidCommand("Can't send command to gphoto2. {!r} \t {}".format(e, cmd))
     except ValueError as e:
-        raise error.InvalidCommand("Bad parameters to gphoto2."
-                                   " {} \t {}".format(e, cmd))
+        raise error.InvalidCommand("Bad parameters to gphoto2. {!r} \t {}".format(e, cmd))
     except Exception as e:
-        raise error.PanError("Timeout on plate solving: {}".format(e))
+        raise error.PanError("Timeout on plate solving: {!r}".format(e))
 
     return fname.replace('cr2', 'jpg')
 
@@ -183,15 +179,20 @@ def create_timelapse(directory, fn_out=None, **kwargs):
 
         field_name = head.split('/')[-2]
         cam_name = head.split('/')[-1]
-        fn_out = '{}/images/timelapse/{}_{}_{}.mp4'.format(
-            os.getenv('PANDIR'), field_name, cam_name, tail)
+        fname = '{}_{}_{}.mp4'.format(field_name, cam_name, tail)
+        fn_out = os.path.join(os.getenv('PANDIR'), 'images', 'timelapse', fname)
+
+    fn_dir = os.path.dirname(fn_out)
+    os.makedirs(fn_dir, exist_ok=True)
+    inputs_glob = os.path.join(directory, '*.jpg')
 
     try:
         ff = FFmpeg(
             global_options='-r 3 -pattern_type glob',
-            inputs={'{}/*.jpg'.format(directory): None},
-            outputs={fn_out: '-s hd1080 -vcodec libx264'}
-        )
+            inputs={inputs_glob: None},
+            outputs={
+                fn_out: '-s hd1080 -vcodec libx264'
+            })
 
         if 'verbose' in kwargs:
             out = None
@@ -203,7 +204,7 @@ def create_timelapse(directory, fn_out=None, **kwargs):
 
         ff.run(stdout=out, stderr=err)
     except Exception as e:
-        warn("Problem creating timelapse: {}".format(fn_out))
+        warn("Problem creating timelapse in {}: {!r}".format(fn_out, e))
         fn_out = None
 
     return fn_out
@@ -229,32 +230,35 @@ def clean_observation_dir(dir_name, *args, **kwargs):
         if verbose:
             print(msg)
 
+    def _glob(s):
+        return glob(os.path.join(dir_name, s))
+
     _print("Cleaning dir: {}".format(dir_name))
 
     # Pack the fits filts
     try:
         _print("Packing FITS files")
-        for f in glob('{}/*.fits'.format(dir_name)):
+        for f in _glob('*.fits'):
             try:
                 fits_utils.fpack(f)
             except Exception as e:  # pragma: no cover
-                warn('Could not compress fits file: {}'.format(e))
+                warn('Could not compress fits file: {!r}'.format(e))
     except Exception as e:
-        warn('Problem with cleanup cleaning FITS:'.format(e))
+        warn('Problem with cleanup cleaning FITS: {!r}'.format(e))
 
     try:
         # Remove .solved files
         _print('Removing .solved files')
-        for f in glob('{}/*.solved'.format(dir_name)):
+        for f in _glob('*.solved'):
             try:
                 os.remove(f)
             except OSError as e:  # pragma: no cover
-                warn('Could not delete file: {}'.format(e))
+                warn('Could not delete file: {!r}'.format(e))
     except Exception as e:
-        warn('Problem with cleanup removing solved:'.format(e))
+        warn('Problem with cleanup removing solved: {!r}'.format(e))
 
     try:
-        jpg_list = glob('{}/*.jpg'.format(dir_name))
+        jpg_list = _glob('*.jpg')
 
         if len(jpg_list) > 0:
 
@@ -269,6 +273,6 @@ def clean_observation_dir(dir_name, *args, **kwargs):
                 try:
                     os.remove(f)
                 except OSError as e:
-                    warn('Could not delete file: {}'.format(e))
+                    warn('Could not delete file: {!r}'.format(e))
     except Exception as e:
-        warn('Problem with cleanup creating timelapse:'.format(e))
+        warn('Problem with cleanup creating timelapse: {!r}'.format(e))

--- a/scripts/install/apt-packages-list.txt
+++ b/scripts/install/apt-packages-list.txt
@@ -63,3 +63,5 @@ libgeos-dev
 byobu
 tmux
 
+# Used for creating a timelapse.
+ffmpeg


### PR DESCRIPTION
Use os.path.join instead of string concatenation for building paths.
Fix exception message output.
Add ffmpeg to requirements, needed for timelapse creation.

Fixes #395.