### PR TITLE
Fix install-dependencies.sh for Ubuntu 18.04

### DIFF
--- a/scripts/install/apt-packages-list.txt
+++ b/scripts/install/apt-packages-list.txt
@@ -73,3 +73,8 @@ grc
 # almost certainly already installed, but let's make sure.
 coreutils
 
+# Want git for upgrading to the latest version. Probably already installed
+# but not necessarily (i.e. it is possible to download a zip of POCS, which
+# includes this file).
+git
+

--- a/scripts/install/apt-packages-list.txt
+++ b/scripts/install/apt-packages-list.txt
@@ -68,3 +68,8 @@ ffmpeg
 
 # Used for colorizing log files.
 grc
+
+# GNU coreutils provides basic commands that we depend on (echo, ls), and is
+# almost certainly already installed, but let's make sure.
+coreutils
+

--- a/scripts/install/install-dependencies.sh
+++ b/scripts/install/install-dependencies.sh
@@ -890,8 +890,7 @@ echo "
 Installation complete. Please run these commands:
       source ${PANOPTES_ENV_SH}
       cd \$POCS
-      python setup.py install
-      pytest
+      python setup.py install ; pytest
 None of the tests should fail.
 "
 

--- a/scripts/install/install-dependencies.sh
+++ b/scripts/install/install-dependencies.sh
@@ -773,12 +773,10 @@ fi
 rmdir --ignore-fail-on-non-empty "${PANDIR}/tmp"
 
 set +x
+
 echo
 echo_bar
 echo_bar
-echo "
-Installation complete.
-"
 
 if [[ "${PROFILE_HAS_BEEN_CHANGED}" -eq 1 || \
       "${DID_CHANGE_CONDA}" -eq 1 || "${HAD_PANOPTES_ENV}" -eq 0 ]] ; then
@@ -791,9 +789,19 @@ if [[ "${PROFILE_HAS_BEEN_CHANGED}" -eq 1 || \
   if [[ "${DID_CHANGE_CONDA}" -eq 1 || "${HAD_PANOPTES_ENV}" -eq 0 ]] ; then
     echo "Your Python environment has been modified."
   fi
-  echo "Please log out and back in again to pickup the changes."
+  echo "Please log out and back in again to pickup the changes,
+then re-run this script, which should leave you ready for testing.
+"
   tput rmso  # Exit standout mode
   echo
+else
+  echo "
+Installation complete. Please run these commands:
+      cd $POCS
+      python setup.py install
+      pytest
+All of the tests should pass.
+"
 fi
 
 exit

--- a/scripts/install/install-dependencies.sh
+++ b/scripts/install/install-dependencies.sh
@@ -315,7 +315,7 @@ export PANLOG="${PANLOG}"
 export PANUSER="${USER}"
 
 # Configure the conda environment:
-. "${PANDIR}/miniconda/etc/profile.d/conda.sh"
+. "\${PANDIR}/miniconda/etc/profile.d/conda.sh"
 conda activate panoptes-env
 
 # Add astrometry to the path.

--- a/scripts/install/install-dependencies.sh
+++ b/scripts/install/install-dependencies.sh
@@ -319,7 +319,7 @@ export PANUSER="${USER}"
 conda activate panoptes-env
 
 # Add astrometry to the path.
-PATH="${ASTROMETRY_DIR}/bin:${PATH}"
+PATH="${ASTROMETRY_DIR}/bin:\${PATH}"
 
 END_OF_FILE
   # We allow for other (optional) commands to be added by adding to

--- a/scripts/install/install-dependencies.sh
+++ b/scripts/install/install-dependencies.sh
@@ -1,6 +1,9 @@
 #!/bin/bash -e
 
-THIS_DIR="$(dirname $(readlink -f "${0}"))"
+# Run with --help to see your options. With no options, does a complete install
+# of dependencies, though attempts to reuse existing installs.
+
+THIS_DIR="$(dirname "$(readlink -f "${0}")")"
 THIS_PROGRAM="$(basename "${0}")"
 
 if [[ -z "${PANDIR}" || -z "${POCS}" || -z "${PAWS}" || -z "${PANLOG}" ||
@@ -9,13 +12,11 @@ if [[ -z "${PANDIR}" || -z "${POCS}" || -z "${PAWS}" || -z "${PANLOG}" ||
   exit 1
 fi
 
-mkdir -p "${PANDIR}"
-cd "${PANDIR}"
-
-# TODO(jamessynge): Add flags to control behavior, such as skipping apt-get.
-
 ASTROMETRY_VERSION="0.72"
 INSTALL_PREFIX="/usr/local"
+CONDA_INSTALL_DIR="${PANDIR}/miniconda"
+TIMESTAMP="$(date "+%Y%m%d.%H%M%S")"
+INSTALL_LOGS_DIR="${PANDIR}/logs/install/${TIMESTAMP}"
 
 DO_APT_GET=1
 DO_MONGODB=1
@@ -26,70 +27,208 @@ DO_CFITSIO=0  # Disabled in favor of installing with apt-get.
 DO_ASTROMETRY=1
 DO_ASTROMETRY_INDICES=1
 DO_PIP_REQUIREMENTS=1
+DO_RUN_ONE_FUNCTION=""
 
+# Which bash file do we need to modify? The last found here is the one that
+# bash executes for login shells, and so provides the environment for
+# all processes under that. THE_PROFILE_TARGET represents the point before
+# which we should insert lines.
+THE_PROFILE="${HOME}/.profile"
+THE_PROFILE_TARGET="# if running bash"
+if [[ -f "${HOME}/.bash_login" ]] ; then
+  THE_PROFILE="${HOME}/.bash_login"
+  THE_PROFILE_TARGET=""
+fi
+if [[ -f "${HOME}/.bash_profile" ]] ; then
+  THE_PROFILE="${HOME}/.bash_profile"
+  THE_PROFILE_TARGET=""
+fi
+PROFILE_HAS_BEEN_CHANGED=0
+
+#-------------------------------------------------------------------------------
+
+function show_help() {
+  echo "${THIS_PROGRAM} - Install software needed for PANOPTES.
+
+${THIS_PROGRAM} [options]
+
+options:
+-h, --help                 show brief help
+-x                         turn on bash debug output
+--run <function>           run the named function and exit, for debugging
+--no-apt-get               don't run apt-get to install Linux packages
+--no-mongodb               don't install and start mongodb server
+--no-cfitsio               don't install the latest version of cfitsio
+--no-conda                 don't install the latest version of Anaconda
+--no-conda-packages        don't install packages into Anaconda
+--rebuild-conda-env        rebuild the panoptes-env
+--no-astrometry            don't install astrometry.net software
+--no-astrometry-indices    don't install astrometry.net indices
+--no-pip-requirements      don't install python packages"
+}
+
+# Parse the command line args.
+while test ${#} -gt 0; do
+  case "${1}" in
+    -h|--help)
+      show_help
+      exit 0
+      ;;
+    -x)
+      set -x
+      shift
+      ;;
+    --run)
+      if [ $# -lt 2 ]; then
+        echo "Function name missing after ${1}."
+        show_help
+        exit 1
+      fi
+      shift
+      DO_RUN_ONE_FUNCTION="${1}"
+      shift
+      ;;
+    --no-apt-get)
+      DO_APT_GET=0
+      shift
+      ;;
+    --no-mongodb)
+      DO_MONGODB=0
+      shift
+      ;;
+    --no-cfitsio)
+      DO_CFITSIO=0
+      shift
+      ;;
+    --no-conda)
+      DO_CONDA=0
+      shift
+      ;;
+    --rebuild-conda-env)
+      DO_REBUILD_CONDA_ENV=1
+      shift
+      ;;
+    --no-conda-packages)
+      DO_INSTALL_CONDA_PACKAGES=0
+      shift
+      ;;
+    --no-pip-requirements)
+      DO_PIP_REQUIREMENTS=0
+      shift
+      ;;
+    --no-astrometry)
+      DO_ASTROMETRY=0
+      shift
+      ;;
+    --no-astrometry-ind*)
+      DO_ASTROMETRY_INDICES=0
+      shift
+      ;;
+    *)
+      echo "Unknown parameter: ${1}"
+      echo
+      show_help
+      exit 1
+      ;;
+  esac
+done
+
+#-------------------------------------------------------------------------------
+
+# Print a separator bar of # characters.
 function echo_bar() {
-  eval $(resize|grep COLUMNS=)
+  if [[ -n "$(which resize)" ]] ; then
+    eval "$(resize|grep COLUMNS=)"
+  elif [[ -n "$(which stty)" ]] ; then
+    COLUMNS="$(stty size | cut '-d ' -f2)"
+  fi
   printf "%${COLUMNS:-80}s\n" | tr ' ' '#'
 }
 
-# Append $1 to .profile 
-function add_to_profile() {
-  local -r the_line="${1}"
-  local -r the_file="${HOME}/.profile"
-  if [[ ! -f "${the_file}" ]] ; then
-    touch "${the_file}"
-  fi
-  if [[ -z "$(fgrep -- "${the_line}" "${the_file}")" ]] ; then
-    echo >>"${the_file}" "
-# Added by PANOPTES install-dependencies.sh
-${the_line}"
-    echo "Appended to ${the_file}: ${the_line}"
-  else
-    echo "Already in ${the_file}: ${the_line}"
+# If the desired profile file doesn't exist, create it.
+function ensure_profile_exists() {
+  if [[ ! -f "${THE_PROFILE}" ]] ; then
+    touch "${THE_PROFILE}"
+    PROFILE_HAS_BEEN_CHANGED=1
   fi
 }
 
-# Append $1 to PATH and write command to do the same to .profile.
+# Return a status code indicating whether the profile file contains the
+# text in the first arg to this function (true if contains, false otherwise).
+function profile_contains_text() {
+  local -r target_text="${1}"
+  if grep -F -q -- "${target_text}" "${THE_PROFILE}" ; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+# Add the text of the first arg to the profile file, just before the appropriate
+# target line, unless the text is already in the file.
+function add_to_profile_before_target() {
+  local -r new_text="${1}"
+  local -r target_text="${2:-${THE_PROFILE_TARGET}}"
+  if profile_contains_text "${new_text}" ; then
+    echo "Already in ${THE_PROFILE}: ${new_text}"
+    return 0
+  fi
+  ensure_profile_exists
+  # This backup is just for debugging (i.e. showing the before and after
+  # diff).
+  local -r the_backup="$(mktemp "${THE_PROFILE}.pre-edit.XXXXX")"
+  cp -p "${THE_PROFILE}" "${the_backup}"
+  if [[ -n "${target_text}" ]] && \
+     profile_contains_text "${target_text}" ; then
+    # Add just before the target text.
+    # Warning, this isn't a very good sed script. It actually performs
+    # the insert before every occurrence of the target text. Sigh.
+    sed -i "/${target_text}/i \
+# Added by PANOPTES install-dependencies.sh\n\
+${new_text}\n" "${THE_PROFILE}"
+  else
+    # Append to the end of the file.
+    echo >>"${THE_PROFILE}" "
+# Added by PANOPTES install-dependencies.sh
+${new_text}"
+  fi
+  PROFILE_HAS_BEEN_CHANGED=1
+  # Again, this diff is just for debugging.
+  echo "Modified ${THE_PROFILE}:"
+  echo
+  diff -u "${the_backup}" "${THE_PROFILE}" || /bin/true
+  echo
+  rm "${the_backup}"
+}
+
+# Append $1 to PATH and write command to do the same to the profile file.
 function add_to_PATH() {
   local -r the_dir="$(readlink -f "${1}")"
-  add_to_profile "PATH=\"${the_dir}:\${PATH}\""
+  add_to_profile_before_target "PATH=\"${the_dir}:\${PATH}\""
   PATH="${the_dir}:${PATH}"
-
-  return 0
-
-  local -r the_file="${HOME}/.profile"
-  if [[ ! -f "${the_file}" ]] ; then
-    touch "${the_file}"
-  fi
-  if [[ -z "$(egrep -- "PATH=.*${the_dir}" "${the_file}")" ]] ; then
-    echo >>"${the_file}" "
-# Added by PANOPTES install-dependencies.sh
-PATH=\"${the_dir}:\${PATH}\""
-    PATH="${the_dir}:${PATH}"
-    echo
-    echo "Added ${the_dir} to PATH in ${the_file}"
-  else
-    echo "${the_file} already adds ${the_dir} to PATH"
-  fi
 }
 
 # Given the path to a pkg-config file (.pc), extract the version number.
 function extract_version_from_pkg_config() {
   if [[ -f "${1}" ]] ; then
-    egrep '^Version:' "${1}" | cut '-d:' -f2
+    grep -E '^Version:' "${1}" | cut '-d:' -f2
   else
     echo ""
   fi
 }
 
+# Install all of the packages specified in the apt-packages-list file.
 function install_apt_packages() {
+  echo
+  echo "Running sudo apt-get update, you may be prompted for your password."
+  echo
+  (set -x ; sudo apt-get update)
   # Remove all the comments from the package list and install the packages whose
   # names are left.
   APT_PKGS="$(cut '-d#' -f1 "${THIS_DIR}/apt-packages-list.txt" | sort | uniq)"
   echo
   echo "Running sudo apt-get install, you may be prompted for your password."
   echo
-  (set -x ; sudo apt-get update)
   (set -x ; sudo apt-get install --yes ${APT_PKGS})
 }
 
@@ -160,27 +299,123 @@ function maybe_install_mongodb() {
   fi
 }
 
-# Install miniconda (conda with no additional packages); we can then select
-# the set to install.
+# Install latest version of Miniconda (Anaconda with very few packages; any that
+# are needed can then be installed).
 function install_conda() {
-  local -r the_script="${PANDIR}/tmp/miniconda.sh"
+  local -r the_destination="${CONDA_INSTALL_DIR}"
+  if [[ -d "${the_destination}" ]] ; then
+    echo_bar
+    echo
+    echo "Removing previous miniconda installation from ${the_destination}"
+    rm -rf "${the_destination}"
+  fi
+
   echo_bar
   echo
   echo "Installing miniconda. License at: https://conda.io/docs/license.html"
+  local -r the_script="${PANDIR}/tmp/miniconda.sh"
   wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
        -O "${the_script}"
-  bash "${the_script}" -b -p "${PANDIR}/miniconda"
+  bash "${the_script}" -b -p "${the_destination}"
   rm "${the_script}"
-  add_to_PATH miniconda/bin
+
+  # As per the Anaconda 4.4 release notes, one is supposed to add the following
+  # to .bash_profile, .bashrc or wherever is appropriate:
+  #    . $CONDA_LOCATION/etc/profile.d/conda.sh
+  #    conda activate <name-of-desired-environment>
+  # Where CONDA_LOCATION is where Anaconda or miniconda was installed.
+  # We do the first step here. Later we'll activate the PANOPTES environment.
+
+  add_to_profile_before_target \
+      ". ${the_destination}/etc/profile.d/conda.sh"
+  . ${the_destination}/etc/profile.d/conda.sh
 }
 
-function install_conda_if_missing() {
-  # Intall latest version of Miniconda (Anaconda with
-  # fewer packages; any that are needed can then be installed).
-  CONDA_BIN="$(which conda)"  # Assuming is a python3 version if found.
-  if [[ -z "${CONDA_BIN}" ]] ; then
-    install_conda
+# Add additional repositories in which conda should search for packages.
+function add_conda_channels() {
+  # Add the astropy channel, i.e. an additional repository in which to
+  # look for packages. With conda 4.1.0 and later, by default the highest
+  # priority repository that contains a package is used as the source for
+  # that package, even if there is a newer version in a lower priority
+  # package. And by default the most recently added repository is treated
+  # as the highest priority repository. Here we use prepend to be clear
+  # that we want astropy to be highest priority.
+  if (conda config --show channels | grep -F -q astropy) ; then
+    conda config --remove channels astropy
   fi
+  conda config --prepend channels astropy
+
+  # And put conda-forge at the back of the line.
+  if (conda config --show channels | grep -F -q conda-forge) ; then
+    conda config --remove channels conda-forge
+  fi
+  conda config --append channels conda-forge
+}
+
+# Prepare the conda environment for PANOPTES.
+function prepare_panoptes_conda_env() {
+  # Use the base Anaconda environment until we're ready to
+  # work with the PANOPTES environment.
+  conda activate base
+
+  # Determine if the PANOPTES environment already exists.
+  local do_create_conda_env=0
+  if [[ -z "$(conda info --envs | grep panoptes-env)" ]] ; then
+    do_create_conda_env=1
+  elif [[ "${DO_REBUILD_CONDA_ENV}" -eq 1 ]] ; then
+    conda remove --all --yes --quiet -n panoptes-env
+    do_create_conda_env=1
+  fi
+
+  # Create the PANOPTES environment if necessary.
+  if [[ "${do_create_conda_env}" -eq 1 ]] ; then
+    echo_bar
+    echo
+    echo "Creating conda environment 'panoptes-env' with Python 3.6"
+    # 3.6 works around a problem building astroscrappy in 3.7.
+    conda create -n panoptes-env --yes --quiet python=3.6
+  fi
+
+  if [[ "${DO_INSTALL_CONDA_PACKAGES}" -eq 1 ]] ; then
+    echo_bar
+    echo
+    echo "Installing panoptes-env packages."
+    conda install -n panoptes-env --yes --quiet "--file=${THIS_DIR}/conda-packages-list.txt"
+
+    echo_bar
+    echo
+    echo "Updating all panoptes-env packages."
+    conda update -n panoptes-env --yes --quiet --all
+  fi
+
+  # Activate the PANOPTES environment at login.
+  add_to_profile_before_target "conda activate panoptes-env"
+}
+
+function safe_type() {
+  type $1 2>/dev/null || /bin/true
+}
+
+# Install conda if we can't find it. Note that starting with version
+# 4.4, conda's bin directory is not on the path, so 'which conda'
+# can't be used to determine if it is present.
+function install_conda_if_missing() {
+  # Just in case conda isn't setup, but exists...
+  local -r conda_sh="${CONDA_INSTALL_DIR}/etc/profile.d/conda.sh"
+  if [[ -z "$(safe_type conda)" && -f "${conda_sh}" ]] ; then
+    . "${conda_sh}"
+  fi
+  if [[ -z "$(safe_type conda)" ]] ; then
+    install_conda
+  else
+    echo_bar
+    echo
+    echo "Reusing existing conda installation ($(conda --version)):" "${_CONDA_ROOT}"
+  fi
+  echo_bar
+  echo
+  echo "Updating base conda."
+  conda update -n base --yes --quiet conda
 }
 
 # Fetches and configures the latest version of cfitsio; this allows us to
@@ -255,221 +490,165 @@ function install_latest_cfitsio() {
 
 # Downloads astrometry version ${ASTROMETRY_VERSION} into a temp directory,
 # then builds and installs into ${PANDIR}/astrometry.
-# TODO(jamessynge): Discuss whether to build directly in ${PANDIR}/astrometry,
-# or instead installing into /usr/local as we do with cfitsio.
+# TODO(jamessynge): Discuss whether to continue installing directly in
+# ${PANDIR}/astrometry, or to instead install into /usr/local as we do
+# with cfitsio.
+# TODO(jamessynge): Come up with a way to determine if the installed version
+# is the same as the new version: i.e. skip the build and install if it isn't
+# trivially apparent that something has changed; the user can always wipe out
+# the dir if necessary to force the matter.
 function install_astrometry() {
   local -r DIR="astrometry.net-${ASTROMETRY_VERSION}"
   local -r FN="${DIR}.tar.gz"
   local -r URL="http://astrometry.net/downloads/${FN}"
   local -r SCRATCH_DIR="$(mktemp -d "${TMPDIR:-/tmp/}install-astrometry.XXXXXXXXXXXX")"
   local -r INSTALL_TO="${PANDIR}/astrometry"
+  local -r make_log="${INSTALL_LOGS_DIR}/make-astrometry.log"
+  local -r make_py_log="${INSTALL_LOGS_DIR}/make-astrometry-py.log"
+  local -r make_install_log="${INSTALL_LOGS_DIR}/make-astrometry-install.log"
   cd "${SCRATCH_DIR}"
 
   echo_bar
-  echo  
+  echo
   echo "Fetching astrometry into directory $(pwd)"
-
   wget "${URL}"
-  tar zxvf "${FN}"
+  tar zxf "${FN}"
   cd "${DIR}"
 
-  echo "Building ${DIR}"
-  make
-  make py
+  echo_bar
+  echo
+  echo "Building astrometry, logging to ${make_log}"
+  make >"${make_log}" 2>&1
+
+  echo_bar
+  echo
+  echo "Building astrometry python support, logging to ${make_py_log}"
+  make py >"${make_py_log}" 2>&1
+
+  echo_bar
+  echo
+  echo "Installing built astrometry into directory ${INSTALL_TO},"
+  echo "and logging to ${make_install_log}"
   if [[ -d "${INSTALL_TO}" ]] ; then
     rm -rf "${INSTALL_TO}"
   fi
   mkdir -p "${INSTALL_TO}"
-  echo "Installing into ${INSTALL_TO}"
-  make install "INSTALL_DIR=${INSTALL_TO}"
+  make install "INSTALL_DIR=${INSTALL_TO}" >"${make_install_log}" 2>&1
 
   add_to_PATH "${INSTALL_TO}/bin"
   cd "${PANDIR}"
   rm -rf "${SCRATCH_DIR}"
 }
 
+# Run a POCS script for installing the indices used by astrometry
+# to solve fields.
 function install_astrometry_indices() {
+  echo_bar
+  echo
+  echo "Fetching astrometry and other indices."
   mkdir -p "${PANDIR}/astrometry/data"
   python "${POCS}/pocs/utils/data.py"
 }
 
 #-------------------------------------------------------------------------------
+# Do what the user asked us to do...
 
-function show_help() {
-  echo "${THIS_PROGRAM} - Install software needed for PANOPTES."
-  echo " "
-  echo "${THIS_PROGRAM} [options]"
-  echo " "
-  echo "options:"
-  echo "-h, --help                 show brief help"
-  echo "-x                         turn on bash debug output"
-  echo "--run <function>           run the named function and exit, for debugging"
-  echo "--no-apt-get               don't run apt-get to install Linux packages"
-  echo "--no-mongodb               don't install and start mongodb server"
-  echo "--no-cfitsio               don't install the latest version of cfitsio"
-  echo "--no-conda                 don't install the latest version of Anaconda"
-  echo "--no-conda-packages        don't install packages into Anaconda"
-  echo "--rebuild-conda-env        rebuild the panoptes-env"
-  echo "--no-astrometry            don't install astrometry.net software"
-  echo "--no-astrometry-indices    don't install astrometry.net indices"
-  echo "--no-pip-requirements      don't install python packages"
-}
-
+mkdir -p "${PANDIR}"
 cd "${PANDIR}"
 mkdir -p tmp
+mkdir -p "${INSTALL_LOGS_DIR}"
 
-while test ${#} -gt 0; do
-  case "${1}" in
-    -h|--help)
-      show_help
-      exit 0
-      ;;
-    -x)
-      set -x
-      shift
-      ;;
-    --run)
-      if [ $# -lt 2 ]; then
-        echo "Function name missing after ${1}."
-        show_help
-        exit 1
-      fi
-      shift
-      (${1})
-      exit
-      ;;
-    --no-apt-get)
-      DO_APT_GET=0
-      shift
-      ;;
-    --no-mongodb)
-      DO_MONGODB=0
-      shift
-      ;;
-    --no-cfitsio)
-      DO_CFITSIO=0
-      shift
-      ;;
-    --no-conda)
-      DO_CONDA=0
-      shift
-      ;;
-    --rebuild-conda-env)
-      DO_REBUILD_CONDA_ENV=1
-      shift
-      ;;
-    --no-conda-packages)
-      DO_INSTALL_CONDA_PACKAGES=0
-      shift
-      ;;
-    --no-pip-requirements)
-      DO_PIP_REQUIREMENTS=0
-      shift
-      ;;
-    --no-astrometry)
-      DO_ASTROMETRY=0
-      shift
-      ;;
-    --no-astrometry-ind*)
-      DO_ASTROMETRY_INDICES=0
-      shift
-      ;;
-    *)
-      echo "Unknown parameter: ${1}"
-      echo
-      show_help
-      exit 1
-      ;;
-  esac
-done
+# For testing, run the named function in a sub-shell, then exit.
+if [[ -n "${DO_RUN_ONE_FUNCTION}" ]] ; then
+  ("${DO_RUN_ONE_FUNCTION}")
+  exit
+fi
 
-
+# Install packages using the APT package manager. Works on Debian based systems,
+# including Ubuntu.
 if [[ "${DO_APT_GET}" -eq 1 ]] ; then
   install_apt_packages
 fi
 
-
+# Install Mongodb, a document database. Used by POCS for storing environment
+# readings, from which weather plots are generated.
 if [[ "${DO_MONGODB}" -eq 1 ]] ; then
   maybe_install_mongodb
 fi
 
-
+# Install Conda, a Python package manager from Anaconda, Inc. Supports both
+# pure Python packages (just as pip does) and packages with non-Python parts
+# (e.g. native libraries).
 if [[ "${DO_CONDA}" -eq 1 ]] ; then
   install_conda_if_missing
 fi
 
-
-# Make sure we use the correct Anaconda environment.
-DO_CREATE_CONDA_ENV=0
-if [[ -z "$(conda info --envs | grep panoptes-env)" ]] ; then
-  DO_CREATE_CONDA_ENV=1
-elif [[ "${DO_REBUILD_CONDA_ENV}" -eq 1 ]] ; then
-  source activate root
-  conda remove --all --yes --quiet -n panoptes-env
-  DO_CREATE_CONDA_ENV=1
-fi
-if [[ "${DO_CREATE_CONDA_ENV}" -eq 1 ]] ; then
-  conda create --yes -n panoptes-env python=3
+if [[ "${DO_CREATE_CONDA_ENV}" -eq 1 || \
+      "${DO_REBUILD_CONDA_ENV}" -eq 1 || \
+      "${DO_INSTALL_CONDA_PACKAGES}" -eq 1 ]] ; then
+  prepare_panoptes_conda_env
 fi
 
-add_to_profile "source activate panoptes-env"
-source activate panoptes-env
-
-if [[ "${DO_CONDA}" -eq 1 || "${DO_CREATE_CONDA_ENV}" -eq 1 || \
-      "${DO_PIP_REQUIREMENTS}" -eq 1 ]] ; then
+if [[ -z "$(which conda)" ]] ; then
   echo_bar
-  echo
-  echo "Updating conda installation."
-  conda update --quiet --all --yes
+  echo "
+Error: conda is not installed, but remaining installation steps make
+use of the conda environment for PANOPTES (panoptes-env).
+"
+  exit 1
 fi
 
+# Activate the PANOPTES environment in this shell.
+conda activate panoptes-env
 
-if [[ "${DO_INSTALL_CONDA_PACKAGES}" -eq 1 ]] ; then
-  echo_bar
-  echo
-  echo "Installing conda packages"
-  conda install --yes "--file=${THIS_DIR}/conda-packages-list.txt"
-fi
-
-
+# Install pure Python packages using pip; note that we prefer to
+# install these with conda if they are available that way, as we
+# try to reduce the number of package managers and repositories
+# we have to deal with.
 if [[ "${DO_PIP_REQUIREMENTS}" -eq 1 ]] ; then
-  # Upgrade pip itself before installing other python packages.
+  echo_bar
+  echo
+  echo "Upgrading pip before installing other python packages."
   pip install -U pip
-  # TODO(jamessynge): Move this script and needed text files into an install
-  # directory.
-  # TODO(wtgee): Consider whether to inline the needed text files into this
-  # file, and add git clone of the PANOPTES repos, so that the user can do
-  # an install with just about two commands (wget script, then run script).
+
+  echo_bar
+  echo
+  echo "Installing python packages using pip."
   pip install -r "${POCS}/requirements.txt"
 fi
 
-
+# Install cfitsio, native tools for reading and writing FITS files.
 if [[ "${DO_CFITSIO}" -eq 1 ]] ; then
   install_latest_cfitsio
 fi
 
-
+# Install the astrometry.net software package, enabling plate-solving
+# of images captured by a PANOPTES unit.
 if [[ "${DO_ASTROMETRY}" -eq 1 ]] ; then
   (install_astrometry)
 fi
-
-
 if [[ "${DO_ASTROMETRY_INDICES}" -eq 1 ]] ; then
   (install_astrometry_indices)
 fi
 
-
-cd "${PANDIR}"
+# Cleanup the tmp directory, but only if it is empty.
 rmdir --ignore-fail-on-non-empty "${PANDIR}/tmp"
 
 set +x
 echo
 echo_bar
 echo_bar
-echo
-echo "Remember to update PATH in your shell before running tests"
-echo "and to run \"source activate panoptes-env\""
-echo
+echo "
+Installation complete.
+"
+
+if [[ "${PROFILE_HAS_BEEN_CHANGED}" -eq 1 ]] ; then
+  echo "
+Your shell initialization script ($THE_PROFILE) has been
+modified. Please log out and back in again to pickup the
+changes.
+
+"
+fi
 
 exit
-

--- a/scripts/install/install-dependencies.sh
+++ b/scripts/install/install-dependencies.sh
@@ -761,7 +761,7 @@ orig_panoptes_env_checksum="$(checksum_panoptes_env)"
 # Before installing conda, figure out if the calling shell had the correct
 # environment setup.
 had_activated_panoptes_env=0
-if panoptes_env_is_activated ; then
+if is_panoptes_env_activated ; then
   had_activated_panoptes_env=1
 fi
 


### PR DESCRIPTION
- Update for conda 4.4
- Avoid astroscrappy build problem by requiring Python 3.6
- Make the install process quieter by logging the output of
  the astrometry make commands, instead flooding the terminal
  with content most folks won't care about.
- Add some more context messages to the output.
- Create an logs/install directory specific to this install.- Move all of the command line arg handling to the start of the
file.
- Add comments to most functions.
- Apply most fixes suggested by shellcheck, e.g. quoting
  variable expansions and replacing fgrep with grep -F.
- Insert changes into the appropriate file used by the shell
  at login.
