### PR TITLE
Pull the state machine file from config by default

### DIFF
--- a/pocs/core.py
+++ b/pocs/core.py
@@ -47,7 +47,7 @@ class POCS(PanStateMachine, PanBase):
     def __init__(
             self,
             observatory,
-            state_machine_file='simple_state_table',
+            state_machine_file=None,
             messaging=False,
             **kwargs):
 
@@ -70,6 +70,9 @@ class POCS(PanStateMachine, PanBase):
         self._sleep_delay = kwargs.get('sleep_delay', 2.5)  # Loop delay
         self._safe_delay = kwargs.get('safe_delay', 60 * 5)  # Safety check delay
         self._is_safe = False
+
+        if state_machine_file is None:
+            state_machine_file = self.config.get('state_machine', 'simple_state_table')
 
         PanStateMachine.__init__(self, state_machine_file, **kwargs)
 


### PR DESCRIPTION
The state machine should come from the config file by default.

For PAN008 (I should start that forum thread) I was having problems running the regular state machine because it currently can't solve image within any reasonable time (among other things). As a result, I created an `imaging` state machine (PR coming soon). This change is in anticipation of that (and to clean up a hack that Huntsman uses in its `huntsman_shell`).