### PR TITLE
Reduce flakiness of test_messaging.py

### DIFF
--- a/pocs/tests/test_messaging.py
+++ b/pocs/tests/test_messaging.py
@@ -6,10 +6,14 @@ from datetime import datetime
 from pocs.utils.messaging import PanMessaging
 
 
+@pytest.fixture(scope='module')
+def mp_manager():
+    return multiprocessing.Manager()
+
 @pytest.fixture(scope='function')
-def forwarder():
-    ready = multiprocessing.Event()
-    done = multiprocessing.Event()
+def forwarder(mp_manager):
+    ready = mp_manager.Event()
+    done = mp_manager.Event()
 
     def start_forwarder():
         PanMessaging.create_forwarder(

--- a/pocs/tests/test_messaging.py
+++ b/pocs/tests/test_messaging.py
@@ -10,6 +10,7 @@ from pocs.utils.messaging import PanMessaging
 def mp_manager():
     return multiprocessing.Manager()
 
+
 @pytest.fixture(scope='function')
 def forwarder(mp_manager):
     ready = mp_manager.Event()

--- a/pocs/tests/test_messaging.py
+++ b/pocs/tests/test_messaging.py
@@ -1,21 +1,41 @@
+import multiprocessing
 import pytest
 import time
 
 from datetime import datetime
-from multiprocessing import Process
 from pocs.utils.messaging import PanMessaging
 
 
 @pytest.fixture(scope='function')
 def forwarder():
+    ready = multiprocessing.Event()
+    done = multiprocessing.Event()
+
     def start_forwarder():
-        PanMessaging.create_forwarder(12345, 54321)
+        PanMessaging.create_forwarder(
+            12345, 54321, ready_fn=lambda: ready.set(), done_fn=lambda: done.set())
 
-    messaging = Process(target=start_forwarder)
-
+    messaging = multiprocessing.Process(target=start_forwarder)
     messaging.start()
+
+    if not ready.wait(timeout=10.0):
+        raise Exception('Forwarder failed to become ready!')
+    # Wait a moment for the forwarder to start using those sockets.
+    time.sleep(0.05)
+
     yield messaging
+
+    # Stop the forwarder. Since we use the same ports in multiple
+    # tests, we wait for the process to shutdown.
     messaging.terminate()
+    for _ in range(100):
+        # We can't be sure that the sub-process will succeed in
+        # calling the done_fn, so we also check for the process
+        # ending.
+        if done.wait(timeout=0.01):
+            break
+        if not messaging.is_alive():
+            break
 
 
 @pytest.fixture(scope='function')
@@ -29,26 +49,15 @@ def sub():
 @pytest.fixture(scope='function')
 def pub():
     messaging = PanMessaging.create_publisher(12345, bind=False, connect=True)
-    time.sleep(2)  # Wait for publisher to start up
     yield messaging
     messaging.close()
-
-
-# def test_publisher_receive(pub):
-#     with pytest.raises(AssertionError):
-#         pub.receive_message()
-
-
-# def test_subscriber_send(sub):
-#     with pytest.raises(AssertionError):
-#         sub.send_message('FOO', 'BAR')
 
 
 def test_forwarder(forwarder):
     assert forwarder.is_alive() is True
 
 
-def test_messaging(forwarder, sub, pub):
+def test_send_string(forwarder, sub, pub):
     pub.send_message('TEST-CHANNEL', 'Hello')
     msg_type, msg_obj = sub.receive_message()
 
@@ -59,17 +68,13 @@ def test_messaging(forwarder, sub, pub):
 
 
 def test_send_datetime(forwarder, sub, pub):
-    pub.send_message('TEST-CHANNEL', {
-        'date': datetime(2017, 1, 1)
-    })
+    pub.send_message('TEST-CHANNEL', {'date': datetime(2017, 1, 1)})
     msg_type, msg_obj = sub.receive_message()
     assert msg_obj['date'] == '2017-01-01T00:00:00'
 
 
-def test_mongo_objectid(forwarder, sub, pub, config, db):
-
+def test_send_mongo_objectid(forwarder, sub, pub, config, db):
     db.insert_current('config', {'foo': 'bar'})
-
     pub.send_message('TEST-CHANNEL', db.get_current('config'))
     msg_type, msg_obj = sub.receive_message()
     assert '_id' in msg_obj

--- a/pocs/utils/messaging.py
+++ b/pocs/utils/messaging.py
@@ -27,11 +27,13 @@ class PanMessaging(object):
         self.socket = None
 
     @classmethod
-    def create_forwarder(cls, sub_port, pub_port):
+    def create_forwarder(cls, sub_port, pub_port, ready_fn=None, done_fn=None):
         subscriber = PanMessaging.create_subscriber(sub_port, bind=True, connect=False)
         publisher = PanMessaging.create_publisher(pub_port, bind=True, connect=False)
 
         try:
+            if ready_fn:
+                ready_fn()
             zmq.device(zmq.FORWARDER, subscriber.socket, publisher.socket)
         except KeyboardInterrupt:
             pass
@@ -41,6 +43,8 @@ class PanMessaging(object):
         finally:
             publisher.close()
             subscriber.close()
+            if done_fn:
+                done_fn()
 
     @classmethod
     def create_publisher(cls, port, bind=False, connect=True):


### PR DESCRIPTION
Use two Event objects to coordinate the usage of the messaging
forwarder. In particular, once the forwarder has created the sockets
we can create the publisher and subscriber. And when shutting down,
we should wait until the sockets have been closed else we may find
that we can't create the ports for the next test. This means we can
remove the sleep() calls which slow the tests down without providing
confidence.

Unlike PR #439, this uses an instance of multiprocessing.SyncManager,
which means that the Event objects are accessed via proxies
communicating with a server process. This avoids the problem that
[TravisCI doesn't directly support shared memory](https://github.com/travis-ci/travis-cookbooks/issues/155) without funny
workarounds. This avoids the issue entirely.

Note that this reduces the flakiness on my laptop from perhaps
3% to around 0.2%, which is an improvement, but there is still
room to go.

Partial fix for #131.