### PR TITLE
Fix weather plot bounds

### DIFF
--- a/scripts/plot_weather.py
+++ b/scripts/plot_weather.py
@@ -701,7 +701,13 @@ class WeatherPlotter(object):
             os.makedirs(plot_dir)
 
         print('Saving Figure: {}'.format(plot_filename))
-        self.fig.savefig(plot_filename, dpi=self.dpi, bbox_inches='tight', pad_inches=0.10)
+        self.fig.savefig(
+            plot_filename,
+            dpi=self.dpi,
+            bbox_inches='tight',
+            bbox_extra_artists=[],
+            pad_inches=0.10
+        )
 
 
 def moving_average(interval, window_size):

--- a/scripts/plot_weather.py
+++ b/scripts/plot_weather.py
@@ -705,7 +705,7 @@ class WeatherPlotter(object):
             plot_filename,
             dpi=self.dpi,
             bbox_inches='tight',
-            bbox_extra_artists=[],
+            bbox_extra_artists=[],  # https://github.com/panoptes/POCS/issues/528
             pad_inches=0.10
         )
 


### PR DESCRIPTION
In some situations (computers? matplotlib or numpy versions? we haven't
been able to figure out) the bounding box for the weather plot produces
a plot that is way too wide. See issue for links and this solution.

Closes #528