### PR TITLE
Improve testing of pocs.scheduler.field.Field

### DIFF
--- a/pocs/scheduler/field.py
+++ b/pocs/scheduler/field.py
@@ -30,6 +30,8 @@ class Field(FixedTarget, PanBase):
         super().__init__(SkyCoord(position, equinox=equinox, frame='icrs'), name=name, **kwargs)
 
         self._field_name = self.name.title().replace(' ', '').replace('-', '')
+        if not self._field_name:
+            raise ValueError('Name is empty')
 
 
 ##################################################################################################

--- a/pocs/tests/test_field.py
+++ b/pocs/tests/test_field.py
@@ -1,5 +1,8 @@
 import pytest
 
+from astropy import units as u
+from astropy.coordinates import Latitude, Longitude
+
 from pocs.scheduler.field import Field
 
 
@@ -10,7 +13,14 @@ def test_create_field_no_params():
 
 def test_create_field_bad_position():
     with pytest.raises(ValueError):
-        Field("TestObservation", "Bad Position")
+        Field('TestObservation', 'Bad Position')
+
+
+def test_create_field_bad_name():
+    with pytest.raises(ValueError):
+        Field('', '20h00m43.7135s +22d42m39.0645s')
+    with pytest.raises(ValueError):
+        Field(' - ', '20h00m43.7135s +22d42m39.0645s')
 
 
 def test_create_field_name():
@@ -26,3 +36,29 @@ def test_equinox_none():
 def test_create_field_Observation_name():
     field = Field('Test Field - 32b', '20h00m43.7135s +22d42m39.0645s')
     assert field.field_name == 'TestField32B'
+
+
+def test_create_field():
+    names = ['oneWord', 'Two Words', '3 Whole - Words']
+    right_ascensions = [
+        ('20h00m43.7135s', Longitude('20h00m43.7135s', unit=u.degree)),
+        ('0d0m0.0s', Longitude(0, unit=u.degree)),
+        ('-0d0m0.0s', Longitude(0, unit=u.degree)),
+        ('+0d0m0.0s', Longitude(0, unit=u.degree)),
+    ]
+    declinations = [
+        ('22d42m39.0645', Latitude('22d42m39.0645', unit=u.degree)),
+        ('+22d42m39.0645', Latitude('22d42m39.0645', unit=u.degree)),
+        ('-22d42m39.0645', Latitude('-22d42m39.0645', unit=u.degree)),
+        ('0d0m0.0s', Latitude(0, unit=u.degree)),
+        ('+0d0m0.0s', Latitude(0, unit=u.degree)),
+        ('-0d0m0.0s', Latitude(0, unit=u.degree)),
+    ]
+
+    for name in names:
+        for ra_str, ra in right_ascensions:
+            for dec_str, dec in declinations:
+                field = Field(name, '%s %s' % (ra_str, dec_str))
+                assert field.name == name
+                assert field.coord.ra == ra
+                assert field.coord.dec == dec


### PR DESCRIPTION
Require that the field name be non-empty.

This is a precursor to adding support for colon separated hour angle or degree values.