### PR TITLE
Add filter FITS header entry in take_exposure

### DIFF
--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -380,6 +380,7 @@ class AbstractCamera(PanBase):
                 header.set('IMAGETYP', 'Dark Frame')
             else:
                 header.set('IMAGETYP', 'Light Frame')
+        header.set('FILTER', self.filter_type)
         try:
             header.set('CCD-TEMP', self.ccd_temp.value, 'Degrees C')
         except NotImplementedError:


### PR DESCRIPTION
Another small bug fix. Previously the `FILTER` FITS header entry was only being added by `process_exposure()` which meant it wasn't present when `make_pretty_image()` was called so that the titles of the JPEGS always said 'Unknown filter', and images taken directly with `take_exposure` instead of `take_observation` would never get the `FILTER` entry in their headers at all. This one line change ensures that the `FILTER` entry gets added to all images at the time the FITS file is created.