### PR TITLE
Disable some tests when hardware is present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,8 @@ notebooks/*
 
 # Ignore link to weather_plots in web/static/
 weather_plots
+
+# Ignore pytest.ini file in root of project. Especially useful on a unit to skip
+# tests that interact with hardware.
+/pytest.ini
+

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,97 @@
+# This is in the root POCS directory so that pytest will recognize the
+# options added below without having to also specify pocs/test, or a
+# one of the tests in that directory, on the command line; i.e. pytest
+# doesn't load pocs/tests/conftest.py until after it has searched for
+# tests.
+
+import os
+import pytest
+
+from pocs import hardware
+
+
+def pytest_addoption(parser):
+    hw_names = ",".join(hardware.get_all_names()) + ' (or all for all hardware)'
+    group = parser.getgroup("PANOPTES pytest options")
+    group.addoption(
+        "--with-hardware",
+        nargs='+',
+        default=[],
+        help=("A comma separated list of hardware to test. " + "List items can include: " +
+              hw_names))
+    group.addoption(
+        "--without-hardware",
+        nargs='+',
+        default=[],
+        help=("A comma separated list of hardware to NOT test. " + "List items can include: " +
+              hw_names))
+    group.addoption(
+        "--solve",
+        action="store_true",
+        default=False,
+        help="If tests that require solving should be run")
+    group.addoption(
+        "--test-cloud-storage",
+        action="store_true",
+        default=False,
+        dest="test_cloud_storage",
+        help="Tests cloud strorage functions." +
+        "Requires $PANOPTES_CLOUD_KEY to be set to path of valid json service key")
+
+
+def pytest_collection_modifyitems(config, items):
+    """Modify tests to skip or not based on cli options.
+
+    Certain tests should only be run when the appropriate hardware is attached.
+    Other tests fail if real hardware is attached (e.g. they expect there is no
+    hardware). The names of the types of hardware are in hardware.py, but
+    include 'mount' and 'camera'. For a test that requires a mount, for
+    example, the test should be marked as follows:
+
+    `@pytest.mark.with_mount`
+
+    And the same applies for the names of other types of hardware.
+    For a test that requires that there be no cameras attached, mark the test
+    as follows:
+
+    `@pytest.mark.without_camera`
+    """
+
+    # without_hardware is a list of hardware names whose tests we don't want to run.
+    without_hardware = hardware.get_simulator_names(
+        simulator=config.getoption('--without-hardware'))
+
+    # with_hardware is a list of hardware names for which we have that hardware attached.
+    with_hardware = hardware.get_simulator_names(simulator=config.getoption('--with-hardware'))
+
+    for name in without_hardware:
+        # User does not want to run tests that interact with hardware called name,
+        # whether it is marked as with_name or without_name.
+        if name in with_hardware:
+            print('Warning: {!r} in both --with-hardware and --without-hardware'.format(name))
+            with_hardware.remove(name)
+        skip = pytest.mark.skip(reason="--without-hardware={} specified".format(name))
+        with_keyword = 'with_' + name
+        without_keyword = 'without_' + name
+        for item in items:
+            if with_keyword in item.keywords or without_keyword in item.keywords:
+                item.add_marker(skip)
+
+    for name in hardware.get_all_names(without=with_hardware):
+        # We don't have hardware called name, so find all tests that need that
+        # hardware and mark it to be skipped.
+        skip = pytest.mark.skip(reason="Test needs --with-hardware={} option to run".format(name))
+        keyword = 'with_' + name
+        for item in items:
+            if keyword in item.keywords:
+                item.add_marker(skip)
+
+
+@pytest.fixture
+def temp_file():
+    temp_file = 'temp'
+    with open(temp_file, 'w') as f:
+        f.write('')
+
+    yield temp_file
+    os.unlink(temp_file)

--- a/pocs/hardware.py
+++ b/pocs/hardware.py
@@ -9,6 +9,10 @@ def get_all_names(all_names=ALL_NAMES, without=list()):
     Note that this doesn't extend to the Arduinos for the telemetry and camera boards, for
     which no simulation is supported at this time.
     """
+    # Make sure that 'all' gets expanded.
+    if without:
+        without = get_simulator_names(simulator=without)
+
     return [v for v in all_names if v not in without]
 
 
@@ -53,7 +57,7 @@ def get_simulator_names(simulator=None, kwargs=None, config=None):
         if isinstance(v, str):
             v = [v]
         if 'all' in v:
-            return get_all_names()
+            return ALL_NAMES
         else:
             return sorted(v)
     return []

--- a/pocs/tests/conftest.py
+++ b/pocs/tests/conftest.py
@@ -1,56 +1,17 @@
+# pytest will load this file, adding the fixtures in it, if some of the tests
+# in the same directory are selected, or if the current working directory when
+# running pytest is the directory containing this file.
+
 import copy
 import os
 import pytest
 
 import pocs.base
-from pocs import hardware
 from pocs.utils.config import load_config
 from pocs.utils.database import PanMongo
 
 # Global variable with the default config; we read it once, copy it each time it is needed.
 _one_time_config = None
-
-
-def pytest_addoption(parser):
-    parser.addoption("--with-hardware", nargs='+', default=[],
-                     help="A comma separated list of hardware to test"
-                     "List items can include: mount, camera, weather, or all")
-    parser.addoption("--solve", action="store_true", default=False,
-                     help="If tests that require solving should be run")
-    parser.addoption("--test-cloud-storage", action="store_true", default=False,
-                     dest="test_cloud_storage",
-                     help="Tests cloud strorage functions." +
-                     "Requires $PANOPTES_CLOUD_KEY to be set to path of valid json service key")
-
-
-def pytest_collection_modifyitems(config, items):
-    """ Modify tests to skip or not based on cli options
-
-    Certain tests should only be run when the appropriate hardware is attached. The names of the
-    types of hardware are in hardware.py, but include 'mount' and 'camera'. For a test that
-    requires a mount, for example, the test should be marked as follows:
-
-    `@pytest.mark.with_mount`: Run tests with mount attached.
-
-    And the same applies for the names of other types of hardware.
-
-    Note:
-        We are marking which tests to skip rather than which tests to include
-        so the logic is opposite of the options.
-    """
-
-    hardware_list = config.getoption('--with-hardware')
-    for name in hardware.get_all_names():
-        # Do we have hardware called name?
-        if name in hardware_list:
-            # Yes, so don't need to skip tests with keyword "with_name".
-            continue
-        # No, so find all the tests that need this type of hardware and mark them to be skipped.
-        skip = pytest.mark.skip(reason="need --with-hardware={} option to run".format(name))
-        keyword = 'with_' + name
-        for item in items:
-            if keyword in item.keywords:
-                item.add_marker(skip)
 
 
 @pytest.fixture(scope='function')
@@ -85,12 +46,3 @@ def db():
 def data_dir():
     return '{}/pocs/tests/data'.format(os.getenv('POCS'))
 
-
-@pytest.fixture
-def temp_file():
-    temp_file = 'temp'
-    with open(temp_file, 'w') as f:
-        f.write('')
-
-    yield temp_file
-    os.unlink(temp_file)

--- a/pocs/tests/conftest.py
+++ b/pocs/tests/conftest.py
@@ -45,4 +45,3 @@ def db():
 @pytest.fixture
 def data_dir():
     return '{}/pocs/tests/data'.format(os.getenv('POCS'))
-

--- a/pocs/tests/test_observatory.py
+++ b/pocs/tests/test_observatory.py
@@ -17,7 +17,7 @@ def simulator():
     """ We assume everything runs on a simulator
 
     Tests that require real hardware should be marked with the appropriate
-    fixtue (see `conftest.py`)
+    fixture (see `conftest.py`)
     """
     return hardware.get_all_names(without=['night'])
 
@@ -36,8 +36,11 @@ def images_dir(tmpdir_factory):
 
 
 def test_error_exit(config):
+    # TODO Describe why this is expected to fail, and how it is different
+    # from the other tests, esp. test_bad_mount_port.
+    # pytest.set_trace()
     with pytest.raises(SystemExit):
-        Observatory(ignore_local_config=True, simulator=['none'])
+        Observatory(ignore_local_config=True, config=config, simulator=['none'])
 
 
 def test_bad_site(simulator, config):
@@ -55,6 +58,7 @@ def test_bad_mount_port(config):
         Observatory(simulator=simulator, config=conf, ignore_local_config=True)
 
 
+@pytest.mark.without_mount
 def test_bad_mount_driver(config):
     conf = config.copy()
     simulator = hardware.get_all_names(without=['mount'])
@@ -79,6 +83,7 @@ def test_bad_scheduler_fields_file(config):
         Observatory(simulator=simulator, config=conf, ignore_local_config=True)
 
 
+@pytest.mark.without_camera
 def test_bad_camera(config):
     conf = config.copy()
     simulator = hardware.get_all_names(without=['camera'])
@@ -86,6 +91,7 @@ def test_bad_camera(config):
         Observatory(simulator=simulator, config=conf, auto_detect=True, ignore_local_config=True)
 
 
+@pytest.mark.without_camera
 def test_camera_not_found(config):
     conf = config.copy()
     simulator = hardware.get_all_names(without=['camera'])


### PR DESCRIPTION
Add option --without-hardware, complementing --with-hardware.
This allows the user to specify that tests are to be skipped
if they fail with hardware being present or if the user doesn't
want the hardware to be interacted with (e.g. when running
tests on a real unit).

Move parts of POCS/pocs/tests/conftest.py to POCS/conftest.py
in order to enable parsing of command line options without
having to specify pocs/tests on the commad line.

Mark 4 tests in test_observatory as disabled if hardware is present.