### PR TITLE
Use master, dilated saturated pixel mask in autofocus

### DIFF
--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -277,6 +277,8 @@ class AbstractCamera(PanBase):
                   take_dark=None,
                   merit_function='vollath_F4',
                   merit_function_kwargs={},
+                  mask_dilations=None,
+                  spline_smoothing=None,
                   coarse=False,
                   plots=True,
                   blocking=False,
@@ -308,6 +310,10 @@ class AbstractCamera(PanBase):
                 focus metric.
             merit_function_kwargs (dict, optional): Dictionary of additional
                 keyword arguments for the merit function.
+            mask_dilations (int, optional): Number of iterations of dilation to perform on the
+                saturated pixel mask (determine size of masked regions), default 10
+            spline_smoothing (float, optional): smoothing parameter for the spline fitting to
+                the autofocus data, 0.0 to 1.0, smaller values mean *less* smoothing, default 0.4
             coarse (bool, optional): Whether to begin with coarse focusing,
                 default False
             plots (bool, optional: Whether to write focus plots to images folder,
@@ -330,6 +336,8 @@ class AbstractCamera(PanBase):
                                       thumbnail_size=thumbnail_size,
                                       merit_function=merit_function,
                                       merit_function_kwargs=merit_function_kwargs,
+                                      mask_dilations=mask_dilations,
+                                      spline_smoothing=spline_smoothing,
                                       coarse=coarse,
                                       plots=plots,
                                       blocking=blocking,

--- a/pocs/focuser/focuser.py
+++ b/pocs/focuser/focuser.py
@@ -381,7 +381,7 @@ class AbstractFocuser(PanBase):
         n_positions = len(focus_positions)
         thumbnails = np.zeros((n_positions, thumbnail_size, thumbnail_size), dtype=thumbnail.dtype)
         masks = np.empty((n_positions, thumbnail_size, thumbnail_size), dtype=np.bool)
-        metric = np.empty(n_positions)
+        metric = np.empty((n_positions))
 
         for i, position in enumerate(focus_positions):
             # Move focus, updating focus_positions with actual encoder position after move.

--- a/pocs/focuser/focuser.py
+++ b/pocs/focuser/focuser.py
@@ -381,7 +381,7 @@ class AbstractFocuser(PanBase):
         n_positions = len(focus_positions)
         thumbnails = np.zeros((n_positions, thumbnail_size, thumbnail_size), dtype=thumbnail.dtype)
         masks = np.empty((n_positions, thumbnail_size, thumbnail_size), dtype=np.bool)
-        metric = np.empty((n_positions))
+        metric = np.empty(n_positions)
 
         for i, position in enumerate(focus_positions):
             # Move focus, updating focus_positions with actual encoder position after move.
@@ -392,12 +392,12 @@ class AbstractFocuser(PanBase):
                                              focus_positions[i], i, self._camera.file_extension)
             thumbnail = self._camera.get_thumbnail(
                 seconds, file_path, thumbnail_size, keep_file=keep_files)
-            mask[i] = focus_utils.mask_saturated(thumbnail).mask
+            masks[i] = focus_utils.mask_saturated(thumbnail).mask
             if dark_thumb is not None:
                 thumbnail = thumbnail - dark_thumb
             thumbnails[i] = thumbnail
 
-        master_mask = mask.any(axis=0)
+        master_mask = masks.any(axis=0)
         master_mask = binary_dilation(master_mask, iterations=dilations)
 
         for i, position in enumerate(focus_positions):

--- a/pocs/focuser/focuser.py
+++ b/pocs/focuser/focuser.py
@@ -346,8 +346,8 @@ class AbstractFocuser(PanBase):
                    plots,
                    start_event,
                    finished_event,
-                   smooth,
-                   dilations,
+                   mask_dilations,
+                   spline_smoothing,
                    *args,
                    **kwargs):
         # If passed a start_event wait until Event is set before proceeding
@@ -419,7 +419,7 @@ class AbstractFocuser(PanBase):
             thumbnails[i] = thumbnail
 
         master_mask = masks.any(axis=0)
-        master_mask = binary_dilation(master_mask, iterations=dilations)
+        master_mask = binary_dilation(master_mask, iterations=mask_dilations)
 
         for i, position in enumerate(focus_positions):
             thumbnail = np.ma.array(thumbnails[i], mask=master_mask)
@@ -438,7 +438,7 @@ class AbstractFocuser(PanBase):
 
         elif not coarse:
             # Crude guess at a standard deviation for focus metric, 40% of the maximum value
-            weights = np.ones(len(focus_positions)) / (smooth * metric.max())
+            weights = np.ones(len(focus_positions)) / (spline_smoothing * metric.max())
 
             # Fit smoothing spline to focus metric data
             fit = UnivariateSpline(focus_positions, metric, w=weights, k=4, ext='raise')

--- a/pocs/focuser/focuser.py
+++ b/pocs/focuser/focuser.py
@@ -257,7 +257,7 @@ class AbstractFocuser(PanBase):
                 mask_dilations = 10
 
         if spline_smoothing is None:
-            if self.autofocus_spline_smoothin is not None:
+            if self.autofocus_spline_smoothing is not None:
                 spline_smoothing = self.autofocus_spline_smoothing
             else:
                 spline_smoothing = 0.4


### PR DESCRIPTION
This is a fix for a problem seen with Huntsman, autofocus failing to select the best focus position when a saturated star is present in the focus images.  The modified autofocus algorithm masks a region surrounding any pixels which saturate in any of the images in the focus sweep.