### PR TITLE
Use shutil to find gphoto2

### DIFF
--- a/pocs/utils/__init__.py
+++ b/pocs/utils/__init__.py
@@ -77,7 +77,8 @@ def list_connected_cameras():
     Cameras should be known and placed in config but this is a useful utility.
     """
 
-    command = ['gphoto2', '--auto-detect']
+    gphoto2 = shutil.which('gphoto2')
+    command = [gphoto2, '--auto-detect']
     result = subprocess.check_output(command)
     lines = result.decode('utf-8').split('\n')
 


### PR DESCRIPTION
If you happen to have two `gphoto2` commands installed this will consistently return the same one, which didn't seem to be the case when just a bare string was passed to a subprocess command.