### PR TITLE
Remove explicit call to backend

### DIFF
--- a/.matplotlib/matplotlibrc
+++ b/.matplotlib/matplotlibrc
@@ -1,0 +1,1 @@
+backend: Agg

--- a/pocs/utils/images/__init__.py
+++ b/pocs/utils/images/__init__.py
@@ -1,12 +1,9 @@
 import os
 import subprocess
 
-import matplotlib
-matplotlib.use('Agg')
 from matplotlib import pyplot as plt
 from warnings import warn
 
-from astropy import units as u
 from astropy.wcs import WCS
 from astropy.io.fits import (getdata, getheader)
 from astropy.visualization import (PercentileInterval, LogStretch, ImageNormalize)
@@ -16,7 +13,6 @@ from glob import glob
 
 from pocs.utils import current_time
 from pocs.utils import error
-from pocs.utils.config import load_config
 from pocs.utils.images import fits as fits_utils
 
 


### PR DESCRIPTION
Having it specified just in this file is not the appropriate solution and generates large warnings whenever an image utility is used within a jupyter notebook.

Edit: A matplotlibrc file has been added and can be used via `MPLBACKEND=$POCS/.matplotlibrc`