### PR TITLE
Coverage calculation accounting for concurrency

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,11 +1,15 @@
 [run]
 branch = True
-concurrency = multiprocessing
+concurrency =
+    multiprocessing
+    threading
+    subprocess
 source =
     peas
     pocs
-omit = 
+omit =
 	pocs/utils/data.py
+parallel = True
 
 [report]
 exclude_lines =

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 cache:
   - pip
 env:
-  - POCS=$TRAVIS_BUILD_DIR PANDIR=/var/panoptes ARDUINO_VERSION=1.8.1
+  - POCS=$TRAVIS_BUILD_DIR PANDIR=/var/panoptes PANUSER=$USER ARDUINO_VERSION=1.8.1
 before_install:
     - sudo mkdir /var/panoptes && sudo chmod 777 /var/panoptes
     - mkdir $PANDIR/logs
@@ -37,17 +37,17 @@ addons:
   apt:
     packages:
     - gphoto2
-    - libcairo2-dev 
-    - libnetpbm10-dev 
+    - libcairo2-dev
+    - libnetpbm10-dev
     - netpbm
     - libpng12-dev
     - libjpeg-dev
     - python-numpy
     - python-pyfits
-    - python-dev 
-    - zlib1g-dev 
-    - libbz2-dev 
-    - swig 
+    - python-dev
+    - zlib1g-dev
+    - libbz2-dev
+    - swig
     - cfitsio-dev
 install:
   - wget http://astrometry.net/downloads/astrometry.net-0.72.tar.gz
@@ -74,8 +74,10 @@ script:
   - arduino --verify --board $BOARD resources/arduino_files/camera_board/camera_board.ino
   - arduino --verify --board $BOARD resources/arduino_files/power_board/power_board.ino
   - arduino --verify --board $BOARD resources/arduino_files/telemetry_board/telemetry_board.ino
+  - export PYTHONPATH="$PYTHONPATH:$TRAVIS_BUILD_DIR/scripts/coverage"
+  - export COVERAGE_PROCESS_START=.coveragerc
   - coverage run $(which pytest) -v
-  - coverage combine .coverage*
+  - coverage combine
 
 after_success:
     - if [[ $TRAVIS_PYTHON_VERSION == 3.6* ]]; then

--- a/scripts/coverage/sitecustomize.py
+++ b/scripts/coverage/sitecustomize.py
@@ -1,0 +1,5 @@
+# Ensure coverage starts for all Python processes so that test coverage is calculated
+# properly when using subprocesses (see https://coverage.readthedocs.io/en/latest/subprocess.html)
+import coverage
+print("Starting coverage")
+coverage.process_startup()


### PR DESCRIPTION
While working on #547 I ran into problems with inaccurate test coverage reports because the existing `coverage` and Travis CI configurations produced results which did not take into account concurrency, in particular scripts started with `subprocess`.  I was able to come up with some changes to the configurations that appear to resolve these problems, and should properly calculate test coverage involving `multiprocessing`, `threading` and `subprocess` concurrency. At @wtgee's suggestion I have split these config changes out into a Pull Request of their own.