### PR TITLE
Cleanup inconsistency in take_exposure call

### DIFF
--- a/pocs/camera/canon_gphoto2.py
+++ b/pocs/camera/canon_gphoto2.py
@@ -104,7 +104,7 @@ class Camera(AbstractGPhotoCamera):
 
         return camera_event
 
-    def take_exposure(self, seconds=1.0 * u.second, filename=None):
+    def take_exposure(self, seconds=1.0 * u.second, filename=None, *args, **kwargs):
         """Take an exposure for given number of seconds and saves to provided filename
 
         Note:

--- a/pocs/camera/simulator.py
+++ b/pocs/camera/simulator.py
@@ -58,7 +58,13 @@ class Camera(AbstractCamera):
 
         return camera_event
 
-    def take_exposure(self, seconds=1.0 * u.second, filename=None, dark=False, blocking=False):
+    def take_exposure(self,
+                      seconds=1.0 * u.second,
+                      filename=None,
+                      dark=False,
+                      blocking=False,
+                      *args,
+                      **kwargs):
         """ Take an exposure for given number of seconds """
         assert self.is_connected, self.logger.error("Camera must be connected for take_exposure!")
 


### PR DESCRIPTION
The base method and sbig expect `*args, **kwargs`. Warning messages were appearing in the tests for the simulator.

@AnthonyHorton I'm tagging you because you cleaned up the code so are more familiar with what would be the expected behaviour. Seems fine to just add the extra args to me.