### PR TITLE
Correct pointing option

### DIFF
--- a/conf_files/pocs.yaml
+++ b/conf_files/pocs.yaml
@@ -38,8 +38,8 @@ mount:
     non_sidereal_available: True
 pointing:
     auto_correct: True
-    threshold: 0.05
-    exptime: 30
+    threshold: 0.05 # degrees
+    exptime: 30 # seconds
     max_iterations: 3
 cameras:
     auto_detect: True

--- a/conf_files/pocs.yaml
+++ b/conf_files/pocs.yaml
@@ -38,7 +38,7 @@ mount:
     non_sidereal_available: True
 pointing:
     auto_correct: True
-    threshold: 0.05 # degrees ≈ 180" ≈ 18 pixels 
+    threshold: 500 # arcseconds ~ 50 pixels
     exptime: 30 # seconds
     max_iterations: 3
 cameras:

--- a/conf_files/pocs.yaml
+++ b/conf_files/pocs.yaml
@@ -37,6 +37,7 @@ mount:
         baudrate: 9600
     non_sidereal_available: True
 pointing:
+    auto_correct: True
     threshold: 0.05
     exptime: 30
     max_iterations: 3

--- a/conf_files/pocs.yaml
+++ b/conf_files/pocs.yaml
@@ -38,7 +38,7 @@ mount:
     non_sidereal_available: True
 pointing:
     auto_correct: True
-    threshold: 0.05 # degrees
+    threshold: 0.05 # degrees ≈ 180" ≈ 18 pixels 
     exptime: 30 # seconds
     max_iterations: 3
 cameras:

--- a/conf_files/pocs.yaml
+++ b/conf_files/pocs.yaml
@@ -37,7 +37,7 @@ mount:
         baudrate: 9600
     non_sidereal_available: True
 pointing:
-    auto_correct: True
+    auto_correct: False
     threshold: 500 # arcseconds ~ 50 pixels
     exptime: 30 # seconds
     max_iterations: 3

--- a/pocs/images.py
+++ b/pocs/images.py
@@ -146,12 +146,19 @@ class Image(PanBase):
             self.header_pointing = SkyCoord(ra=float(self.header['RA-MNT']) * u.degree,
                                             dec=float(self.header['DEC-MNT']) * u.degree)
 
-            self.header_ra = self.header_pointing.ra.to(u.hourangle)
+            self.header_ra = self.header_pointing.ra.to(u.degree)
             self.header_dec = self.header_pointing.dec.to(u.degree)
 
-            # Precess to the current equinox otherwise the RA - LST method will be off.
-            self.header_ha = self.header_pointing.transform_to(
-                self.FK5_Jnow).ra.to(u.hourangle) - self.sidereal
+            try:
+                self.header_ha = float(self.header['HA-MNT']) * u.hourangle
+            except KeyError as e:
+                # Compute the HA from the RA and sidereal time.
+                # Precess to the current equinox otherwise the
+                # RA - LST method will be off.
+                # NOTE(wtgee): This conversion doesn't seem to be correct.
+                self.header_ha = self.header_pointing.transform_to(
+                    self.FK5_Jnow).ra.to(u.hourangle) - self.sidereal
+
         except Exception as e:
             self.logger.warning('Cannot get header pointing information: {}'.format(e))
 
@@ -167,11 +174,11 @@ class Image(PanBase):
 
             self.pointing = SkyCoord(ra=ra * u.degree, dec=dec * u.degree)
 
-            self.ra = self.pointing.ra.to(u.hourangle)
+            self.ra = self.pointing.ra.to(u.degree)
             self.dec = self.pointing.dec.to(u.degree)
 
             # Precess to the current equinox otherwise the RA - LST method will be off.
-            self.ha = self.pointing.transform_to(self.FK5_Jnow).ra.to(u.hourangle) - self.sidereal
+            self.ha = self.pointing.transform_to(self.FK5_Jnow).ra.to(u.degree) - self.sidereal
 
     def solve_field(self, **kwargs):
         """ Solve field and populate WCS information

--- a/pocs/mount/mount.py
+++ b/pocs/mount/mount.py
@@ -341,7 +341,7 @@ class AbstractMount(PanBase):
                 }
         """
         pier_side = 'east'
-        if pointing_ha <= 12:
+        if pointing_ha >= 0 and pointing_ha <= 12:
             pier_side = 'west'
 
         self.logger.debug("Mount pier side: {}".format(pier_side))
@@ -388,6 +388,7 @@ class AbstractMount(PanBase):
             if offset_ms > max_time:
                 offset_ms = max_time
 
+            self.logger.debug("{}: {} {:.02f} ms".format(axis, delta_direction, offset_ms))
             axis_corrections[axis] = (offset, offset_ms, delta_direction)
 
         return axis_corrections

--- a/pocs/mount/mount.py
+++ b/pocs/mount/mount.py
@@ -344,7 +344,7 @@ class AbstractMount(PanBase):
         if pointing_ha >= 0 and pointing_ha <= 12:
             pier_side = 'west'
 
-        self.logger.debug("Mount pier side: {}".format(pier_side))
+        self.logger.debug("Mount pier side: {} {:.02f}".format(pier_side, pointing_ha))
 
         axis_corrections = {
             'dec': None,

--- a/pocs/observatory.py
+++ b/pocs/observatory.py
@@ -347,7 +347,7 @@ class Observatory(PanBase):
             except AttributeError:
                 pass
 
-            self.logger.debug("Pointing HA: {}".format(pointing_ha))
+            self.logger.debug("Pointing HA: {:.02f}".format(pointing_ha))
             correction_info = self.mount.get_tracking_correction(
                 self.current_offset_info,
                 pointing_ha

--- a/pocs/observatory.py
+++ b/pocs/observatory.py
@@ -335,8 +335,6 @@ class Observatory(PanBase):
         Here we take the number of arcseconds that the mount is offset and,
         via the `mount.get_ms_offset`, find the number of milliseconds we
         should adjust in a given direction, one for each axis.
-
-        Uses the `rate_adjustment` key from the `self.current_offset_info`
         """
         if self.current_offset_info is not None:
             self.logger.debug("Updating the tracking")

--- a/pocs/state/states/default/pointing.py
+++ b/pocs/state/states/default/pointing.py
@@ -20,7 +20,7 @@ def on_enter(event_data):
     pointing_config = pocs.config['pointing']
     num_pointing_images = pointing_config.get('max_iterations', 3)
     should_correct = pointing_config.get('auto_correct', False)
-    pointing_threshold = pointing_config.get('threshold', False)
+    pointing_threshold = pointing_config.get('threshold', 0.05)  # degrees
 
     try:
         pocs.say("Taking pointing picture.")

--- a/pocs/state/states/default/pointing.py
+++ b/pocs/state/states/default/pointing.py
@@ -21,6 +21,7 @@ def on_enter(event_data):
     num_pointing_images = pointing_config.get('max_iterations', 3)
     should_correct = pointing_config.get('auto_correct', False)
     pointing_threshold = pointing_config.get('threshold', 0.05)  # degrees
+    exptime = pointing_config.get('exptime', 30)  # seconds
 
     try:
         pocs.say("Taking pointing picture.")
@@ -46,7 +47,7 @@ def on_enter(event_data):
                         camera_event = camera.take_observation(
                             observation,
                             fits_headers,
-                            exp_time=30.,
+                            exp_time=exptime,
                             filename='pointing{:02d}'.format(img_num)
                         )
 

--- a/pocs/state/states/default/pointing.py
+++ b/pocs/state/states/default/pointing.py
@@ -6,8 +6,6 @@ from pocs.utils import error
 wait_interval = 3.
 timeout = 150.
 
-num_pointing_images = 2
-
 
 def on_enter(event_data):
     """Pointing State
@@ -17,6 +15,12 @@ def on_enter(event_data):
     pocs = event_data.model
 
     pocs.next_state = 'parking'
+
+    # Get pointing parameters
+    pointing_config = pocs.config['pointing']
+    num_pointing_images = pointing_config.get('max_iterations', 3)
+    should_correct = pointing_config.get('auto_correct', False)
+    pointing_threshold = pointing_config.get('threshold', False)
 
     try:
         pocs.say("Taking pointing picture.")
@@ -29,9 +33,11 @@ def on_enter(event_data):
         fits_headers['POINTING'] = 'True'
         pocs.logger.debug("Pointing headers: {}".format(fits_headers))
 
+        # Loop over maximum number of pointing iterations
         for img_num in range(num_pointing_images):
             camera_events = dict()
 
+            # Take pointing image with primary camera
             for cam_name, camera in pocs.observatory.cameras.items():
                 if camera.is_primary:
                     pocs.logger.debug("Exposing for camera: {}".format(cam_name))
@@ -49,6 +55,7 @@ def on_enter(event_data):
                     except Exception as e:
                         pocs.logger.error("Problem waiting for images: {}".format(e))
 
+            # Wait for images to complete
             wait_time = 0.
             while not all([event.is_set() for event in camera_events.values()]):
                 pocs.check_messages()
@@ -65,8 +72,9 @@ def on_enter(event_data):
                 sleep(wait_interval)
                 wait_time += wait_interval
 
+            # Analyze pointing
             if pocs.observatory.current_observation is not None:
-                pointing_id, pointing_path = pocs.observatory.current_observation.last_exposure
+                pointing_id, pointing_path = observation.last_exposure
                 pointing_image = Image(
                     pointing_path,
                     location=pocs.observatory.earth_location
@@ -84,13 +92,16 @@ def on_enter(event_data):
 
                 separation = pointing_image.pointing_error.magnitude.value
 
-                if separation > pocs.config.get('pointing_threshold', 0.05):
-                    pocs.say("I'm still a bit away from the field so I'm going to get a bit closer.")
+                # Correct the pointing
+                if should_correct and separation > pointing_threshold:
+                    pocs.say("I'm still a bit away from the field so I'm going to get closer.")
 
                     # Tell the mount we are at the field, which is the center
                     pocs.say("Syncing with the latest image...")
                     has_field = pocs.observatory.mount.set_target_coordinates(pointing_image.pointing)
                     pocs.logger.debug("Coords set, calibrating")
+
+                    # Sync the mount
                     pocs.observatory.mount.query('calibrate_mount')
 
                     # Now set back to field
@@ -99,6 +110,10 @@ def on_enter(event_data):
                             pocs.logger.debug("Slewing back to target")
                             pocs.observatory.mount.set_target_coordinates(observation.field)
                             pocs.observatory.mount.slew_to_target()
+                else:
+                    # Either we want to correct pointing or we are close enough
+                    # so we stop the pointing loop correction.
+                    break
 
         pocs.next_state = 'tracking'
 


### PR DESCRIPTION
This adds an `auto_correct` option to the pointing configuration that will "sync" the mount with the current coordinates in an attempt to minimize the pointing error.

See also #579, #340 

Note: we used this by default for a long time then removed it as we were debugging pointing/tracking issues on PAN001. I've added it back to PAN001 and have been using it recently.

Edit: this also includes a fix to the pointing headers which is actually used in tracking.