### PR TITLE
Remove destructor from SBIGDriver class

### DIFF
--- a/pocs/camera/sbigudrv.py
+++ b/pocs/camera/sbigudrv.py
@@ -111,17 +111,6 @@ class SBIGDriver(PanBase):
 
         self.logger.info('\t\t\t SBIGDriver initialised: found {} cameras'.format(self._camera_info.camerasFound))
 
-    def __del__(self):
-        self.logger.debug('Closing SBIGUDrv driver')
-        # Using Set Handle to do this should ensure that both device and driver are closed
-        # regardless of current state
-        shp = SetDriverHandleParams(INVALID_HANDLE_VALUE)
-        self._send_command('CC_SET_DRIVER_HANDLE', params=shp)
-        # Vain attempt to unload the shared library
-        self.logger.debug('Closing SBIGUDrv library')
-        _ctypes.dlclose(self._CDLL._handle)
-        del self._CDLL
-
     @property
     def retries(self):
         return self._retries


### PR DESCRIPTION
Fix for intermittent error messages reported in https://github.com/AstroHuntsman/huntsman-pocs/issues/23.

The reason for adding the destructor to this class in the first place was an attempt to allow the SBIG cameras to be reinitialised without restarting the whole Python session. I was never able to get that to work however, as the associated shared library would not properly unload. The presence of the destructor hence serves no purpose and is potentially misleading (a user might assume that it does work as originally intended).