### PR TITLE
Run pytest -v instead of setup.py test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ script:
   - arduino --verify --board $BOARD resources/arduino_files/camera_board/camera_board.ino
   - arduino --verify --board $BOARD resources/arduino_files/power_board/power_board.ino
   - arduino --verify --board $BOARD resources/arduino_files/telemetry_board/telemetry_board.ino
-  - coverage run setup.py test
+  - coverage run $(which pytest) -v
   - coverage combine .coverage*
 
 after_success:


### PR DESCRIPTION
Modify .travis.yml so that we get more details of the tests being run. This is especially useful when tests are stuck.