### PR TITLE
Improve logging and speed of startup scripts

### DIFF
--- a/scripts/startup/README.md
+++ b/scripts/startup/README.md
@@ -74,8 +74,8 @@ you add that rule at the end of the file, save the file and exit the
 editor. You can confirm that it was added correctly by viewing the
 file with the command `crontab -l`. Next, reboot the computer (e.g.
 with the command `sudo shutdown -r now`), log back in, remove that
-test rule, and see if /tmp/at-reboot-worked was created. If it was,
-then `@reboot` works. Otherwise, skip the @reboot rule in the
+test rule, and see if `/tmp/at-reboot-worked` was created. If it was,
+then `@reboot` works. Otherwise, skip the `@reboot` rule in the
 steps that follow, and follow the instructions in 
 __Execution by `root`__ after editing your crontab.
 

--- a/scripts/startup/README.md
+++ b/scripts/startup/README.md
@@ -3,6 +3,17 @@ when the Linux computer that runs a PANOPTES starts or restarts.
 We assume here that you are logged in as user $PANUSER, and that user
 $PANUSER has permissions to execute `sudo`.
 
+> Note: We use `tmux`, a [terminal
+> multiplexer](https://en.wikipedia.org/wiki/Terminal_multiplexer),
+> to run all of the software. This means that when the computer boots,
+> it can create several virtual terminals, each running a separate
+> program. Later, when you want to see what those programs are doing,
+> you can login and attach to those terminals. With `tmux`, the command
+> to do that is:
+> ```bash
+> tmux attach-session -t panoptes
+> ```
+
 # PANOPTES Environement Variables
 
 First we need to have the PANOPTES environement variables set in all
@@ -31,15 +42,45 @@ reboots. We document these ways to achieve this:
 * `@reboot` rule in crontab of user $PANUSER
 * Execution by root during boot
 
+When you are ready to have the telescope run automatically (i.e. have
+done all the manual setup and alignment that you need to), follow one
+of these steps to arrange for your telescope to run automatically after
+reboot.
+
+> Note: the EDITOR environment variable allows you to specify the
+> editor used by commands such as `crontab`. `nano` is a simple editor
+> that runs in almost any terminal window. On some systems, the
+> default editor may be `vi` or `vim`, which are rather more difficult
+> to use than `nano`, unless you're already familiar with them.
+
 ## Crontab
 
 [Crontab](https://linux.die.net/man/5/crontab) provides a means to run
 a command line at various times. Some versions of crontab have support
 for [`@reboot`](https://www.google.com/search?q=crontab+%40reboot) as
-a *time* at which to run a command. If your system has this feature, it
-is the easiest way to launch the PANOPTES software.
+a *time* at which to run a command. If your system has this feature,
+it is the easiest way to launch the PANOPTES software.
+
+You can test whether `@reboot` works by adding a rule that
+leaves an indication of whether it works. For example:
+
+```bash
+@reboot touch /tmp/at-reboot-worked
+```
+
+Add the rule to your ($PANUSER) crontab by executing the command
+`crontab -e`, which will start an editor on your crontab file. After
+you add that rule at the end of the file, save the file and exit the
+editor. You can confirm that it was added correctly by viewing the
+file with the command `crontab -l`. Next, reboot the computer (e.g.
+with the command `sudo shutdown -r now`), log back in, remove that
+test rule, and see if /tmp/at-reboot-worked was created. If it was,
+then `@reboot` works. Otherwise, skip the @reboot rule in the
+steps that follow, and follow the instructions in 
+__Execution by `root`__ after editing your crontab.
+
 Add these lines to your ($PANUSER) crontab by executing the command
-`crontab -e`, which will start an editor on your crontab file.
+`crontab -e`:
 
 ```bash
 POCS=/var/panoptes/POCS
@@ -51,7 +92,7 @@ PANLOG=/var/panoptes/logs
 11  12  *   *   *    /bin/bash --login python $POCS/pocs/utils/data.py >> $PANLOG/update_data.log 2>&1
 ```
 
-If your values for POCS and PANLOG don't match those show, please
+If your values for POCS and PANLOG don't match those shown above, please
 edit them appropriately. Use the fully evaluated values (e.g. the
 value produced by `echo $POCS` and by `echo $PANLOG`), as `cron`
 does not expand variables in those lines.
@@ -62,8 +103,13 @@ Notice that each of these commands starts with `/bin/bash --login`. We
 do this because `cron` does not run the commands in a shell with all
 of the normal environment variables set, so we force that to happen.
 
+The other two rules are for generating a plot (image) of the
+weather sensor data every 5 minutes and for updating astronomical
+coordinate system data every day at 11 minutes after noon.
+
 ## Execution by `root`
 
+If your crontab does not support the `@reboot` directive (you can 
 If necessary, you can modify the Linux boot scripts to start the
 PANOPTES software. For that, we provide the script `su_panoptes.sh`.
 
@@ -95,6 +141,12 @@ For example, adding it to the default Ubuntu `/etc/rc.local`:
 /etc/su_panoptes.sh >> /tmp/su_panoptes.log 2>&1
 
 exit 0
+```
+
+To edit the file, run this command:
+
+```bash
+sudo nano /etc/rc.local
 ```
 
 As the default text says, you may need to enable that script to execute:

--- a/scripts/startup/README.md
+++ b/scripts/startup/README.md
@@ -1,5 +1,9 @@
 These scripts support starting the PANOPTES software automatically
 when the Linux computer that runs a PANOPTES starts or restarts.
+We assume here that you are logged in as user $PANUSER, and that user
+$PANUSER has permissions to execute `sudo`.
+
+# PANOPTES Environement Variables
 
 First we need to have the PANOPTES environement variables set in all
 the shells that are involved in running PANOPTES. The simplest
@@ -15,8 +19,55 @@ sudo chmod +x /etc/profile.d/set_panoptes_env_vars.sh
 This will then be executed when any user logs in. The exact means
 of doing this varies on different versions of Unix/Linux.
 
-Next, we need to arrange for `su_panoptes.sh` to be executed when
-the operating system launches. First copy it to /etc:
+If you've changed the location of the PANOPTES directories (e.g. if
+log files are not stored in $PANDIR/logs), you'll need to edit that
+script accordingly.
+
+# Start PANOPTES Software on System Start
+
+We intend for a PANOPTES telescope to run automatically, including after
+reboots. We document these ways to achieve this:
+
+* `@reboot` rule in crontab of user $PANUSER
+* Execution by root during boot
+
+## Crontab
+
+[Crontab](https://linux.die.net/man/5/crontab) provides a means to run
+a command line at various times. Some versions of crontab have support
+for [`@reboot`](https://www.google.com/search?q=crontab+%40reboot) as
+a *time* at which to run a command. If your system has this feature, it
+is the easiest way to launch the PANOPTES software.
+Add these lines to your ($PANUSER) crontab by executing the command
+`crontab -e`, which will start an editor on your crontab file.
+
+```bash
+POCS=/var/panoptes/POCS
+PANLOG=/var/panoptes/logs
+
+# m h  dom mon dow   command
+@reboot              /bin/bash --login $POCS/scripts/startup/tmux_launch.sh
+*/5 *   *   *   *    /bin/bash --login python $POCS/scripts/plot_weather.py >> $PANLOG/plot_weather.log 2>&1
+11  12  *   *   *    /bin/bash --login python $POCS/pocs/utils/data.py >> $PANLOG/update_data.log 2>&1
+```
+
+If your values for POCS and PANLOG don't match those show, please
+edit them appropriately. Use the fully evaluated values (e.g. the
+value produced by `echo $POCS` and by `echo $PANLOG`), as `cron`
+does not expand variables in those lines.
+
+Save the edited file and exit the editor.
+
+Notice that each of these commands starts with `/bin/bash --login`. We
+do this because `cron` does not run the commands in a shell with all
+of the normal environment variables set, so we force that to happen.
+
+## Execution by `root`
+
+If necessary, you can modify the Linux boot scripts to start the
+PANOPTES software. For that, we provide the script `su_panoptes.sh`.
+
+First, copy that file to /etc:
 
 ```bash
 sudo cp $POCS/scripts/startup/su_panoptes.sh \
@@ -25,7 +76,7 @@ sudo chmod +x /etc/su_panoptes.sh
 ```
 
 Next, edit `/etc/rc.local`, adding a command to run `su_panoptes.sh`.
-For example, adding it to the default Ubuntu `rc.local`:
+For example, adding it to the default Ubuntu `/etc/rc.local`:
 
 ```bash
 #!/bin/sh -e
@@ -44,4 +95,10 @@ For example, adding it to the default Ubuntu `rc.local`:
 /etc/su_panoptes.sh >> /tmp/su_panoptes.log 2>&1
 
 exit 0
+```
+
+As the default text says, you may need to enable that script to execute:
+
+```bash
+sudo chmod +x /etc/rc.local
 ```

--- a/scripts/startup/start_log_viewer.sh
+++ b/scripts/startup/start_log_viewer.sh
@@ -4,12 +4,12 @@ WINDOW="${1}"
 LOGFILE="${2}"
 echo "Running $(basename "${0}") at $(date), WINDOW=${WINDOW}, LOGFILE=${LOGFILE}"
 
-# Wait for bash to be ready (not necessary, but makes
-# the window look tidier when you attach later).
-sleep 1s
-
 tmux send-keys -t "${WINDOW}" "date" C-m
+sleep 0.5s
 tmux send-keys -t "${WINDOW}" "cd \"${PANLOG}\"" C-m
+sleep 0.5s
+tmux send-keys -t "${WINDOW}" "while [[ ! -f \"${LOGFILE}\" ]] ; do echo \"Waiting for ${LOGFILE} to exist\" ; sleep 1s ; done" C-m
+sleep 2s
 tmux send-keys -t "${WINDOW}" "less --follow-name \"${LOGFILE}\"" C-m
 sleep 2s
 tmux send-keys -t "${WINDOW}" "F"

--- a/scripts/startup/start_log_viewer.sh
+++ b/scripts/startup/start_log_viewer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -ex
 
 WINDOW="${1}"
 LOGFILE="${2}"

--- a/scripts/startup/start_messaging_hub.sh
+++ b/scripts/startup/start_messaging_hub.sh
@@ -3,11 +3,8 @@
 WINDOW="${1}"
 echo "Running $(basename "${0}") at $(date), WINDOW=${WINDOW}"
 
-# Wait for bash to be ready (not necessary, but makes
-# the window look tidier when you attach later).
-sleep 1s
-
 tmux send-keys -t "${WINDOW}" "date" C-m
+sleep 0.5s
 tmux send-keys -t "${WINDOW}" \
      "python $POCS/scripts/run_messaging_hub.py --from_config" C-m
 

--- a/scripts/startup/start_panoptes_in_tmux.sh
+++ b/scripts/startup/start_panoptes_in_tmux.sh
@@ -34,7 +34,6 @@ echo "PANLOG: ${PANLOG}"
 echo "POCS: ${POCS}"
 echo "PAWS: ${PAWS}"
 echo "PIAA: ${PIAA}"
-echo "MATPLOTLIBRC: ${MATPLOTLIBRC}"
 # $- expands to the current option flags as specified upon invocation, by the
 # set built-in command, or those set by the shell itself (such as the -i).
 echo '$-:' "$-"

--- a/scripts/startup/start_panoptes_in_tmux.sh
+++ b/scripts/startup/start_panoptes_in_tmux.sh
@@ -15,7 +15,7 @@ echo "Will log to ${LOG_FILE}"
 
 exec 2> "${LOG_FILE}"  # send stderr to a log file
 exec 1>&2              # send stdout to the same log file
-set -x
+set +x
 
 echo "Running ${BASH_SOURCE[0]} at $(date)"
 
@@ -40,12 +40,6 @@ echo "MATPLOTLIBRC: ${MATPLOTLIBRC}"
 echo '$-:' "$-"
 # Just in case conda isn't setup as expected, don't die here.
 (set +e ; conda info)
-
-# We get noisy complaints from astroplan about the IERS Bulletin A
-# being too old, and this can cause some concern for those running
-# this software. Avoid these by downloading fresh data,; ignore
-# errors, such as due to the lack of an internet connection.
-(set +e ; python "${POCS}/pocs/utils/data.py")
 
 function create_and_init_window() {
     local -r WINDOW="${1}"
@@ -72,6 +66,14 @@ function create_and_init_window() {
     # may not be strictly necessary.
     sleep 2s
 }
+
+set -x
+
+# We get noisy complaints from astroplan about the IERS Bulletin A
+# being too old, and this can cause some concern for those running
+# this software. Avoid these by downloading fresh data,; ignore
+# errors, such as due to the lack of an internet connection.
+(set +e ; python "${POCS}/pocs/utils/data.py")
 
 # Create a window running the zeromq message forwarders.
 # These provide connections between message publishers and subscribers.

--- a/scripts/startup/start_panoptes_in_tmux.sh
+++ b/scripts/startup/start_panoptes_in_tmux.sh
@@ -54,9 +54,11 @@ function create_and_init_window() {
     # Create the window.
     tmux new-window -n "${WINDOW}"
 
-    # Give the window a few seconds to start up (i.e. to start bash, and
-    # for bash to run the initialization script).
-    sleep 3s  
+    # Give the window a little while to start up (i.e. to start bash, and
+    # for bash to run the initialization script). 8 seconds was chosen
+    # based on how long it takes on PAN006 for a new tmux window to
+    # print the bash prompt.
+    sleep 8s
 
     # Run the script in a separate process, and prevent it from being
     # killed when this script ends.

--- a/scripts/startup/start_paws.sh
+++ b/scripts/startup/start_paws.sh
@@ -3,11 +3,10 @@
 WINDOW="${1}"
 echo "Running $(basename "${0}") at $(date), WINDOW=${WINDOW}"
 
-# Wait for bash to be ready (not necessary, but makes
-# the window look tidier when you attach later).
-sleep 1s
-
 tmux send-keys -t "${WINDOW}" "date" C-m
-tmux send-keys -t "${WINDOW}" "python $PAWS/app.py" C-m
+sleep 0.5s
+tmux send-keys -t "${WINDOW}" "cd \"${PAWS}\"" C-m
+sleep 0.5s
+tmux send-keys -t "${WINDOW}" "python app.py" C-m
 
 echo "Done at $(date)"

--- a/scripts/startup/start_peas.sh
+++ b/scripts/startup/start_peas.sh
@@ -3,12 +3,10 @@
 WINDOW="${1}"
 echo "Running $(basename "${0}") at $(date), WINDOW=${WINDOW}"
 
-# Wait for bash to be ready (not necessary, but makes
-# the window look tidier when you attach later).
-sleep 1s
-
 tmux send-keys -t "${WINDOW}" "date" C-m
-tmux send-keys -t "${WINDOW}" "cd $POCS" C-m
+sleep 0.5s
+tmux send-keys -t "${WINDOW}" "cd ${POCS}" C-m
+sleep 0.5s
 tmux send-keys -t "${WINDOW}" "bin/peas_shell" C-m
 sleep 10s
 tmux send-keys -t "${WINDOW}" "display_config" C-m

--- a/scripts/startup/start_peas.sh
+++ b/scripts/startup/start_peas.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -ex
 
 WINDOW="${1}"
 echo "Running $(basename "${0}") at $(date), WINDOW=${WINDOW}"

--- a/scripts/startup/start_pocs.sh
+++ b/scripts/startup/start_pocs.sh
@@ -3,12 +3,10 @@
 WINDOW="${1}"
 echo "Running $(basename "${0}") at $(date), WINDOW=${WINDOW}"
 
-# Wait for bash to be ready (not necessary, but makes
-# the window look tidier when you attach later).
-sleep 1s
-
 tmux send-keys -t "${WINDOW}" "date" C-m
-tmux send-keys -t "${WINDOW}" "cd $POCS" C-m
+sleep 0.5s
+tmux send-keys -t "${WINDOW}" "cd ${POCS}" C-m
+sleep 0.5s
 tmux send-keys -t "${WINDOW}" "bin/pocs_shell" C-m
 sleep 10s
 tmux send-keys -t "${WINDOW}" "setup_pocs" C-m

--- a/scripts/startup/start_pocs.sh
+++ b/scripts/startup/start_pocs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -ex
 
 WINDOW="${1}"
 echo "Running $(basename "${0}") at $(date), WINDOW=${WINDOW}"

--- a/scripts/startup/su_panoptes.sh
+++ b/scripts/startup/su_panoptes.sh
@@ -1,13 +1,24 @@
 #!/bin/sh -ex
 
-# Start the PANOPTES software running as user $PANUSER in a detached
-# tmux session; this enables an admin to attach to that session
-# later, see the output and take control of all the shells.
+# Start running the script tmux_launch as user $PANUSER in a login
+# shell, i.e. one that will run that user's shell initialization
+# scripts, such as .profile and/or .bashrc.
+
+# This script is designed to be run from /etc/rc.local (or similar)
+# by the user root, after the PANOPTES environment variables have
+# been set.
 
 # Put the date & time into the log (e.g. /tmp/su_panoptes.log).
 echo
 echo "Running ${0} at $(/bin/date)"
 echo
+
+# Make sure that the PANOPTES environment variables have been setup
+# (e.g. by /etc/profile).
+if [[ -z "${POCS}" || -z "${PANUSER}" ]] ; then
+  echo "The POCS and PANUSER environment variables must be set!"
+  exit 1
+fi
 
 # Execute tmux_launch.sh in a login shell for user $PANUSER.
 /bin/su --login --command \

--- a/scripts/startup/tmux_launch.sh
+++ b/scripts/startup/tmux_launch.sh
@@ -11,12 +11,16 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 echo "Setting up logging..."
 
-# Setup a directory into which we can log.
-export STARTUP_LOG_DIR_SLASH="${PANLOG}/per-run/startup/"
+# Setup a directory for the log file from this script and from those
+# it invokes. By creating a unique directory per startup, we make it
+# easier to view the group of files from a single reboot.
+export STARTUP_LOG_DIR_SLASH="${PANLOG}/per-run/startup/$(date +%Y%m%d-%H%M%S-%Z)/"
 mkdir -p "${STARTUP_LOG_DIR_SLASH}"
 
-NOW="$(date +%Y%m%d-%H%M%S-%Z)"
-LOG_FILE="${STARTUP_LOG_DIR_SLASH}$(basename "${BASH_SOURCE[0]}" .sh)-${NOW}.log"
+LOG_NAME="$(basename "${BASH_SOURCE[0]}" .sh).log"
+LOG_FILE="${STARTUP_LOG_DIR_SLASH}${LOG_NAME}"
+
+echo "Will log to ${LOG_FILE}"
 
 exec 2> "${LOG_FILE}"  # send stderr to a log file
 exec 1>&2              # send stdout to the same log file

--- a/scripts/startup/tmux_launch.sh
+++ b/scripts/startup/tmux_launch.sh
@@ -32,6 +32,7 @@ echo "Will log to ${LOG_FILE}"
 
 exec 2> "${LOG_FILE}"  # send stderr to a log file
 exec 1>&2              # send stdout to the same log file
+set +x
 
 # Record a bunch of environment variables into the log file. This
 # helps us later if we need to debug the execution of this script
@@ -54,6 +55,8 @@ echo 'Shell options ($-):' "$-"
 # their values as they may impact things.
 echo "PIAA: ${PIAA}"
 echo "MATPLOTLIBRC: ${MATPLOTLIBRC}"
+
+set -x
 
 # Finally, the point of this script: create a detached (-d) tmux session
 # called panoptes (-s), with a scrollback buffer of 5000 lines.

--- a/scripts/startup/tmux_launch.sh
+++ b/scripts/startup/tmux_launch.sh
@@ -3,7 +3,9 @@
 # Start the PANOPTES software in a detached tmux (terminal multiplexer)
 # session; this enables the PANOPTES unit's owner/administrator to
 # attach to that session later, see the output and take control of all
-# the shells.
+# the shells. You can attach to the session with this command:
+
+#      tmux attach-session -t panoptes
 
 # This script is intended to be executed in a fully initialized shell
 # (i.e. one in which .profile, .bashrc, etc. have been executed)
@@ -46,15 +48,11 @@ echo "PANDIR: ${PANDIR}"
 echo "PANLOG: ${PANLOG}"
 echo "POCS: ${POCS}"
 echo "PAWS: ${PAWS}"
+echo "PIAA: ${PIAA}"
 
 # $- expands to the current option flags as specified upon invocation, by the
 # set built-in command, or those set by the shell itself (such as the -i).
 echo 'Shell options ($-):' "$-"
-
-# These two environment variables don't have to be set, but let's record
-# their values as they may impact things.
-echo "PIAA: ${PIAA}"
-echo "MATPLOTLIBRC: ${MATPLOTLIBRC}"
 
 set -x
 

--- a/scripts/startup/tmux_launch.sh
+++ b/scripts/startup/tmux_launch.sh
@@ -1,7 +1,15 @@
 #!/bin/bash -ex
 
-# This script is designed to be run from /etc/rc.local (or similar)
-# as user $PANUSER with the PANOPTES environment variables set.
+# Start the PANOPTES software in a detached tmux (terminal multiplexer)
+# session; this enables the PANOPTES unit's owner/administrator to
+# attach to that session later, see the output and take control of all
+# the shells.
+
+# This script is intended to be executed in a fully initialized shell
+# (i.e. one in which .profile, .bashrc, etc. have been executed)
+# because those setup the environment variables needed.
+# In particular, this script can be run by su_panoptes.sh or by
+# a @reboot rule in the crontab of user $PANUSER.
 
 echo "Running ${BASH_SOURCE[0]} at $(date)"
 
@@ -24,11 +32,10 @@ echo "Will log to ${LOG_FILE}"
 
 exec 2> "${LOG_FILE}"  # send stderr to a log file
 exec 1>&2              # send stdout to the same log file
-set -x
 
-# Record important debugging info into the log file.
-# These environment variables do NOT all have to be set.
-
+# Record a bunch of environment variables into the log file. This
+# helps us later if we need to debug the execution of this script
+# and those it invokes.
 echo "Running ${BASH_SOURCE[0]} at $(date)"
 echo "Current dir: $(pwd)"
 echo "Current user: ${USER}"
@@ -38,14 +45,18 @@ echo "PANDIR: ${PANDIR}"
 echo "PANLOG: ${PANLOG}"
 echo "POCS: ${POCS}"
 echo "PAWS: ${PAWS}"
-echo "PIAA: ${PIAA}"
-echo "MATPLOTLIBRC: ${MATPLOTLIBRC}"
+
 # $- expands to the current option flags as specified upon invocation, by the
 # set built-in command, or those set by the shell itself (such as the -i).
-echo '$-:' "$-"
+echo 'Shell options ($-):' "$-"
 
-# Create a detached (-d) tmux session called panoptes (-s),
-# with a scrollback buffer of 5000 lines.
+# These two environment variables don't have to be set, but let's record
+# their values as they may impact things.
+echo "PIAA: ${PIAA}"
+echo "MATPLOTLIBRC: ${MATPLOTLIBRC}"
+
+# Finally, the point of this script: create a detached (-d) tmux session
+# called panoptes (-s), with a scrollback buffer of 5000 lines.
 tmux set-option -g history-limit 5000 \; new-session -d \
                 -s panoptes ./start_panoptes_in_tmux.sh
 


### PR DESCRIPTION
Create a directory for each tmux_launch execution, used
by all of the startup scripts it launches.

Run the scripts for initializing each of the terminals
in a separate process and don't wait for them to complete.
This will speed the process of starting up the system.

Add -ex to all of the bash shebang lines so that the log
files show what was being executed, and so that bash
errors are detected.