### PR TITLE
Upload images for night

### DIFF
--- a/conf_files/pocs.yaml
+++ b/conf_files/pocs.yaml
@@ -18,6 +18,8 @@ directories:
     resources: POCS/resources/
     targets: POCS/resources/targets
     mounts: POCS/resources/mounts
+panoptes_network:
+    image_storage: True
 db: 
     name: panoptes
 scheduler:

--- a/pocs/observatory.py
+++ b/pocs/observatory.py
@@ -221,6 +221,7 @@ class Observatory(PanBase):
                 )
 
                 img_utils.clean_observation_dir(dir_name)
+                img_utils.upload_observation_dir(dir_name)
 
             self.logger.debug('Cleanup finished')
 

--- a/pocs/observatory.py
+++ b/pocs/observatory.py
@@ -226,6 +226,7 @@ class Observatory(PanBase):
                 except KeyError:
                     self.logger.warning("pan_id not set in config, can't upload images.")
                 else:
+                    self.logger.debug("Uploading directory to google cloud storage")
                     img_utils.upload_observation_dir(pan_id, dir_name)
 
             self.logger.debug('Cleanup finished')

--- a/pocs/observatory.py
+++ b/pocs/observatory.py
@@ -221,7 +221,12 @@ class Observatory(PanBase):
                 )
 
                 img_utils.clean_observation_dir(dir_name)
-                img_utils.upload_observation_dir(self.config['pan_id'], dir_name)
+                try:
+                    pan_id = self.config['pan_id']
+                except KeyError:
+                    self.logger.warning("pan_id not set in config, can't upload images.")
+                else:
+                    img_utils.upload_observation_dir(pan_id, dir_name)
 
             self.logger.debug('Cleanup finished')
 

--- a/pocs/observatory.py
+++ b/pocs/observatory.py
@@ -233,7 +233,7 @@ class Observatory(PanBase):
 
                 img_utils.clean_observation_dir(dir_name)
 
-                if upload_images:
+                if upload_images is True:
                     self.logger.debug("Uploading directory to google cloud storage")
                     img_utils.upload_observation_dir(pan_id, dir_name)
 

--- a/pocs/observatory.py
+++ b/pocs/observatory.py
@@ -221,7 +221,7 @@ class Observatory(PanBase):
                 )
 
                 img_utils.clean_observation_dir(dir_name)
-                img_utils.upload_observation_dir(dir_name)
+                img_utils.upload_observation_dir(self.config['pan_id'], dir_name)
 
             self.logger.debug('Cleanup finished')
 

--- a/pocs/observatory.py
+++ b/pocs/observatory.py
@@ -206,6 +206,11 @@ class Observatory(PanBase):
         `observed_list` when done
 
         """
+        try:
+            upload_images = self.config.get('panoptes_network', {})['image_storage']
+        except KeyError:
+            upload_images = False
+
         for seq_time, observation in self.scheduler.observed_list.items():
             self.logger.debug("Housekeeping for {}".format(observation))
 
@@ -221,6 +226,10 @@ class Observatory(PanBase):
                 )
 
                 img_utils.clean_observation_dir(dir_name)
+
+                if upload_images is False:
+                    continue
+
                 try:
                     pan_id = self.config['pan_id']
                 except KeyError:

--- a/pocs/observatory.py
+++ b/pocs/observatory.py
@@ -211,6 +211,12 @@ class Observatory(PanBase):
         except KeyError:
             upload_images = False
 
+        try:
+            pan_id = self.config['pan_id']
+        except KeyError:
+            self.logger.warning("pan_id not set in config, can't upload images.")
+            upload_images = False
+
         for seq_time, observation in self.scheduler.observed_list.items():
             self.logger.debug("Housekeeping for {}".format(observation))
 
@@ -227,14 +233,7 @@ class Observatory(PanBase):
 
                 img_utils.clean_observation_dir(dir_name)
 
-                if upload_images is False:
-                    continue
-
-                try:
-                    pan_id = self.config['pan_id']
-                except KeyError:
-                    self.logger.warning("pan_id not set in config, can't upload images.")
-                else:
+                if upload_images:
                     self.logger.debug("Uploading directory to google cloud storage")
                     img_utils.upload_observation_dir(pan_id, dir_name)
 

--- a/pocs/utils/images/__init__.py
+++ b/pocs/utils/images/__init__.py
@@ -208,7 +208,7 @@ def create_timelapse(directory, fn_out=None, **kwargs):
 
 
 def clean_observation_dir(dir_name, *args, **kwargs):
-    """ Clean an observation directory
+    """ Clean an observation directory.
 
     For the given `dir_name`, will:
         * Compress FITS files
@@ -275,17 +275,15 @@ def clean_observation_dir(dir_name, *args, **kwargs):
         warn('Problem with cleanup creating timelapse: {!r}'.format(e))
 
 
-def upload_observation_dir(pan_id, dir_name, bucket='panoptes-survey', *args, **kwargs):
-    """ Upload an observation directory to google cloud storage
+def upload_observation_dir(pan_id, dir_name, bucket='panoptes-survey'):
+    """ Upload an observation directory to google cloud storage.
 
     Note:
         This requires that the command line utility `gsutil` be installed
         and that authentication has properly been set up.
 
     Args:
-        dir_name (str): Full path to observation directory
-        *args: Description
-        **kwargs: Can include `verbose`
+        dir_name (str): Full path to observation directory.
     """
     assert os.path.exists(dir_name)
     gsutil = shutil.which('gsutil')

--- a/pocs/utils/images/__init__.py
+++ b/pocs/utils/images/__init__.py
@@ -289,7 +289,8 @@ def upload_observation_dir(pan_id, dir_name, bucket='panoptes-survey'):
     gsutil = shutil.which('gsutil')
 
     img_path = '{}/*.fz'.format(dir_name)
-    remote_path = '{}/{}/'.format(pan_id, dir_name).replace('//', '/')
+    field_dir = dir_name.split('fields')[-1]
+    remote_path = '{}/{}/'.format(pan_id, field_dir).replace('//', '/')
 
     bucket = 'gs://{}/'.format(bucket)
     run_cmd = [gsutil, '-mq', 'cp', '-r', img_path, bucket + remote_path]

--- a/scripts/upload_image_dir.py
+++ b/scripts/upload_image_dir.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import os
-import subprocess
 
 from warnings import warn
 from astropy import units as u
@@ -11,6 +10,7 @@ from pprint import pprint
 from pocs.utils.database import PanMongo
 from pocs.utils import current_time
 from pocs.utils.config import load_config
+from pocs.utils.images import upload_observation_dir
 
 
 def main(date, auto_confirm=False, verbose=False):
@@ -62,19 +62,9 @@ def main(date, auto_confirm=False, verbose=False):
         dir_iterator = dirs
 
     for d in dir_iterator:
-        img_path = '{}/{}/*.fz'.format(fields_dir, d)
-        remote_path = '{}/{}/'.format(pan_id, d).replace('//', '/')
-        bucket = 'gs://panoptes-survey/'
-        run_cmd = ['gsutil', '-mq', 'cp', '-r', img_path, bucket + remote_path]
+        dir_name = '{}/{}'.format(fields_dir, d)
 
-        try:
-            completed_process = subprocess.run(run_cmd, stdout=subprocess.PIPE)
-
-            if completed_process.returncode != 0:
-                warn("Problem uploading")
-                warn(completed_process.stdout)
-        except Exception as e:
-            warn("Problem uploading: {}".format(e))
+        upload_observation_dir(pan_id, dir_name)
 
     return len(imgs)
 


### PR DESCRIPTION
* Upload the observation directory during `housekeeping` step
* Move upload function to utils and adjust cli script

Note that I haven't actually tested this yet. I was previously using the `upload_image_dir.py` script without problems.

Edited: I've added an option to the config file about whether or not image uploading should even be tried. This is under a `panoptes_network` heading and currently just has `image_storage`. In the future I see this being expanded, e.g. `network_scheduler`.