### PR TITLE
Add grc to requirements, ignore .pytest_cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,7 +80,9 @@ notebooks/*
 # Ignore link to weather_plots in web/static/
 weather_plots
 
-# Ignore pytest.ini file in root of project. Especially useful on a unit to skip
-# tests that interact with hardware.
+# Ignore pytest.ini file in root of project. Especially useful
+# on a unit to skip tests that interact with hardware.
 /pytest.ini
 
+# Ignore pytest's cache of data across tests.
+/.pytest_cache

--- a/scripts/install/apt-packages-list.txt
+++ b/scripts/install/apt-packages-list.txt
@@ -65,3 +65,6 @@ tmux
 
 # Used for creating a timelapse.
 ffmpeg
+
+# Used for colorizing log files.
+grc


### PR DESCRIPTION
We can use grc to colorize log files. Supports #490.

Some pytest stores data across tests in folder .pytest_cache.
Ignore that folder.