### PR TITLE
Add class ArduinoIO

### DIFF
--- a/pocs/sensors/arduino_io.py
+++ b/pocs/sensors/arduino_io.py
@@ -1,0 +1,209 @@
+import copy
+import threading
+
+from pocs.utils.logger import get_root_logger
+from pocs.utils import rs232
+
+
+def auto_detect_arduino_devices(ports=None, logger=None):
+    """Returns a list of tuples of (board_name, port)."""
+    if ports is None:
+        ports = list_arduino_ports()
+    if not logger:
+        logger = get_root_logger()
+    result = []
+    for port in ports:
+        board_name = detect_board_on_port(port, logger)
+        if board_name:
+            result.append((board_name, port))
+    return result
+
+
+# Note: list_arduino_ports is modified by test_arduino_io.py, so if changing
+# this import, the test will also need to be updated.
+def list_arduino_ports():
+    """Find devices (paths or URLs) that appear to be Arduinos.
+
+    Returns:
+        a list of strings; device paths (e.g. /dev/ttyACM1) or URLs (e.g. rfc2217://host:port
+        arduino_simulator://?board=camera).
+    """
+    ports = rs232.get_serial_port_info()
+    return [p.device for p in ports
+            if 'arduino' in p.description.lower() or 'arduino' in p.manufacturer.lower()]
+
+
+def detect_board_on_port(port, logger=None):
+    """Open a port and determine which type of board its producing output.
+
+    Returns: board_name if we can read a line of JSON from the
+        port, parse it and find a 'name' attribute in the top-level object.
+        Else returns None.
+    """
+    if not logger:
+        logger = get_root_logger()
+    logger.debug('Attempting to connect to serial port: {}'.format(port))
+    serial_reader = None
+    try:
+        # First open a connection to the device.
+        try:
+            serial_reader = open_serial_device(port)
+            if not serial_reader.is_connected:
+                serial_reader.connect()
+            logger.debug('Connected to {}', port)
+        except Exception as e:
+            logger.warning('Could not connect to port: {}'.format(port))
+            return None
+        try:
+            reading = serial_reader.get_and_parse_reading(retry_limit=3)
+            if not reading:
+                return None
+            (ts, data) = reading
+            if isinstance(data, dict) and 'name' in data and isinstance(data['name'], str):
+                return data['name']
+            logger.warning('Unable to find board name in reading: {!r}', reading)
+            return None
+        except Exception as e:
+            logger.error('Exception while auto-detecting port {!r}: {!r}'.format(port, e))
+    finally:
+        if serial_reader:
+            serial_reader.disconnect()
+
+
+def open_serial_device(port, serial_config=None, **kwargs):
+    # Using a long timeout (2 times the report interval) rather than retries which can just break
+    # a JSON line into two unparseable fragments.
+    sd_kwargs = dict(baudrate=9600, retry_limit=1, retry_delay=0, timeout=4.0, name=port)
+    if serial_config:
+        sd_kwargs.update(serial_config)
+    sd_kwargs.update(kwargs)
+    sd_kwargs['port'] = port
+    return rs232.SerialData(**sd_kwargs)
+
+
+class ArduinoIO(object):
+    """Reads the output from an arduino, and exposes the relays for change."""
+
+    def __init__(self, board_name, port, output_queue, serial_config=None):
+        """Inits for board on device.
+
+        Args:
+            board_name:
+                The name of the board, used as the name of the database
+                table/collection to write to.
+            port:
+                The device to connect to.
+            output_queue:
+                The queue to which to send the readings. Will not block
+                on sending (put call), so the queue should have room for
+                a few entries. By not blocking on put, we avoid dropping
+                records while reading from the serial line due to dropped
+                chars, and thus corrupted JSON.
+            serial_config:
+                The portion of the config file descibing the serial settings.
+        """
+        self.board_name = board_name or port
+        self.port = port
+        self._serial_data = open_serial_device(
+            port, serial_config=serial_config, name=board_name)
+        self._output_queue = output_queue
+        self._logger = get_root_logger()
+        self._last_reading = None
+
+        self._serial_data_lock = threading.Lock()
+        self._last_reading_lock = threading.Lock()
+        self._thread = None
+        self._stop = threading.Event()
+
+    def last_reading(self):
+        """Returns the last reading.
+
+        This may be newer than the last reading in the queue if the queue was full.
+        """
+        with self._last_reading_lock:
+            return self._last_reading
+
+    def start_reading(self):
+        if self._thread and self._thread.is_alive():
+            self._logger.debug('Thread {!r} is already running with ident {!r}',
+                               self._thread.name, self._thread.ident)
+            return
+
+        def reader():
+            self._logger.info('Started reader thread {!r} with ident {!r}',
+                              threading.current_thread().name, threading.get_ident())
+            announce = False
+            while not self._stop.is_set():
+                reading = self._read1()
+                if self._stop.is_set():
+                    break
+                if not reading:
+                    # Consider adding an error counter.
+                    announce = True
+                    continue
+                if announce:
+                    self._logger.info('Succeeded in reading from {!r}; got:\n{!r}',
+                                      self.port, reading)
+                    announce = False
+                self._handle_reading(reading)
+            self._logger.info('Stopping reader thread {!r} with ident {!r}',
+                              threading.current_thread().name, threading.get_ident())
+
+        self._thread = threading.Thread(target=reader, name=self.board_name)
+        self._thread.daemon = True
+        self._thread.start()
+
+    def stop_reading(self):
+        if self._thread and self._thread.is_alive():
+            self._logger.info('Waiting for thread {!r} to stop.', self._thread.name)
+            self._stop.set()
+            self._thread.join(timeout=4.0)
+            if self._thread.is_alive():
+                self._logger.error('Thread {!r} is still running.', self._thread.name)
+            else:
+                self._thread = None
+
+    def write(self, text):
+        with self._serial_data_lock:
+            if not self._serial_data.is_connected:
+                self._serial_data.connect()
+            return self._serial_data.write(text)
+
+    def disconnect(self):
+        try:
+            with self._serial_data_lock:
+                if self._serial_data.is_connected:
+                    self._serial_data.disconnect()
+        except Exception as e:
+            self._logger.error('Failed to disconnect from {!r} due to: {!r}', self.port, e)
+            return None
+
+    def _read1(self):
+        """Reads and returns a single reading."""
+        try:
+            with self._serial_data_lock:
+                if self._stop.is_set():
+                    return None
+                if not self._serial_data.is_connected:
+                    self._serial_data.connect()
+                reading = self._serial_data.get_and_parse_reading()
+                if not reading:
+                    self._logger.warning('Unable to get reading from {}', self.port)
+                    return None
+                return reading
+        except Exception as e:
+            self._logger.error('Failed to read from {!r} due to: {!r}', self.port, e)
+            return None
+
+    def _handle_reading(self, reading):
+        # TODO(jamessynge): Discuss with Wilfred changing the timestamp to a datetime object
+        # instead of a string. Obviously it needs to be serialized eventually.
+        timestamp, data = reading
+        reading = dict(timestamp=timestamp, data=data, board=self.board_name)
+        with self._last_reading_lock:
+            self._last_reading = copy.deepcopy(reading)
+        try:
+            self._output_queue.put(reading, block=False)
+        except Exception as e:
+            self._logger.error('output_queue.put failed for board {!r}', self.board_name)
+            self._logger.error('Exception: {!r}', e)

--- a/pocs/serial_handlers/__init__.py
+++ b/pocs/serial_handlers/__init__.py
@@ -1,0 +1,5 @@
+"""The protocol_*.py files in this package are based on PySerial's file
+test/handlers/protocol_test.py, modified for different behaviors.
+The call serial.serial_for_url("XYZ://") looks for a class Serial in a
+file named protocol_XYZ.py in this package (i.e. directory).
+"""

--- a/pocs/serial_handlers/protocol_arduinosimulator.py
+++ b/pocs/serial_handlers/protocol_arduinosimulator.py
@@ -251,11 +251,13 @@ class FakeArduinoSerialHandler(serial_handlers.NoOpSerial):
             if timeout_obj.expired():
                 break
         response = bytes(response)
-        # if size > 1:
-        #     self.logger.debug('FakeArduinoSerialHandler.read({}) -> {!r}', size, response)
         return response
 
     def readline(self):
+        """Read and return one line from the simulator.
+
+        This override exists just to support logging of the line.
+        """
         line = super().readline()
         self.logger.debug('FakeArduinoSerialHandler.readline -> {!r}', line)
         return line

--- a/pocs/serial_handlers/protocol_arduinosimulator.py
+++ b/pocs/serial_handlers/protocol_arduinosimulator.py
@@ -251,8 +251,14 @@ class FakeArduinoSerialHandler(serial_handlers.NoOpSerial):
             if timeout_obj.expired():
                 break
         response = bytes(response)
-        self.logger.info('FakeArduinoSerialHandler.read({}) -> {!r}', size, response)
+        # if size > 1:
+        #     self.logger.debug('FakeArduinoSerialHandler.read({}) -> {!r}', size, response)
         return response
+
+    def readline(self):
+        line = super().readline()
+        self.logger.debug('FakeArduinoSerialHandler.readline -> {!r}', line)
+        return line
 
     @property
     def out_waiting(self):
@@ -300,7 +306,6 @@ class FakeArduinoSerialHandler(serial_handlers.NoOpSerial):
             raise ValueError("write takes bytes")
         data = bytes(data)  # Make sure it can't change.
         self.logger.info('FakeArduinoSerialHandler.write({!r})', data)
-        count = len(data)
         try:
             self.relay_queue.put(data, block=True, timeout=self.write_timeout)
             return len(data)
@@ -401,7 +406,7 @@ class FakeArduinoSerialHandler(serial_handlers.NoOpSerial):
     # Internal (non-standard) methods.
 
     def _params_from_url(self, url):
-        """\
+        """
         extract host and port from an URL string, other settings are extracted
         an stored in instance
         """
@@ -430,7 +435,14 @@ class FakeArduinoSerialHandler(serial_handlers.NoOpSerial):
                 {
                     "name":"telemetry_board",
                     "ver":"2017-09-23",
-                    "power": {"computer":1, "fan":1, "mount":1, "cameras":1, "weather":1, "main":1},
+                    "power": {
+                        "computer":1,
+                        "fan":1,
+                        "mount":1,
+                        "cameras":1,
+                        "weather":1,
+                        "main":1
+                    },
                     "current": {"main":387,"fan":28,"mount":34,"cameras":27},
                     "amps": {"main":1083.60,"fan":50.40,"mount":61.20,"cameras":27.00},
                     "humidity":42.60,

--- a/pocs/tests/test_arduino_io.py
+++ b/pocs/tests/test_arduino_io.py
@@ -2,13 +2,18 @@
 
 import collections
 import pytest
+import queue as queue_module
 import serial
+import threading
+import time
 
-from peas import sensors as sensors_module
+from pocs.sensors import arduino_io
 from pocs.utils import rs232
 
+# For serial_handlers to be loaded
+# import pocs.serial_handlers as serial_handlers_module
 
-SerDevInfo = collections.namedtuple('SerDevInfo', 'device description')
+SerDevInfo = collections.namedtuple('SerDevInfo', 'device description manufacturer')
 
 
 @pytest.fixture(scope='function')
@@ -20,25 +25,33 @@ def serial_handlers():
     serial.protocol_handler_packages.remove('pocs.serial_handlers')
 
 
-def list_comports():
+def get_serial_port_info():
     return [
-        SerDevInfo(device='bogus://', description='Not an arduino'),
-        SerDevInfo(device='loop://', description='Some Arduino device'),
-        SerDevInfo(device='arduinosimulator://?board=telemetry&name=t1', description='Some Arduino device'),
-        SerDevInfo(device='arduinosimulator://?board=camera&name=c1', description='Arduino Micro'),
+        SerDevInfo(
+            device='bogus://', description='Some USB-to-Serial device', manufacturer='Acme'),
+        SerDevInfo(device='loop://', description='Some text', manufacturer='Arduino LLC'),
+        SerDevInfo(
+            device='arduinosimulator://?board=telemetry&name=t1',
+            description='Some Arduino device',
+            manufacturer='www.arduino.cc'),
+        SerDevInfo(
+            device='arduinosimulator://?board=camera&name=c1',
+            description='Arduino Micro',
+            manufacturer=''),
     ]
 
 
 @pytest.fixture(scope='function')
-def inject_list_comports():
-    saved = sensors_module.list_comports
-    sensors_module.list_comports = list_comports
+def inject_get_serial_port_info():
+    saved = rs232.get_serial_port_info
+    rs232.get_serial_port_info = get_serial_port_info
     yield True
-    sensors_module.list_comports = saved
+    rs232.get_serial_port_info = saved
 
 
 # --------------------------------------------------------------------------------------------------
 # Basic tests of FakeArduinoSerialHandler.
+
 
 def test_create_camera_simulator(serial_handlers):
     ser = rs232.SerialData(port='arduinosimulator://?board=camera', baudrate=9600)
@@ -75,12 +88,13 @@ def test_create_default_simulator(serial_handlers):
 
 # --------------------------------------------------------------------------------------------------
 
+
 def test_detect_board_on_port_not_a_board():
     """detect_board_on_port will fail if the port doesn't produce the expected output.
 
     Detection will fail because loop:// handler doesn't print anything.
     """
-    assert sensors_module.detect_board_on_port('loop://') is None
+    assert arduino_io.detect_board_on_port('loop://') is None
 
 
 def test_detect_board_on_port_no_handler_installed():
@@ -90,24 +104,20 @@ def test_detect_board_on_port_no_handler_installed():
     PySerial's `serial_for_url`. Therefore, detect_board_on_port won't be able to determine the
     type of board.
     """
-    assert sensors_module.detect_board_on_port('arduinosimulator://?board=telemetry') is None
+    assert arduino_io.detect_board_on_port('arduinosimulator://?board=telemetry') is None
 
 
 def test_detect_board_on_port_telemetry(serial_handlers):
     """Detect a telemetry board."""
-    v = sensors_module.detect_board_on_port('arduinosimulator://?board=telemetry')
-    assert isinstance(v, tuple)
-    assert v[0] == 'telemetry_board'
-    assert isinstance(v[1], rs232.SerialData)
-    assert v[1].is_connected is True
-    v[1].disconnect()
-    assert v[1].is_connected is False
+    assert arduino_io.detect_board_on_port(
+        'arduinosimulator://?board=telemetry') == 'telemetry_board'
 
 
 # --------------------------------------------------------------------------------------------------
 
-def test_find_arduino_devices(inject_list_comports):
-    v = sensors_module.find_arduino_devices()
+
+def test_find_arduino_devices(inject_get_serial_port_info):
+    v = arduino_io.list_arduino_ports()
     assert len(v) == 3
     assert v == [
         'loop://',
@@ -118,19 +128,53 @@ def test_find_arduino_devices(inject_list_comports):
 
 # --------------------------------------------------------------------------------------------------
 
-def test_auto_detect_arduino_devices(inject_list_comports, serial_handlers):
-    v = sensors_module.auto_detect_arduino_devices()
+
+def test_auto_detect_arduino_devices(inject_get_serial_port_info, serial_handlers):
+    v = arduino_io.auto_detect_arduino_devices()
     assert len(v) == 2
     for ndx, (board, name) in enumerate([('telemetry', 't1'), ('camera', 'c1')]):
         print('ndx=%r   board=%r   name=%r' % (ndx, board, name))
         expected = 'arduinosimulator://?board=%s&name=%s' % (board, name)
         assert v[ndx][0] == '{}_board'.format(board)
-        assert isinstance(v[ndx][1], rs232.SerialData)
-        assert v[ndx][1].name == expected
-        assert v[ndx][1].ser.port == expected
-        # ser.name is set by the simulator, a way to test that the correcct
-        # simulator setup is in use.
-        assert v[ndx][1].ser.name == name
-        assert v[ndx][1].is_connected is True
-        v[ndx][1].disconnect()
-        assert v[ndx][1].is_connected is False
+        assert v[ndx][1] == expected
+
+
+# --------------------------------------------------------------------------------------------------
+
+
+def test_basic_arduino_io(serial_handlers):
+    queue = queue_module.Queue(maxsize=1)
+    assert queue.empty()
+    aio = arduino_io.ArduinoIO(
+        'telemetry',
+        'arduinosimulator://?board=telemetry',
+        queue,
+        serial_config=dict(open_delay=0))
+    aio.stop_reading()
+    aio.disconnect()
+    aio.write('foo=1\n')
+    aio.disconnect()
+    aio.stop_reading()
+    try:
+        first_reading = None
+        try:
+            assert queue.empty()
+            aio.start_reading()
+            while queue.empty():
+                time.sleep(0.05)
+            first_reading = aio.last_reading()
+            assert queue.qsize() == 1
+            # Wait for one more reading, which will fail to be added due
+            # to the full queue; we can check for this by looking in the
+            # log file manually. Not sure that it is worth doing in code.
+            time.sleep(2.1)
+            assert queue.qsize() == 1
+        finally:
+            aio.stop_reading()
+        item = queue.get_nowait()
+        assert item is not None
+        assert item == first_reading
+        assert aio.last_reading() != item
+    finally:
+        aio.stop_reading()
+        aio.disconnect()

--- a/pocs/tests/test_arduino_io.py
+++ b/pocs/tests/test_arduino_io.py
@@ -4,7 +4,6 @@ import collections
 import pytest
 import queue as queue_module
 import serial
-import threading
 import time
 
 from pocs.sensors import arduino_io
@@ -116,8 +115,8 @@ def test_detect_board_on_port_telemetry(serial_handlers):
 # --------------------------------------------------------------------------------------------------
 
 
-def test_find_arduino_devices(inject_get_serial_port_info):
-    v = arduino_io.list_arduino_ports()
+def test_get_arduino_ports(inject_get_serial_port_info):
+    v = arduino_io.get_arduino_ports()
     assert len(v) == 3
     assert v == [
         'loop://',

--- a/pocs/utils/rs232.py
+++ b/pocs/utils/rs232.py
@@ -3,6 +3,7 @@
 import json
 import operator
 import serial
+from serial.tools.list_ports import comports as get_comports
 import time
 
 from pocs.base import PanBase
@@ -35,8 +36,7 @@ def get_serial_port_info():
     Returns: a list of PySerial's ListPortInfo objects. See:
         https://github.com/pyserial/pyserial/blob/master/serial/tools/list_ports_common.py
     """
-    from serial.tools.list_ports import comports
-    return sorted(comports(), key=operator.attrgetter('device'))
+    return sorted(get_comports(), key=operator.attrgetter('device'))
 
 
 class SerialData(PanBase):

--- a/pocs/utils/rs232.py
+++ b/pocs/utils/rs232.py
@@ -1,6 +1,7 @@
 """Provides SerialData, a PySerial wrapper."""
 
 import json
+import operator
 import serial
 import time
 
@@ -24,6 +25,18 @@ def _parse_json(line, logger, min_error_pos=0):
         logger.debug('Exception while parsing JSON: %r', e)
         logger.debug('Erroneous JSON: %r', line)
         return None
+
+
+# Note: get_serial_port_info is replaced by tests to override the normal
+# behavior, so don't change the name without fixing the tests.
+def get_serial_port_info():
+    """Returns the serial ports defined on the system.
+
+    Returns: a list of PySerial's ListPortInfo objects. See:
+        https://github.com/pyserial/pyserial/blob/master/serial/tools/list_ports_common.py
+    """
+    from serial.tools.list_ports import comports
+    return sorted(comports(), key=operator.attrgetter('device'))
 
 
 class SerialData(PanBase):
@@ -127,7 +140,6 @@ class SerialData(PanBase):
         except serial.serialutil.SerialException as err:
             raise BadSerialConnection(msg=err)
         self.logger.debug('Serial connection established to {}', self.name)
-        return True
 
     def disconnect(self):
         """Closes the serial connection.

--- a/scripts/list_arduinos.py
+++ b/scripts/list_arduinos.py
@@ -12,10 +12,10 @@ if __name__ == '__main__':
     if port_infos:
         fmt = '{:20s} {:30s} {}'
         print(fmt.format('Device', 'Manufacturer', 'Description'))
-        for pi in rs232.get_serial_port_info():
+        for pi in port_infos:
             print(fmt.format(pi.device, pi.manufacturer, pi.description))
         print()
-    devices = arduino_io.list_arduino_ports()
+    devices = arduino_io.get_arduino_ports()
     if devices:
         print("Arduino devices: {}".format(", ".join(devices)))
     else:
@@ -24,6 +24,6 @@ if __name__ == '__main__':
 
     print()
     boards_and_ports = arduino_io.auto_detect_arduino_devices()
-    for (board, port) in boards_and_ports:
+    for board, port in boards_and_ports:
         print('Found board {!r} on port {!r}'.format(board, port))
     sys.exit(0)

--- a/scripts/list_arduinos.py
+++ b/scripts/list_arduinos.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+import sys
+
+from pocs.sensors import arduino_io
+from pocs.utils import rs232
+
+
+# Support testing by just listing the available devices.
+if __name__ == '__main__':
+    port_infos = rs232.get_serial_port_info()
+    if port_infos:
+        fmt = '{:20s} {:30s} {}'
+        print(fmt.format('Device', 'Manufacturer', 'Description'))
+        for pi in rs232.get_serial_port_info():
+            print(fmt.format(pi.device, pi.manufacturer, pi.description))
+        print()
+    devices = arduino_io.list_arduino_ports()
+    if devices:
+        print("Arduino devices: {}".format(", ".join(devices)))
+    else:
+        print("No Arduino devices found.")
+        sys.exit(1)
+
+    print()
+    boards_and_ports = arduino_io.auto_detect_arduino_devices()
+    for (board, port) in boards_and_ports:
+        print('Found board {!r} on port {!r}'.format(board, port))
+    sys.exit(0)


### PR DESCRIPTION
pocs/sensors/arduino_io.py is based on peas/sensors.py, but
ArduinoIO handles only a single device, and writes readings
to a queue rather than to a database.

Moved protocol_arduinosimulator.py to a new folder,
pocs/serial_handlers. This will be the home of the other PySerial
handlers in the future.