### PR TITLE
Determine if PanMongoDB works just once

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -8,6 +8,7 @@ import os
 import pytest
 
 from pocs import hardware
+from pocs.utils.logger import get_root_logger
 
 
 def pytest_addoption(parser):
@@ -85,6 +86,40 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if keyword in item.keywords:
                 item.add_marker(skip)
+
+
+def pytest_runtest_logstart(nodeid, location):
+    """Signal the start of running a single test item.
+
+    This hook will be called before pytest_runtest_setup(),
+    pytest_runtest_call() and pytest_runtest_teardown() hooks.
+
+    Args:
+        nodeid (str) – full id of the item
+        location – a triple of (filename, linenum, testname)
+    """
+    logger = get_root_logger()
+    logger.critical('')
+    logger.critical('##########' * 8)
+    logger.critical('     START TEST {}', nodeid)
+    logger.critical('')
+
+
+def pytest_runtest_logfinish(nodeid, location):
+    """Signal the complete finish of running a single test item.
+
+    This hook will be called after pytest_runtest_setup(),
+    pytest_runtest_call() and pytest_runtest_teardown() hooks.
+
+    Args:
+        nodeid (str) – full id of the item
+        location – a triple of (filename, linenum, testname)
+    """
+    logger = get_root_logger()
+    logger.critical('')
+    logger.critical('       END TEST {}', nodeid)
+    logger.critical('')
+    logger.critical('##########' * 8)
 
 
 @pytest.fixture

--- a/pocs/tests/conftest.py
+++ b/pocs/tests/conftest.py
@@ -44,7 +44,7 @@ _can_connect_to_mongo = None
 def can_connect_to_mongo():
     global _can_connect_to_mongo
     if _can_connect_to_mongo is None:
-        logger = get_root_logger(),
+        logger = get_root_logger()
         try:
             PanDB(
                 db_type='mongo',

--- a/pocs/utils/database.py
+++ b/pocs/utils/database.py
@@ -22,13 +22,7 @@ def get_shared_mongo_client(host, port, connect):
     except KeyError:
         pass
 
-    client = pymongo.MongoClient(
-        host,
-        port,
-        connect=connect,
-        connectTimeoutMS=2500,
-        serverSelectionTimeoutMS=2500
-    )
+    client = pymongo.MongoClient(host, port, connect=connect)
 
     _shared_mongo_clients[key] = client
     return client


### PR DESCRIPTION
Refactor db fixture to use db_type fixture.

Modify db_type fixture to determine if mongo is available just once.

Add log messages at the start and end of each test. This makes it easier
to debug tests because you can tell which log messages go with which test
(mostly).

Remove temp_file from pocs/tests/conftest.py as it is already in
the root conftest.py.