### PR TITLE
Adjust Shutdown States

### DIFF
--- a/pocs/core.py
+++ b/pocs/core.py
@@ -286,9 +286,6 @@ class POCS(PanStateMachine, PanBase):
 
         Returns:
             bool: Latest safety flag
-
-        Deleted Parameters:
-            event_data(transitions.EventData): carries information about the event if
         """
         if not self.connected:
             return False

--- a/pocs/core.py
+++ b/pocs/core.py
@@ -290,6 +290,9 @@ class POCS(PanStateMachine, PanBase):
         Deleted Parameters:
             event_data(transitions.EventData): carries information about the event if
         """
+        if not self.connected:
+            return False
+
         is_safe_values = dict()
 
         # Check if night time
@@ -421,9 +424,13 @@ class POCS(PanStateMachine, PanBase):
         # If delay is greater than 10 seconds check for messages during wait
         if delay >= 10.0:
             while delay >= 10.0:
+                self.check_messages()
+                # If we shutdown leave loop
+                if self.connected is False:
+                    return
+
                 time.sleep(10.0)
                 delay -= 10.0
-                self.check_messages()
 
         if delay > 0.0:
             time.sleep(delay)

--- a/pocs/core.py
+++ b/pocs/core.py
@@ -282,10 +282,12 @@ class POCS(PanStateMachine, PanBase):
             This condition is called by the state machine during each transition
 
         Args:
-            called from the state machine.
+            no_warning (bool, optional): If a warning message should show in logs,
+                defaults to False.
 
         Returns:
             bool: Latest safety flag
+
         """
         if not self.connected:
             return False

--- a/pocs/core.py
+++ b/pocs/core.py
@@ -263,6 +263,8 @@ class POCS(PanStateMachine, PanBase):
             self._connected = False
             self.logger.info("Power down complete")
 
+        return self.connected is False
+
     def reset_observing_run(self):
         """Reset an observing run loop. """
         self.logger.debug("Resetting observing run attempts")

--- a/pocs/core.py
+++ b/pocs/core.py
@@ -263,8 +263,6 @@ class POCS(PanStateMachine, PanBase):
             self._connected = False
             self.logger.info("Power down complete")
 
-        return self.connected is False
-
     def reset_observing_run(self):
         """Reset an observing run loop. """
         self.logger.debug("Resetting observing run attempts")

--- a/pocs/state/states/default/parked.py
+++ b/pocs/state/states/default/parked.py
@@ -11,14 +11,16 @@ def on_enter(event_data):
             if pocs.should_retry is False or pocs.run_once is True:
                 pocs.say("Done retrying for this run, going to clean up and shut down!")
                 pocs.next_state = 'housekeeping'
-            else:
+            else:  # This branch will only happen if there is an error causing a shutdown
                 pocs.say("Things look okay for now. I'm going to try again.")
                 pocs.next_state = 'ready'
-        else:
+        else:  # Normal end of night
             pocs.say("Cleaning up for the night!")
             pocs.next_state = 'housekeeping'
     else:
         pocs.say("No observations found.")
+        # TODO Should check if we are close to morning and if so do some morning
+        # calibration frames rather than just waiting for 30 minutes then shutting down.
         if pocs.run_once is False:
             pocs.say("Going to stay parked for half an hour then will try again.")
 

--- a/pocs/state/states/default/parked.py
+++ b/pocs/state/states/default/parked.py
@@ -27,7 +27,10 @@ def on_enter(event_data):
             while True:
                 pocs.sleep(delay=1800)  # 30 minutes = 1800 seconds
 
-                if pocs.is_safe():
+                # We might have shutdown in long wait
+                if not pocs.connected:
+                    break
+                elif pocs.is_safe():
                     pocs.reset_observing_run()
                     pocs.next_state = 'ready'
                     break

--- a/pocs/state/states/default/parked.py
+++ b/pocs/state/states/default/parked.py
@@ -27,7 +27,7 @@ def on_enter(event_data):
             while True:
                 pocs.sleep(delay=1800)  # 30 minutes = 1800 seconds
 
-                # We might have shutdown in long wait
+                # We might have shutdown during previous sleep.
                 if not pocs.connected:
                     break
                 elif pocs.is_safe():

--- a/pocs/state/states/default/parked.py
+++ b/pocs/state/states/default/parked.py
@@ -18,12 +18,23 @@ def on_enter(event_data):
             pocs.say("Cleaning up for the night!")
             pocs.next_state = 'housekeeping'
     else:
+        pocs.say("No observations found.")
         if pocs.run_once is False:
-            pocs.say("No observations found. Going to stay parked for an hour then try again.")
-            pocs.sleep(delay=3600)  # 1 hour = 3600 seconds
+            pocs.say("Going to stay parked for half an hour then will try again.")
 
-            pocs.reset_observing_run()
-            pocs.next_state = 'ready'
+            while True:
+                pocs.sleep(delay=1800)  # 30 minutes = 1800 seconds
+
+                if pocs.is_safe():
+                    pocs.reset_observing_run()
+                    pocs.next_state = 'ready'
+                    break
+                elif pocs.is_dark() is False:
+                    pocs.say("Looks like it's not dark anymore. Going to clean up.")
+                    pocs.next_state = 'housekeeping'
+                    break
+                else:
+                    pocs.say("Seems to be bad weather. I'll wait another 30 minutes.")
         else:
             pocs.say("Only wanted to run once so cleaning up!")
             pocs.next_state = 'housekeeping'

--- a/pocs/tests/test_pocs.py
+++ b/pocs/tests/test_pocs.py
@@ -359,9 +359,11 @@ def test_pocs_park_to_ready(pocs):
     assert pocs.observatory.current_observation is not None
     pocs.next_state = 'parking'
     assert pocs.goto_next_state()
+    assert pocs.state == 'parking'
     assert pocs.observatory.current_observation is None
     assert pocs.observatory.mount.is_parked
     assert pocs.goto_next_state()
+    assert pocs.state == 'parked'
     # Should be safe and still have valid observations so next state should
     # be ready
     assert pocs.goto_next_state()

--- a/pocs/tests/test_pocs.py
+++ b/pocs/tests/test_pocs.py
@@ -366,4 +366,5 @@ def test_pocs_park_to_ready(pocs):
     # be ready
     assert pocs.goto_next_state()
     assert pocs.state == 'ready'
-    assert pocs.power_down()
+    pocs.power_down()
+    assert pocs.connected is False

--- a/pocs/tests/test_pocs.py
+++ b/pocs/tests/test_pocs.py
@@ -343,3 +343,27 @@ def test_run_power_down_interrupt(observatory):
 
     pocs_process.join()
     assert pocs_process.is_alive() is False
+
+
+def test_pocs_park_to_ready(pocs):
+    # We don't want to run_once here
+    pocs._run_once = False
+
+    assert pocs.is_safe() is True
+    assert pocs.state == 'sleeping'
+    pocs.next_state = 'ready'
+    assert pocs.initialize()
+    assert pocs.goto_next_state()
+    assert pocs.state == 'ready'
+    assert pocs.goto_next_state()
+    assert pocs.observatory.current_observation is not None
+    pocs.next_state = 'parking'
+    assert pocs.goto_next_state()
+    assert pocs.observatory.current_observation is None
+    assert pocs.observatory.mount.is_parked
+    assert pocs.goto_next_state()
+    # Should be safe and still have valid observations so next state should
+    # be ready
+    assert pocs.goto_next_state()
+    assert pocs.state == 'ready'
+    assert pocs.power_down()

--- a/pocs/tests/test_pocs.py
+++ b/pocs/tests/test_pocs.py
@@ -419,3 +419,4 @@ def test_pocs_park_to_ready_without_obs(config, observatory):
     assert pocs.state == 'parked'
 
     assert pocs.connected is False
+    assert pocs.is_safe is False

--- a/pocs/tests/test_pocs.py
+++ b/pocs/tests/test_pocs.py
@@ -419,4 +419,4 @@ def test_pocs_park_to_ready_without_obs(config, observatory):
     assert pocs.state == 'parked'
 
     assert pocs.connected is False
-    assert pocs.is_safe is False
+    assert pocs.is_safe() is False

--- a/resources/state_table/simple_state_table.yaml
+++ b/resources/state_table/simple_state_table.yaml
@@ -38,7 +38,7 @@ transitions:
         dest: sleeping
         trigger: goto_sleep
     -
-        source: housekeeping
+        source: parked
         dest: ready
         trigger: get_ready
         conditions: mount_is_initialized


### PR DESCRIPTION
Change the routing on the shutdown states so that the `housekeeping` state is only entered when actually shutting down for the day. This means the unit can wait in the `parked` state if no immediate observations are found but if otherwise safe. If it's daytime after waiting then go to `housekeeping`. If it's bad weather wait another 30 minutes. Otherwise try to observe again.

* Add route from `parked` to `ready`
* Remove route from `housekeeping` to `ready`
* Return value for `power_down`