### PR TITLE
Support both old and new Google Cloud libraries

### DIFF
--- a/pocs/utils/google/storage.py
+++ b/pocs/utils/google/storage.py
@@ -2,11 +2,11 @@ import os
 import re
 
 # Supporting a change in Google Cloud libraries by trying imports both ways:
-try:
+try:  # pragma: no cover
     # New way:
     from google.cloud import storage
     from google.cloud.exceptions import Forbidden
-except:
+except ImportError:  # pragma: no cover
     # Old way:
     from gcloud import storage
     from gcloud.exceptions import Forbidden

--- a/pocs/utils/google/storage.py
+++ b/pocs/utils/google/storage.py
@@ -1,8 +1,16 @@
 import os
 import re
 
-from gcloud import storage
-from gcloud.exceptions import Forbidden
+# Supporting a change in Google Cloud libraries by trying imports both ways:
+try:
+    # New way:
+    from google.cloud import storage
+    from google.cloud.exceptions import Forbidden
+except:
+    # Old way:
+    from gcloud import storage
+    from gcloud.exceptions import Forbidden
+
 
 from pocs.utils import error
 from pocs.utils.logger import get_root_logger


### PR DESCRIPTION
It appears that the Python package gcloud has been
replaced by google.cloud. This change allows for both
packages to be used until we update all units.