### PR TITLE
Update guide rate

### DIFF
--- a/pocs/mount/ioptron.py
+++ b/pocs/mount/ioptron.py
@@ -212,7 +212,7 @@ class Mount(AbstractSerialMount):
         self.logger.debug('Setting manual moving rate to max')
         self.query('set_button_moving_rate', 9)
         self.logger.debug("Mount guide rate: {}".format(self.query('get_guide_rate')))
-        self.query('set_guide_rate', '5050')
+        self.query('set_guide_rate', '9090')
         guide_rate = self.query('get_guide_rate')
         self.ra_guide_rate = int(guide_rate[0:2]) / 100
         self.dec_guide_rate = int(guide_rate[2:]) / 100


### PR DESCRIPTION
The guide rate is used to adjust the tracking, which happens between
exposures. Typically guide rates are set at .5 * sidereal because the
correction happens during exposure so movement is minimized. Since we
are out of exposure we want the correction to happen as fast as possible.
.9 * sidereal is max.