### PR TITLE
Record test failure info in the log file

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -98,11 +98,14 @@ def pytest_runtest_logstart(nodeid, location):
         nodeid (str) – full id of the item
         location – a triple of (filename, linenum, testname)
     """
-    logger = get_root_logger()
-    logger.critical('')
-    logger.critical('##########' * 8)
-    logger.critical('     START TEST {}', nodeid)
-    logger.critical('')
+    try:
+        logger = get_root_logger()
+        logger.critical('')
+        logger.critical('##########' * 8)
+        logger.critical('     START TEST {}', nodeid)
+        logger.critical('')
+    except Exception:
+        pass
 
 
 def pytest_runtest_logfinish(nodeid, location):
@@ -115,11 +118,34 @@ def pytest_runtest_logfinish(nodeid, location):
         nodeid (str) – full id of the item
         location – a triple of (filename, linenum, testname)
     """
-    logger = get_root_logger()
-    logger.critical('')
-    logger.critical('       END TEST {}', nodeid)
-    logger.critical('')
-    logger.critical('##########' * 8)
+    try:
+        logger = get_root_logger()
+        logger.critical('')
+        logger.critical('       END TEST {}', nodeid)
+        logger.critical('')
+        logger.critical('##########' * 8)
+    except Exception:
+        pass
+
+
+def pytest_runtest_logreport(report):
+    """Adds the failure info that pytest prints to stdout into the log."""
+    if report.skipped or report.outcome != 'failed':
+        return
+    try:
+        logger = get_root_logger()
+        logger.critical('')
+        logger.critical('  TEST {} FAILED during {}\n\n{}\n', report.nodeid, report.when,
+                        report.longreprtext)
+        cnt = 15
+        if report.capstdout:
+            logger.critical('{}Captured stdout during {}{}\n{}\n', '= ' * cnt, report.when,
+                            ' =' * cnt, report.capstdout)
+        if report.capstderr:
+            logger.critical('{}Captured stderr during {}{}\n{}\n', '* ' * cnt, report.when,
+                            ' *' * cnt, report.capstderr)
+    except Exception:
+        pass
 
 
 @pytest.fixture

--- a/pocs/utils/logger.py
+++ b/pocs/utils/logger.py
@@ -68,6 +68,13 @@ def get_root_logger(profile='panoptes', log_config=None):
 
     # Alter the log_config to use UTC times
     if log_config.get('use_utc', True):
+        # TODO(jamessynge): Figure out why 'formatters' is sometimes
+        # missing from the log_config. It is hard to understand how
+        # this could occur given that none of the callers of
+        # get_root_logger pass in their own log_config.
+        if 'formatters' not in log_config and sys.stdout.isatty():
+            import pdb
+            pdb.set_trace()
         for name, formatter in log_config['formatters'].items():
             log_config['formatters'][name].setdefault('()', _UTCFormatter)
         log_fname_datetime = datetime.datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')


### PR DESCRIPTION
Make pytest-all.log much more useful by recording pytest failure
info in the log file.