### PR TITLE
Ensure that bash is used by tmux

### DIFF
--- a/scripts/startup/README.md
+++ b/scripts/startup/README.md
@@ -92,11 +92,6 @@ PANLOG=/var/panoptes/logs
 11  12  *   *   *    /bin/bash --login python $POCS/pocs/utils/data.py >> $PANLOG/update_data.cron.log 2>&1
 ```
 
-
-
-
-
-
 If your values for POCS and PANLOG don't match those shown above, please
 edit them appropriately. Use the fully evaluated values (e.g. the
 value produced by `echo $POCS` and by `echo $PANLOG`), as `cron`
@@ -105,8 +100,11 @@ does not expand variables in those lines.
 Save the edited file and exit the editor.
 
 Notice that each of these commands starts with `/bin/bash --login`. We
-do this because `cron` does not run the commands in a shell with all
-of the normal environment variables set, so we force that to happen.
+do this because, by default, `cron` runs commands in a very minimal
+environment with /bin/sh as the shell. This means that the PANOPTES
+environment variables are not set, nor is the appropriate conda
+environment activated. The `/bin/bash --login` selects the correct
+shell and tells that shell to initialize its environment.
 
 The other two rules are for generating a plot (image) of the
 weather sensor data every 5 minutes and for updating astronomical

--- a/scripts/startup/README.md
+++ b/scripts/startup/README.md
@@ -87,10 +87,15 @@ POCS=/var/panoptes/POCS
 PANLOG=/var/panoptes/logs
 
 # m h  dom mon dow   command
-@reboot              /bin/bash --login $POCS/scripts/startup/tmux_launch.sh
-*/5 *   *   *   *    /bin/bash --login python $POCS/scripts/plot_weather.py >> $PANLOG/plot_weather.log 2>&1
-11  12  *   *   *    /bin/bash --login python $POCS/pocs/utils/data.py >> $PANLOG/update_data.log 2>&1
+@reboot              /bin/bash --login $POCS/scripts/startup/tmux_launch.sh >> $PANLOG/tmux_launch.cron-reboot.log 2>&1
+*/5 *   *   *   *    /bin/bash --login python $POCS/scripts/plot_weather.py >> $PANLOG/plot_weather.cron.log 2>&1
+11  12  *   *   *    /bin/bash --login python $POCS/pocs/utils/data.py >> $PANLOG/update_data.cron.log 2>&1
 ```
+
+
+
+
+
 
 If your values for POCS and PANLOG don't match those shown above, please
 edit them appropriately. Use the fully evaluated values (e.g. the

--- a/scripts/startup/set_panoptes_env_vars.sh
+++ b/scripts/startup/set_panoptes_env_vars.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
 
 # This file is to be copied into /etc/profile.d/ and SOURCED by
-# /etc/rc.local. We have the shebang line at the top to help shellcheck
-# recognize the type of script.
+# /etc/rc.local. We have the shebang line at the top to help the
+# shellcheck tool (a lint-like tool for shell scripts) recognize
+# the type of this script.
 
 export PANUSER=panoptes          # User that runs PANOPTES software.
 export PANDIR=/var/panoptes      # Main directory.

--- a/scripts/startup/start_panoptes_in_tmux.sh
+++ b/scripts/startup/start_panoptes_in_tmux.sh
@@ -1,10 +1,23 @@
 #!/bin/bash -ex
 
+if [[ -z "$BASH_VERSION" ]] ; then
+  echo "This script must be run by bash."
+  exit 1
+fi
+
 # This script is designed to be run inside tmux, launched by
 # tmux_launch.sh. Make sure that is so.
 echo "Running ${BASH_SOURCE[0]} at $(date)"
 if [[ -z "${STARTUP_LOG_DIR_SLASH}" ]] ; then
   echo "This script must be run by tmux_launch.sh"
+  exit 1
+fi
+
+# And we need the shell to have the the PANOPTES environment
+# setup.
+if [[ -z "$PANDIR" || -z "$POCS" || -z "$PANLOG" || -z "$PAWS" ]] ; then
+  echo "The PANOPTES environment variables must be set."
+  echo "This script should be run from a login shell."
   exit 1
 fi
 
@@ -26,8 +39,8 @@ echo "Running ${BASH_SOURCE[0]} at $(date)"
 # executed). Let's check (PATH and conda info are the giveaway).
 
 echo "Current dir: $(pwd)"
-echo "Current user: ${USER}"
-echo "Current path: ${PATH}"
+echo "USER: ${USER}"
+echo "PATH: ${PATH}"
 echo "PANUSER: ${PANUSER}"
 echo "PANDIR: ${PANDIR}"
 echo "PANLOG: ${PANLOG}"

--- a/scripts/startup/start_panoptes_in_tmux.sh
+++ b/scripts/startup/start_panoptes_in_tmux.sh
@@ -28,7 +28,10 @@ echo "Will log to ${LOG_FILE}"
 
 exec 2> "${LOG_FILE}"  # send stderr to a log file
 exec 1>&2              # send stdout to the same log file
+
 set +x
+# set +x turns off the verbose logging of each line. This makes
+# the following block of echoes easier to read in the log file.
 
 echo "Running ${BASH_SOURCE[0]} at $(date)"
 
@@ -81,6 +84,7 @@ function create_and_init_window() {
     sleep 2s
 }
 
+# Resume verbose logging in order to support debugging these scripts.
 set -x
 
 # We get noisy complaints from astroplan about the IERS Bulletin A

--- a/scripts/startup/start_panoptes_in_tmux.sh
+++ b/scripts/startup/start_panoptes_in_tmux.sh
@@ -96,6 +96,14 @@ create_and_init_window messaging start_messaging_hub.sh
 # Start PAWS, the PANOPTES Administrative Web Server.
 create_and_init_window paws start_paws.sh
 
+# Monitor the PEAS log file.
+create_and_init_window log_peas start_log_viewer.sh \
+    "${PANLOG}/peas_shell-all.log"
+
+# Monitor the POCS log file.
+create_and_init_window log_pocs start_log_viewer.sh \
+    "${PANLOG}/pocs_shell-all.log"
+
 # Start PEAS, the PANOPTES Environmental Analysis System
 # (primarily takes care of reading from the sensors and loading
 # the data into a Mongo Db).
@@ -104,13 +112,5 @@ create_and_init_window peas start_peas.sh
 # Start POCS, the PANOPTES Observatory Control System,
 # the main software we're interested in having running.
 create_and_init_window pocs start_pocs.sh
-
-# Monitor the POCS log file.
-create_and_init_window log_pocs start_log_viewer.sh \
-    "${PANLOG}/pocs_shell-all.log"
-
-# Monitor the PEAS log file.
-create_and_init_window log_peas start_log_viewer.sh \
-    "${PANLOG}/peas_shell-all.log"
 
 exit

--- a/scripts/startup/su_panoptes.sh
+++ b/scripts/startup/su_panoptes.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -ex
+#!/bin/bash -ex
 
 # Start running the script tmux_launch as user $PANUSER in a login
 # shell, i.e. one that will run that user's shell initialization

--- a/scripts/startup/tmux_launch.sh
+++ b/scripts/startup/tmux_launch.sh
@@ -71,7 +71,7 @@ set -x
 
 # Finally, the point of this script: create a detached (-d) tmux session
 # called panoptes (-s), with a scrollback buffer of 5000 lines, where
-# the shell is bash.
+# the shell used by new-window is bash.
 tmux set-option -g history-limit 5000 \; \
      set-option -g default-shell /bin/bash \; \
      new-session -d -s panoptes ./start_panoptes_in_tmux.sh

--- a/scripts/startup/tmux_launch.sh
+++ b/scripts/startup/tmux_launch.sh
@@ -7,11 +7,24 @@
 
 #      tmux attach-session -t panoptes
 
-# This script is intended to be executed in a fully initialized shell
-# (i.e. one in which .profile, .bashrc, etc. have been executed)
+# This script is intended to be executed in a fully initialized bash
+# shell (i.e. one in which .profile, .bashrc, etc. have been executed)
 # because those setup the environment variables needed.
 # In particular, this script can be run by su_panoptes.sh or by
 # a @reboot rule in the crontab of user $PANUSER.
+
+if [[ -z "$BASH_VERSION" ]] ; then
+  echo "This script must be run by bash."
+  exit 1
+fi
+
+# And we need the shell to have the the PANOPTES environment
+# setup.
+if [[ -z "$PANDIR" || -z "$POCS" || -z "$PANLOG" || -z "$PAWS" ]] ; then
+  echo "The PANOPTES environment variables must be set."
+  echo "This script should be run from a login shell."
+  exit 1
+fi
 
 echo "Running ${BASH_SOURCE[0]} at $(date)"
 
@@ -57,8 +70,10 @@ echo 'Shell options ($-):' "$-"
 set -x
 
 # Finally, the point of this script: create a detached (-d) tmux session
-# called panoptes (-s), with a scrollback buffer of 5000 lines.
-tmux set-option -g history-limit 5000 \; new-session -d \
-                -s panoptes ./start_panoptes_in_tmux.sh
+# called panoptes (-s), with a scrollback buffer of 5000 lines, where
+# the shell is bash.
+tmux set-option -g history-limit 5000 \; \
+     set-option -g default-shell /bin/bash \; \
+     new-session -d -s panoptes ./start_panoptes_in_tmux.sh
 
 exit


### PR DESCRIPTION
When cron runs an @reboot rule, only a minimal environment is provided,
and SHELL=/bin/sh. This means that without taking steps, tmux windows
will have sh as their shell, while our startup scripts assume that
the windows are running bash.