### PR TITLE
Export mongo to datastore

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,3 @@ scikit_image >= 0.12.3
 scipy >= 0.17.1
 transitions >= 0.4.0
 wcsaxes
->>>>>>> 2cff65424487aa644407a22e3995f9f2e9363f28

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,9 +17,9 @@ ccdproc
 astroplan
 codecov
 ffmpy
-google-cloud-storage
 dateparser
 coveralls
 mocket
+google-cloud
 google-cloud-storage
 gcloud

--- a/scripts/data/observations_to_datastore.py
+++ b/scripts/data/observations_to_datastore.py
@@ -10,23 +10,30 @@ from pocs.utils import current_time
 
 
 class ObservatonsExporter(PanBase):
-    """ A simple class for exporting observations to Google Datastore
 
-    Observations are pulled from the corresponding mongo collection.
-    """
+    def __init__(self, start_date=None, project_id='panoptes-survey'):
+        """A simple class for exporting observations to Google Datastore
 
-    def __init__(self, date=None, project_id='panoptes-survey'):
-        super(ObservatonsExporter, self).__init__()
+        Observations are pulled from the corresponding mongo collection.
+
+        Args:
+            start_date (None|str, optional): Observations later than provided date
+                will be exported. Defaults to None, in which case the previous
+                date will be used. If provided, should be str, e.g. `2018-01-01`
+            project_id (str, optional): The project associated with the datastore.
+                Defaults to 'panoptes-survey'
+        """
+        super().__init__()
         self.ds_client = datastore.Client(project_id)
 
-        if date is None:
-            date = (current_time() - 1. * u.day).datetime
+        if start_date is None:
+            start_date = (current_time() - 1. * u.day).datetime
         else:
-            date = Time(date).datetime
+            start_date = Time(start_date).datetime
 
-        self.logger.debug("Export observations since {}", date)
+        self.logger.debug("Export observations since {}", start_date)
 
-        self.date = date
+        self.date = start_date
 
         self.units = dict()
         self.fields = dict()
@@ -171,7 +178,7 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(
         description="Export observations information to datastore")
-    parser.add_argument('--date', default=None,
+    parser.add_argument('--start-date', default=None,
                         help='Export start date, e.g. 2016-01-01, defaults to yesterday')
     parser.add_argument('--auto-confirm', action='store_true', default=False,
                         help='Auto-confirm upload, implies verbose.')
@@ -180,15 +187,15 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    if args.date is None:
-        args.date = (current_time() - 1. * u.day).datetime
+    if args.start_date is None:
+        args.start_date = (current_time() - 1. * u.day).datetime
     else:
-        args.date = Time(args.date).datetime
+        args.start_date = Time(args.start_date).datetime
 
     if args.auto_confirm is False:
         args.verbose = True
 
-    obs_exporter = ObservatonsExporter(date=args.date)
+    obs_exporter = ObservatonsExporter(date=args.start_date)
     obs_exporter.collect_entities()
 
     print("Found the following records:")

--- a/scripts/data/observations_to_datastore.py
+++ b/scripts/data/observations_to_datastore.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python
+
+from astropy import units as u
+from astropy.time import Time
+
+from google.cloud import datastore
+
+from pocs.base import PanBase
+from pocs.utils import current_time
+
+
+class ObservatonsExporter(PanBase):
+    """ A simple class for exporting observations to Google Datastore
+
+    Observations are pulled from the corresponding mongo collection.
+    """
+
+    def __init__(self, date=None, project_id='panoptes-survey'):
+        super(ObservatonsExporter, self).__init__()
+        self.ds_client = datastore.Client(project_id)
+
+        if date is None:
+            date = (current_time() - 1. * u.day).datetime
+        else:
+            date = Time(date).datetime
+
+        self.logger.debug("Export observations since {}", date)
+
+        self.date = date
+
+        self.units = dict()
+        self.fields = dict()
+        self.sequences = dict()
+        self.images = dict()
+
+        self.problems = list()
+
+    def collect_entities(self):
+        observations = self.db.observations.find(
+            {'date': {'$gte': self.date}}
+        )
+        for obs_full in observations:
+            try:
+                self._build_observation_entity(obs_full['data'])
+            except Exception as e:
+                self.logger.warning(e)
+                self.problems.append(obs_full)
+
+    def _build_observation_entity(self, observation):
+        obs = observation
+        try:
+            unit_id = obs['observer']
+        except KeyError:
+            unit_id = self.config['pan_id']
+
+        if unit_id == 'Generic PANOPTES Unit':
+            unit_id = self.config['pan_id']
+
+        field_id = ''.join(x.capitalize() for x in obs['field_name'].replace('-', '').split(' '))
+        if field_id.startswith('Alt_') or field_id.startswith('Az_'):
+            return
+
+        seq_id = obs['seq_time']
+        img_id = obs['start_time']
+
+        try:
+            unit_key = self.units[unit_id].key
+        except KeyError:
+            unit_key = self.ds_client.key('Unit', unit_id)
+            unit_entity = datastore.Entity(
+                unit_key,
+                exclude_from_indexes=['elevation']
+            )
+            unit_entity.update({
+                'lat': obs['latitude'],
+                'lon': obs['longitude'],
+                'elevation': obs['elevation']
+            })
+            self.units[unit_id] = unit_entity
+
+        try:
+            field_key = self.fields[field_id].key
+        except KeyError:
+            field_key = self.ds_client.key('Field', field_id, parent=unit_key)
+            field_entity = datastore.Entity(field_key)
+            field_entity.update({
+                'ra': obs['field_ra'],
+                'dec': obs['field_dec'],
+            })
+            self.fields[field_id] = field_entity
+
+        try:
+            seq_key = self.sequences[seq_id].key
+        except KeyError:
+            seq_key = self.ds_client.key('Seq', seq_id, parent=field_key)
+            seq_entity = datastore.Entity(
+                seq_key,
+                exclude_from_indexes=[
+                    'set_size',
+                    'merit',
+                    'min_nexp',
+                    'min_duration',
+                    'priority',
+                    'set_duration',
+                    'ra_rate',
+                ]
+            )
+            seq_entity.update({
+                'set_size': obs['exp_set_size'],
+                'exp_time': obs['exp_time'],
+                'merit': obs['merit'],
+                'min_nexp': obs['min_nexp'],
+                'min_duration': obs['minimum_duration'],
+                'priority': obs['priority'],
+                'set_duration': obs['set_duration'],
+                'ra_rate': obs['tracking_rate_ra'],
+                'pocs_version': obs['creator']
+            })
+            self.sequences[seq_id] = seq_entity
+
+        try:
+            img_entity = self.images[img_id]
+            # If here, we have the same image but different camera
+            img_entity['cam_id'].append(obs['camera_uid'])
+        except KeyError:
+            if 'POINTING' in obs:
+                if bool(obs['POINTING']) is True:
+                    img_key = self.ds_client.key('Pointing', img_id, parent=seq_key)
+                    obs['exp_time'] = 30.  # Handle bug where wasn't recorded correctly
+            else:
+                img_key = self.ds_client.key('Img', img_id, parent=seq_key)
+
+            img_entity = datastore.Entity(
+                img_key,
+                exclude_from_indexes=[
+                    'exp_num',
+                ]
+            )
+            img_entity.update({
+                'airmass': obs['airmass'],
+                'exp_num': obs['current_exp'],
+                'moon_frac': obs['moon_fraction'],
+                'moon_sep': obs['moon_separation'],
+                'ra_mnt': obs['ra_mnt'],
+                'dec_mnt': obs['dec_mnt'],
+                'ha_mnt': obs['ha_mnt'],
+                'cam_id': [obs['camera_uid']]
+            })
+            self.images[img_id] = img_entity
+
+    def send_to_datastore(self):
+        # self.ds_client.put_multi(self.units.values())
+        self.logger.debug("Sending {} field entities to datastore", len(self.fields))
+        self.ds_client.put_multi(self.fields.values())
+
+        self.logger.debug("Sending {} sequence entities to datastore", len(self.sequences))
+        self.ds_client.put_multi(self.sequences.values())
+
+        img_ents = list(self.images.values())
+        while len(img_ents) > 0:
+            images_batch = img_ents[0:500]
+            self.logger.debug("Sending {}/{} images entities to datastore",
+                              len(images_batch), len(self.images))
+            self.ds_client.put_multi(images_batch)
+            img_ents = img_ents[500:]
+
+
+if __name__ == '__main__':
+
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Export observations information to datastore")
+    parser.add_argument('--date', default=None,
+                        help='Export start date, e.g. 2016-01-01, defaults to yesterday')
+    parser.add_argument('--auto-confirm', action='store_true', default=False,
+                        help='Auto-confirm upload, implies verbose.')
+    parser.add_argument('--verbose', action='store_true', default=False,
+                        help='Verbose')
+
+    args = parser.parse_args()
+
+    if args.date is None:
+        args.date = (current_time() - 1. * u.day).datetime
+    else:
+        args.date = Time(args.date).datetime
+
+    if args.auto_confirm is False:
+        args.verbose = True
+
+    obs_exporter = ObservatonsExporter(date=args.date)
+    obs_exporter.collect_entities()
+
+    print("Found the following records:")
+    print("\tFields: {}".format(len(obs_exporter.fields)))
+    print("\tSeq:    {}".format(len(obs_exporter.sequences)))
+    print("\tImgs:   {}".format(len(obs_exporter.images)))
+    print("\tProblems:   {}".format(len(obs_exporter.problems)))
+
+    if args.auto_confirm is not True:
+        do_upload = input("Send to datastore? [Y/n]:")
+        if do_upload.lower() == 'y' or do_upload == '':
+            print("Starting upload")
+            # obs_exporter.send_to_datastore()
+        else:
+            print("Skipping upload")

--- a/scripts/data/observations_to_datastore.py
+++ b/scripts/data/observations_to_datastore.py
@@ -201,6 +201,6 @@ if __name__ == '__main__':
         do_upload = input("Send to datastore? [Y/n]:")
         if do_upload.lower() == 'y' or do_upload == '':
             print("Starting upload")
-            # obs_exporter.send_to_datastore()
+            obs_exporter.send_to_datastore()
         else:
             print("Skipping upload")

--- a/scripts/data/observations_to_datastore.py
+++ b/scripts/data/observations_to_datastore.py
@@ -180,8 +180,8 @@ if __name__ == '__main__':
         description="Export observations information to datastore")
     parser.add_argument('--start-date', default=None,
                         help='Export start date, e.g. 2016-01-01, defaults to yesterday')
-    parser.add_argument('--auto-confirm', action='store_true', default=False,
-                        help='Auto-confirm upload, implies verbose.')
+    parser.add_argument('--skip-confirmation', action='store_true', default=False,
+                        help='Skip upload confirmation, implies verbose.')
     parser.add_argument('--verbose', action='store_true', default=False,
                         help='Verbose')
 
@@ -192,7 +192,7 @@ if __name__ == '__main__':
     else:
         args.start_date = Time(args.start_date).datetime
 
-    if args.auto_confirm is False:
+    if args.skip_confirmation is False:
         args.verbose = True
 
     obs_exporter = ObservatonsExporter(date=args.start_date)
@@ -204,7 +204,7 @@ if __name__ == '__main__':
     print("\tImgs:   {}".format(len(obs_exporter.images)))
     print("\tProblems:   {}".format(len(obs_exporter.problems)))
 
-    if args.auto_confirm is not True:
+    if args.skip_confirmation is not True:
         do_upload = input("Send to datastore? [Y/n]:")
         if do_upload.lower() == 'y' or do_upload == '':
             print("Starting upload")


### PR DESCRIPTION
Tool for sending observation information up to Datastore in bulk.

Note: I will start a discussion as to exact format of Keys/Entities and that should be agreed upon before this is used in mass. However, I have used it to send all of PAN001 information to Datastore.

Note: this should be used for sending items that have not been stored already. The next PR will involve sending of observations as they are record so we will have real-time information.

Note: This **does not** send the entity for the Unit as that should be part of a registration script. However, the unit as parent key will still work, just missing lat/long information about unit.

Edited: See also https://github.com/orgs/panoptes/teams/cloud-devs/discussions/1