### PR TITLE
End of night shutdown improvements.

### DIFF
--- a/pocs/core.py
+++ b/pocs/core.py
@@ -81,7 +81,8 @@ class POCS(PanStateMachine, PanBase):
         self._interrupted = False
         self.force_reschedule = False
 
-        self._retry_attempts = 3
+        self._retry_attempts = kwargs.get('retry_attempts', 3)
+        self._nightly_retries = self._retry_attempts
 
         self.status()
 
@@ -118,8 +119,7 @@ class POCS(PanStateMachine, PanBase):
 
     @property
     def should_retry(self):
-        self._retry_attempts -= 1
-        return self._retry_attempts >= 0
+        return self._nightly_retries >= 0
 
 
 ##################################################################################################
@@ -263,6 +263,10 @@ class POCS(PanStateMachine, PanBase):
             self._connected = False
             self.logger.info("Power down complete")
 
+    def reset_observing_run(self):
+        """Reset an observing run loop. """
+        self.logger.debug("Resetting observing run attempts")
+        self._nightly_retries = self._retry_attempts
 
 ##################################################################################################
 # Safety Methods

--- a/pocs/core.py
+++ b/pocs/core.py
@@ -82,7 +82,7 @@ class POCS(PanStateMachine, PanBase):
         self.force_reschedule = False
 
         self._retry_attempts = kwargs.get('retry_attempts', 3)
-        self._nightly_retries = self._retry_attempts
+        self._obs_run_retries = self._retry_attempts
 
         self.status()
 
@@ -119,7 +119,7 @@ class POCS(PanStateMachine, PanBase):
 
     @property
     def should_retry(self):
-        return self._nightly_retries >= 0
+        return self._obs_run_retries >= 0
 
 
 ##################################################################################################
@@ -266,7 +266,7 @@ class POCS(PanStateMachine, PanBase):
     def reset_observing_run(self):
         """Reset an observing run loop. """
         self.logger.debug("Resetting observing run attempts")
-        self._nightly_retries = self._retry_attempts
+        self._obs_run_retries = self._retry_attempts
 
 ##################################################################################################
 # Safety Methods

--- a/pocs/core.py
+++ b/pocs/core.py
@@ -136,6 +136,7 @@ class POCS(PanStateMachine, PanBase):
         """
 
         if not self._initialized:
+            self.logger.info('*' * 80)
             self.say("Initializing the system! Woohoo!")
 
             try:
@@ -176,6 +177,7 @@ class POCS(PanStateMachine, PanBase):
         Args:
             msg(str): Message to be sent
         """
+        self.logger.info('Unit says: {}', msg)
         self.send_message(msg, channel='PANCHAT')
 
     def send_message(self, msg, channel='POCS'):
@@ -422,7 +424,7 @@ class POCS(PanStateMachine, PanBase):
             time.sleep(delay)
 
     def wait_until_safe(self):
-        """ Waits until weather is safe
+        """ Waits until weather is safe.
 
         This will wait until a True value is returned from the safety check,
         blocking until then.

--- a/pocs/core.py
+++ b/pocs/core.py
@@ -177,7 +177,8 @@ class POCS(PanStateMachine, PanBase):
         Args:
             msg(str): Message to be sent
         """
-        self.logger.info('Unit says: {}', msg)
+        if self.has_messaging is False:
+            self.logger.info('Unit says: {}', msg)
         self.send_message(msg, channel='PANCHAT')
 
     def send_message(self, msg, channel='POCS'):

--- a/pocs/observatory.py
+++ b/pocs/observatory.py
@@ -186,8 +186,8 @@ class Observatory(PanBase):
         self.logger.debug("Getting observation for observatory")
 
         # If observation list is empty or a reread is requested
-        if self.scheduler.has_valid_observations is False or \
-                kwargs.get('reread_fields_file', False):
+        if (self.scheduler.has_valid_observations is False or
+                kwargs.get('reread_fields_file', False)):
             self.scheduler.read_field_list()
 
         self.scheduler.get_observation(*args, **kwargs)

--- a/pocs/observatory.py
+++ b/pocs/observatory.py
@@ -184,9 +184,16 @@ class Observatory(PanBase):
         """
 
         self.logger.debug("Getting observation for observatory")
+
+        # If observation list is empty or a reread is requested
+        if self.scheduler.has_valid_observations is False or \
+                kwargs.get('reread_fields_file', False):
+            self.scheduler.read_field_list()
+
         self.scheduler.get_observation(*args, **kwargs)
 
         if self.scheduler.current_observation is None:
+            self.scheduler.clear_available_observations()
             raise error.NoObservation("No valid observations found")
 
         return self.current_observation

--- a/pocs/observatory.py
+++ b/pocs/observatory.py
@@ -190,9 +190,10 @@ class Observatory(PanBase):
                 kwargs.get('reread_fields_file', False)):
             self.scheduler.read_field_list()
 
+        # This will set the `current_observation`
         self.scheduler.get_observation(*args, **kwargs)
 
-        if self.scheduler.current_observation is None:
+        if self.current_observation is None:
             self.scheduler.clear_available_observations()
             raise error.NoObservation("No valid observations found")
 

--- a/pocs/scheduler/dispatch.py
+++ b/pocs/scheduler/dispatch.py
@@ -22,7 +22,7 @@ class Scheduler(BaseScheduler):
 # Methods
 ##########################################################################
 
-    def get_observation(self, time=None, show_all=False, reread_fields_file=False):
+    def get_observation(self, time=None, show_all=False):
         """Get a valid observation
 
         Args:
@@ -30,16 +30,10 @@ class Scheduler(BaseScheduler):
                 defaults to time called
             show_all (bool, optional): Return all valid observations along with
                 merit value, defaults to False to only get top value
-            reread_fields_file (bool, optional): If targets file should be reread
-                before getting observation, default False.
 
         Returns:
             tuple or list: A tuple (or list of tuples) with name and score of ranked observations
         """
-        if reread_fields_file:
-            self.logger.debug("Rereading fields file")
-            # The setter method on `fields_file` will force a reread
-            self.fields_file = self.fields_file
 
         if time is None:
             time = current_time()

--- a/pocs/scheduler/dispatch.py
+++ b/pocs/scheduler/dispatch.py
@@ -22,7 +22,7 @@ class Scheduler(BaseScheduler):
 # Methods
 ##########################################################################
 
-    def get_observation(self, time=None, show_all=False):
+    def get_observation(self, time=None, show_all=False, reread_fields_file=False):
         """Get a valid observation
 
         Args:
@@ -34,6 +34,9 @@ class Scheduler(BaseScheduler):
         Returns:
             tuple or list: A tuple (or list of tuples) with name and score of ranked observations
         """
+        if reread_fields_file:
+            self.logger.debug("Rereading fields file")
+            self.read_field_list()
 
         if time is None:
             time = current_time()

--- a/pocs/scheduler/scheduler.py
+++ b/pocs/scheduler/scheduler.py
@@ -175,6 +175,7 @@ class BaseScheduler(PanBase):
         """Reset the list of available observations"""
         # Clear out existing list and observations
         self.current_observation = None
+        self._fields_file = None
         self._fields_list = None
         self._observations = dict()
 

--- a/pocs/scheduler/scheduler.py
+++ b/pocs/scheduler/scheduler.py
@@ -66,10 +66,14 @@ class BaseScheduler(PanBase):
         Note:
             `read_field_list` is called if list is None
         """
-        if len(self._observations.keys()) == 0:
+        if self.has_valid_observations is False:
             self.read_field_list()
 
         return self._observations
+
+    @property
+    def has_valid_observations(self):
+        return len(self._observations.keys()) > 0
 
     @property
     def current_observation(self):
@@ -134,7 +138,7 @@ class BaseScheduler(PanBase):
         # Clear out existing list and observations
         self.current_observation = None
         self._fields_list = None
-        self._observations = dict()
+        self.clear_available_observations()
 
         self._fields_file = new_file
         if new_file is not None:
@@ -163,7 +167,7 @@ class BaseScheduler(PanBase):
     def fields_list(self, new_list):
         # Clear out existing list and observations
         self._fields_file = None
-        self._observations = dict()
+        self.clear_available_observations()
 
         self._fields_list = new_list
         self.read_field_list()
@@ -171,6 +175,10 @@ class BaseScheduler(PanBase):
 ##########################################################################
 # Methods
 ##########################################################################
+
+    def clear_available_observations(self):
+        """Reset the list of available observations"""
+        self._observations = dict()
 
     def get_observation(self, time=None, show_all=False):
         """Get a valid observation

--- a/pocs/scheduler/scheduler.py
+++ b/pocs/scheduler/scheduler.py
@@ -135,9 +135,6 @@ class BaseScheduler(PanBase):
 
     @fields_file.setter
     def fields_file(self, new_file):
-        # Clear out existing list and observations
-        self.current_observation = None
-        self._fields_list = None
         self.clear_available_observations()
 
         self._fields_file = new_file
@@ -165,8 +162,6 @@ class BaseScheduler(PanBase):
 
     @fields_list.setter
     def fields_list(self, new_list):
-        # Clear out existing list and observations
-        self._fields_file = None
         self.clear_available_observations()
 
         self._fields_list = new_list
@@ -178,6 +173,9 @@ class BaseScheduler(PanBase):
 
     def clear_available_observations(self):
         """Reset the list of available observations"""
+        # Clear out existing list and observations
+        self.current_observation = None
+        self._fields_list = None
         self._observations = dict()
 
     def get_observation(self, time=None, show_all=False):
@@ -227,6 +225,7 @@ class BaseScheduler(PanBase):
         if 'exp_time' in field_config:
             field_config['exp_time'] = float(field_config['exp_time']) * u.second
 
+        self.logger.debug("Adding {} to scheduler", field_config['name'])
         field = Field(field_config['name'], field_config['position'])
 
         try:
@@ -264,7 +263,10 @@ class BaseScheduler(PanBase):
 
         if self._fields_list is not None:
             for field_config in self._fields_list:
-                self.add_observation(field_config)
+                try:
+                    self.add_observation(field_config)
+                except AssertionError:
+                    self.logger.debug("Skipping duplicate field.")
 
 ##########################################################################
 # Utility Methods

--- a/pocs/state/machine.py
+++ b/pocs/state/machine.py
@@ -152,7 +152,7 @@ class PanStateMachine(Machine):
 
                 # If we are in ready state then we are making one attempt
                 if self.state == 'ready':
-                    self._nightly_retries -= 1
+                    self._obs_run_retries -= 1
 
                 if self.state == 'sleeping' and self.run_once:
                     self.stop_states()

--- a/pocs/state/states/default/parked.py
+++ b/pocs/state/states/default/parked.py
@@ -4,5 +4,25 @@ def on_enter(event_data):
     pocs = event_data.model
     pocs.say("I'm parked now. Phew.")
 
-    pocs.say("Cleaning up for the night!")
-    pocs.next_state = 'housekeeping'
+    has_valid_observations = pocs.observatory.scheduler.has_valid_observations
+
+    if (has_valid_observations and pocs.is_safe() is False):
+        pocs.say("Cleaning up for the night!")
+        pocs.next_state = 'housekeeping'
+    elif (has_valid_observations and pocs.is_safe()):
+        if pocs.should_retry is False or pocs.run_once is True:
+            pocs.say("Done retrying for this run, going to clean up and shut down!")
+            pocs.next_state = 'housekeeping'
+        else:
+            pocs.say("Things look okay for now. I'm going to try again.")
+            pocs.next_state = 'ready'
+    elif has_valid_observations is False:
+        if pocs.run_once is False:
+            pocs.say("No observations found. Going to stay parked for an hour then try again.")
+            pocs.sleep(delay=3600)  # 1 hour = 3600 seconds
+
+            pocs.reset_observing_run()
+            pocs.next_state = 'ready'
+        else:
+            pocs.say("Only wanted to run once so cleaning up!")
+            pocs.next_state = 'housekeeping'

--- a/pocs/state/states/default/parked.py
+++ b/pocs/state/states/default/parked.py
@@ -6,17 +6,18 @@ def on_enter(event_data):
 
     has_valid_observations = pocs.observatory.scheduler.has_valid_observations
 
-    if (has_valid_observations and pocs.is_safe() is False):
-        pocs.say("Cleaning up for the night!")
-        pocs.next_state = 'housekeeping'
-    elif (has_valid_observations and pocs.is_safe()):
-        if pocs.should_retry is False or pocs.run_once is True:
-            pocs.say("Done retrying for this run, going to clean up and shut down!")
-            pocs.next_state = 'housekeeping'
+    if has_valid_observations:
+        if pocs.is_safe():
+            if pocs.should_retry is False or pocs.run_once is True:
+                pocs.say("Done retrying for this run, going to clean up and shut down!")
+                pocs.next_state = 'housekeeping'
+            else:
+                pocs.say("Things look okay for now. I'm going to try again.")
+                pocs.next_state = 'ready'
         else:
-            pocs.say("Things look okay for now. I'm going to try again.")
-            pocs.next_state = 'ready'
-    elif has_valid_observations is False:
+            pocs.say("Cleaning up for the night!")
+            pocs.next_state = 'housekeeping'
+    else:
         if pocs.run_once is False:
             pocs.say("No observations found. Going to stay parked for an hour then try again.")
             pocs.sleep(delay=3600)  # 1 hour = 3600 seconds

--- a/pocs/state/states/default/sleeping.py
+++ b/pocs/state/states/default/sleeping.py
@@ -4,11 +4,17 @@ def on_enter(event_data):
     pocs.next_state = 'ready'
 
     # If it is dark and safe we shouldn't be in sleeping state
-    if pocs.is_dark() and pocs.is_safe():
+    if pocs.observatory.scheduler.has_valid_observations and \
+            pocs.is_dark() and pocs.is_safe():
         if pocs.should_retry is False:
-            pocs.say("Weather is good and it is dark. Something must have gone wrong. Stopping loop")
+            pocs.say("Weather is good and it is dark. Something must have gone wrong. " +
+                     "Stopping loop.")
             pocs.stop_states()
         else:
             pocs.say("Things look okay for now. I'm going to try again.")
+    elif pocs.observatory.scheduler.has_valid_observations is False:
+        if pocs.run_once is False:
+            pocs.say("No more observations for the night. Gonna sleep for an hour.")
+            pocs.sleep(delay=3600)  # 1 hour = 3600 seconds
     else:
         pocs.say("Another successful night!")

--- a/pocs/state/states/default/sleeping.py
+++ b/pocs/state/states/default/sleeping.py
@@ -1,20 +1,15 @@
 def on_enter(event_data):
     """ """
     pocs = event_data.model
-    pocs.next_state = 'ready'
 
-    # If it is dark and safe we shouldn't be in sleeping state
-    if pocs.observatory.scheduler.has_valid_observations and \
-            pocs.is_dark() and pocs.is_safe():
-        if pocs.should_retry is False:
-            pocs.say("Weather is good and it is dark. Something must have gone wrong. " +
-                     "Stopping loop.")
-            pocs.stop_states()
-        else:
-            pocs.say("Things look okay for now. I'm going to try again.")
-    elif pocs.observatory.scheduler.has_valid_observations is False:
-        if pocs.run_once is False:
-            pocs.say("No more observations for the night. Gonna sleep for an hour.")
-            pocs.sleep(delay=3600)  # 1 hour = 3600 seconds
+    if pocs.should_retry is False:
+        pocs.say("Weather is good and it is dark. Something must have gone wrong. " +
+                 "Stopping loop.")
+        pocs.stop_states()
     else:
-        pocs.say("Another successful night!")
+        # Note: Unit will "sleep" before transition until it is safe
+        # to observe again.
+        pocs.next_state = 'ready'
+        pocs.reset_observing_run()
+
+    pocs.say("Another successful night!")

--- a/pocs/tests/test_dispatch_scheduler.py
+++ b/pocs/tests/test_dispatch_scheduler.py
@@ -119,11 +119,12 @@ def test_get_observation_reread(field_list, observer, temp_file, constraints):
         f.write(yaml.dump([{
             'name': 'New Name',
             'position': '20h00m43.7135s +22d42m39.0645s',
-            'priority': 50
+            'priority': 5000
         }]))
 
-    # Get observation but reread file
-    best = scheduler.get_observation(time=time, reread_fields_file=True)
+    # Get observation but reread file first
+    scheduler.read_field_list()
+    best = scheduler.get_observation(time=time)
     assert best[0] != 'HD 189733'
     assert isinstance(best[1], float)
 

--- a/pocs/tests/test_dispatch_scheduler.py
+++ b/pocs/tests/test_dispatch_scheduler.py
@@ -115,7 +115,7 @@ def test_get_observation_reread(field_list, observer, temp_file, constraints):
     assert isinstance(best[1], float)
 
     # Alter the field file - note same target but new name
-    with open(temp_file, 'w') as f:
+    with open(temp_file, 'a') as f:
         f.write(yaml.dump([{
             'name': 'New Name',
             'position': '20h00m43.7135s +22d42m39.0645s',
@@ -123,8 +123,7 @@ def test_get_observation_reread(field_list, observer, temp_file, constraints):
         }]))
 
     # Get observation but reread file first
-    scheduler.read_field_list()
-    best = scheduler.get_observation(time=time)
+    best = scheduler.get_observation(time=time, reread_fields_file=True)
     assert best[0] != 'HD 189733'
     assert isinstance(best[1], float)
 

--- a/pocs/tests/test_pocs.py
+++ b/pocs/tests/test_pocs.py
@@ -286,6 +286,7 @@ def test_run_no_targets_and_exit(pocs):
     pocs.state = 'sleeping'
 
     pocs.initialize()
+    pocs.observatory.scheduler.clear_available_observations()
     assert pocs.is_initialized is True
     pocs.run(exit_when_done=True, run_once=True)
     assert pocs.state == 'sleeping'

--- a/pocs/tests/test_pocs.py
+++ b/pocs/tests/test_pocs.py
@@ -287,7 +287,7 @@ def test_run_no_targets_and_exit(pocs):
 
     pocs.initialize()
     assert pocs.is_initialized is True
-    pocs.run(exit_when_done=True)
+    pocs.run(exit_when_done=True, run_once=True)
     assert pocs.state == 'sleeping'
 
 

--- a/pocs/tests/test_pocs.py
+++ b/pocs/tests/test_pocs.py
@@ -312,41 +312,6 @@ def test_run_complete(pocs):
     assert pocs.state == 'sleeping'
 
 
-def test_run_interrupt_with_reschedule_of_target(observatory):
-    def start_pocs():
-        pocs = POCS(observatory, messaging=True)
-        pocs.logger.info('Before initialize')
-        pocs.initialize()
-        pocs.logger.info('POCS initialized, back in test')
-        pocs.observatory.scheduler.fields_list = [{'name': 'KIC 8462852',
-                                                   'position': '20h06m15.4536s +44d27m24.75s',
-                                                   'priority': '100',
-                                                   'exp_time': 2,
-                                                   'min_nexp': 1,
-                                                   'exp_set_size': 1,
-                                                   }]
-        pocs.run(exit_when_done=True, run_once=True)
-        pocs.logger.info('run finished, powering down')
-        pocs.power_down()
-
-    pub = PanMessaging.create_publisher(6500)
-    sub = PanMessaging.create_subscriber(6511)
-
-    pocs_process = Process(target=start_pocs)
-    pocs_process.start()
-
-    while True:
-        msg_type, msg_obj = sub.receive_message()
-        if msg_type == 'STATUS':
-            current_state = msg_obj.get('state', {})
-            if current_state == 'pointing':
-                pub.send_message('POCS-CMD', 'shutdown')
-                break
-
-    pocs_process.join()
-    assert pocs_process.is_alive() is False
-
-
 def test_run_power_down_interrupt(observatory):
     def start_pocs():
         pocs = POCS(observatory, messaging=True)


### PR DESCRIPTION
A number of fixes and changes to account for situation when no valid
observations are found but we don't want to shut down the state machine.

* If scheduler has a list of `observations` then it `has_valid_observations`.
	which is True when starting.

Process:
* `scheduling` state calls `observatory.get_observation()`
* `get_observation` first checks if `has_valid_observations is False`
	if so it will reread the field list.
* `get_observation` either returns an observation or, if none found,
	calls `clear_available_observations`, making `has_valid_observations = False`.
* If no observation is returned to `scheduling` state, send to `parking` (then to `sleeping`).
* In `sleeping`, if `has_valid_observations is False` then sleep for an hour
	then try again (or shut down if `run_once` is specified).
  If `has_valid_observations is True` and it is safe and dark, shut down because
  	of unknown error.

Other changes:
* Remove `reread_fields_file` from dispatch scheduler as it is handled at
the `observatory` level by `observatory.get_observation`.
* Misc small fixes

> ⚠️ Note: I think I've gotten all the logic correct so that Bad Things™ won't happen. I think. :)

Closes #390 