### PR TITLE
Eliminate circular dependencies in pocs package

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ instead of `My File.py`.
 - Use root-relative imports (i.e. relative to the POCS directory). This means that rather
   than using a directory relative imports such as:
   ```python
-  from .. import PanBase
+  from ..base import PanBase
   from ..utils import current_time
   ```
   Import from the top-down instead:

--- a/bin/imiloa
+++ b/bin/imiloa
@@ -9,7 +9,7 @@ import time
 
 from astropy import units as u
 
-from pocs import POCS
+from pocs.core import POCS
 
 # Constants
 park_ha = 290 * u.deg

--- a/bin/pocs
+++ b/bin/pocs
@@ -6,7 +6,7 @@ import sys
 
 from warnings import warn
 
-from pocs import POCS
+from pocs.core import POCS
 
 
 def main():

--- a/bin/pocs_shell
+++ b/bin/pocs_shell
@@ -14,8 +14,8 @@ from astropy.coordinates import ICRS
 from astropy.io import fits
 from astropy.utils import console
 
-from pocs import POCS
 from pocs import hardware
+from pocs.core import POCS
 from pocs.observatory import Observatory
 from pocs.scheduler.field import Field
 from pocs.scheduler.observation import Observation

--- a/examples/notebooks/Example Collecting Stats.ipynb
+++ b/examples/notebooks/Example Collecting Stats.ipynb
@@ -11,7 +11,7 @@
     "from astropy.coordinates import SkyCoord\n",
     "from astropy import units as u\n",
     "\n",
-    "from pocs import POCS"
+    "from pocs.core import POCS"
    ]
   },
   {

--- a/examples/notebooks/Horizon Obstruction Limits.ipynb
+++ b/examples/notebooks/Horizon Obstruction Limits.ipynb
@@ -331,7 +331,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pocs import POCS\n",
+    "from pocs.core import POCS\n",
     "from pocs.observatory import Observatory\n",
     "\n",
     "obs = Observatory(simulator=['all'])\n",

--- a/examples/notebooks/POCS Operation.ipynb
+++ b/examples/notebooks/POCS Operation.ipynb
@@ -18,7 +18,7 @@
    "outputs": [],
    "source": [
     "# Load the POCS module\n",
-    "from pocs import POCS"
+    "from pocs.core import POCS"
    ]
   },
   {

--- a/pocs/__init__.py
+++ b/pocs/__init__.py
@@ -5,12 +5,10 @@ PANOPTES hardware unit. POCS provides complete automation of all observing
 processes and is intended to be run in an automated fashion.
 """
 
-from __future__ import absolute_import
-from pocs.version import __version__
-from pocs.base import PanBase
-from pocs.core import POCS
+import pocs.version
 
 __copyright__ = "Copyright (c) 2017 Project PANOPTES"
 __license__ = "MIT"
 __summary__ = "PANOPTES Observatory Control System"
 __uri__ = "https://github.com/panoptes/POCS"
+__version__ = pocs.version.__version__

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -1,4 +1,4 @@
-from pocs import PanBase
+from pocs.base import PanBase
 
 from pocs.utils import error
 from pocs.utils import listify

--- a/pocs/camera/sbigudrv.py
+++ b/pocs/camera/sbigudrv.py
@@ -22,7 +22,7 @@ from astropy import units as u
 from astropy.io import fits
 from astropy.time import Time
 
-from pocs import PanBase
+from pocs.base import PanBase
 
 
 ################################################################################

--- a/pocs/core.py
+++ b/pocs/core.py
@@ -8,7 +8,7 @@ import zmq
 
 from astropy import units as u
 
-from pocs import PanBase
+from pocs.base import PanBase
 from pocs.observatory import Observatory
 from pocs.state.machine import PanStateMachine
 from pocs.utils import current_time

--- a/pocs/dome/__init__.py
+++ b/pocs/dome/__init__.py
@@ -33,7 +33,7 @@ def create_dome_from_config(config, logger=None):
     return dome
 
 
-class AbstractDome(pocs.PanBase):
+class AbstractDome(pocs.base.PanBase):
     """Abstract base class for controlling a non-rotating dome.
 
     This assumes that the observatory 'dome' is not a classic rotating

--- a/pocs/focuser/focuser.py
+++ b/pocs/focuser/focuser.py
@@ -10,7 +10,7 @@ from threading import Event
 from threading import Thread
 
 
-from pocs import PanBase
+from pocs.base import PanBase
 from pocs.utils import current_time
 from pocs.utils.images import focus as focus_utils
 

--- a/pocs/images.py
+++ b/pocs/images.py
@@ -9,7 +9,7 @@ from astropy.io import fits
 from astropy.time import Time
 from collections import namedtuple
 
-from pocs import PanBase
+from pocs.base import PanBase
 from pocs.utils.images import fits as fits_utils
 
 OffsetError = namedtuple('OffsetError', ['delta_ra', 'delta_dec', 'magnitude'])

--- a/pocs/mount/mount.py
+++ b/pocs/mount/mount.py
@@ -4,7 +4,7 @@ from astropy import units as u
 from astropy.coordinates import EarthLocation
 from astropy.coordinates import SkyCoord
 
-from pocs import PanBase
+from pocs.base import PanBase
 
 from pocs.utils import current_time
 from pocs.utils import error

--- a/pocs/observatory.py
+++ b/pocs/observatory.py
@@ -12,7 +12,7 @@ from astropy.coordinates import EarthLocation
 from astropy.coordinates import get_moon
 from astropy.coordinates import get_sun
 
-from pocs import PanBase
+from pocs.base import PanBase
 import pocs.dome
 from pocs.images import Image
 from pocs.scheduler.constraint import Duration

--- a/pocs/scheduler/constraint.py
+++ b/pocs/scheduler/constraint.py
@@ -1,7 +1,7 @@
 from astropy import units as u
 
 from pocs.utils import horizon as horizon_utils
-from pocs import PanBase
+from pocs.base import PanBase
 
 
 class BaseConstraint(PanBase):

--- a/pocs/scheduler/field.py
+++ b/pocs/scheduler/field.py
@@ -1,7 +1,7 @@
 from astroplan import FixedTarget
 from astropy.coordinates import SkyCoord
 
-from pocs import PanBase
+from pocs.base import PanBase
 
 
 class Field(FixedTarget, PanBase):

--- a/pocs/scheduler/observation.py
+++ b/pocs/scheduler/observation.py
@@ -1,7 +1,7 @@
 from astropy import units as u
 from collections import OrderedDict
 
-from pocs import PanBase
+from pocs.base import PanBase
 from pocs.scheduler.field import Field
 
 

--- a/pocs/scheduler/scheduler.py
+++ b/pocs/scheduler/scheduler.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from astroplan import Observer
 from astropy import units as u
 
-from pocs import PanBase
+from pocs.base import PanBase
 from pocs.utils import current_time
 from pocs.scheduler.field import Field
 from pocs.scheduler.observation import Observation

--- a/pocs/tests/bisque/test_run.py
+++ b/pocs/tests/bisque/test_run.py
@@ -3,7 +3,7 @@ import pytest
 
 from astropy.coordinates import EarthLocation
 
-from pocs import POCS
+from pocs.core import POCS
 from pocs.dome.bisque import Dome
 from pocs.utils import altaz_to_radec
 from pocs.utils import current_time

--- a/pocs/tests/test_base.py
+++ b/pocs/tests/test_base.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pocs import PanBase
+from pocs.base import PanBase
 
 
 def test_check_config1(config):

--- a/pocs/tests/test_pocs.py
+++ b/pocs/tests/test_pocs.py
@@ -7,7 +7,7 @@ from multiprocessing import Process
 from astropy import units as u
 
 from pocs import hardware
-from pocs import POCS
+from pocs.core import POCS
 from pocs.observatory import Observatory
 from pocs.utils.messaging import PanMessaging
 

--- a/pocs/tests/test_state_machine.py
+++ b/pocs/tests/test_state_machine.py
@@ -2,7 +2,7 @@ import os
 import pytest
 import yaml
 
-from pocs import POCS
+from pocs.core import POCS
 from pocs.observatory import Observatory
 from pocs.utils import error
 

--- a/pocs/utils/error.py
+++ b/pocs/utils/error.py
@@ -2,7 +2,7 @@ import sys
 
 from astropy.utils.exceptions import AstropyWarning
 
-from pocs import PanBase
+from pocs.base import PanBase
 
 
 class PanError(AstropyWarning, PanBase):

--- a/pocs/utils/rs232.py
+++ b/pocs/utils/rs232.py
@@ -4,7 +4,7 @@ import json
 import serial
 import time
 
-from pocs import PanBase
+from pocs.base import PanBase
 from pocs.utils.error import BadSerialConnection
 
 

--- a/pocs/utils/theskyx.py
+++ b/pocs/utils/theskyx.py
@@ -1,6 +1,6 @@
 import socket
 
-from pocs import PanBase
+from pocs.base import PanBase
 from pocs.utils import error
 
 

--- a/scripts/collect-grid-stats.py
+++ b/scripts/collect-grid-stats.py
@@ -6,7 +6,7 @@ from time import sleep
 from astropy.coordinates import SkyCoord
 from astropy import units as u
 
-from pocs import POCS
+from pocs.core import POCS
 from pocs.utils import current_time
 from pocs.utils.database import PanMongo
 from pocs.utils import images as img_utils

--- a/scripts/send_home.py
+++ b/scripts/send_home.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from pocs import hardware
-from pocs import POCS
+from pocs.core import POCS
 
 pocs = POCS(simulator=hardware.get_all_names(without=['mount', 'night']))
 pocs.observatory.mount.initialize()


### PR DESCRIPTION
`pocs/__init__.py` imported pocs.core.POCS, which imported
PanBase from pocs, which meant that we had a circular
dependency which just barely loaded (i.e. small changes
could cause it to fail to load).