### PR TITLE
Reduce yapf column limit to 99.

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -48,7 +48,7 @@ blank_line_before_nested_class_or_def=False
 coalesce_brackets=False
 
 # The column limit.
-column_limit=100
+column_limit=99
 
 # Indent width used for line continuations.
 continuation_indent_width=4


### PR DESCRIPTION
This means that `yapf -i some_file.py` will match the style for pep8 with column limit == 100 (for some reason the newline is included).