### PR TITLE
Adding a basic script for taking a bias frame.

### DIFF
--- a/scripts/take_bias.sh
+++ b/scripts/take_bias.sh
@@ -1,0 +1,29 @@
+#!/bin/bash -e
+
+##################################################
+# Take a bias from
+# 
+# This will change the camera setting to the quickest
+# exposure possible and then take a number of photos
+##################################################
+
+P=$1
+SAVE_FILE=${2:-"bias-%Y%m%d-%H%M%S.cr2"}
+echo "Taking bias frames on port ${P}: ${SAVE_FILE}"
+
+SHUTTER_INDEX=52
+NUM_FRAMES=5
+
+# Set to fast speed
+gphoto2 --port=${P} --set-config-index shutterspeed=${SHUTTER_INDEX}
+
+COUNTER=0
+until [[ ${COUNTER} -eq ${NUM_FRAMES} ]]; do
+	gphoto2 --port=${P} --filename=${SAVE_FILE} --capture-image-and-download
+	let COUNTER+=1
+done
+
+# Set back to bulb
+gphoto2 --port=${P} --set-config-index shutterspeed=0
+
+echo "Done with bias"


### PR DESCRIPTION
This script takes the usb port (as reported by gphoto2) as the first
parameter and an optional second parameter for a filename. Default
filename is timestamped file prefixed with the word `bias-` that is
saved in current directory.

Changes camera settings to fastest possible shutter speed (1/4000s on
the EOS 100D), takes five exposures, then returns the camera to the
bulb setting.

I've had this hanging around for a while and finally cleaned it up a bit. Submitting now so we can possible integrate into camera tests.