### PR TITLE
Make sure to use existing observation

### DIFF
--- a/pocs/state/states/default/scheduling.py
+++ b/pocs/state/states/default/scheduling.py
@@ -32,6 +32,9 @@ def on_enter(event_data):
 
             if existing_observation and observation.name == existing_observation.name:
                 pocs.say("I'm sticking with {}".format(observation.name))
+
+                # Make sure we are using existing observation (with pointing image)
+                pocs.observatory.current_observation = existing_observation
                 pocs.next_state = 'tracking'
             else:
                 pocs.say("Got it! I'm going to check out: {}".format(observation.name))


### PR DESCRIPTION
When selecting the same observation make sure to use the actual same observation object. The new observation object, while the same in principle, does not have a pointing image attached to it, which is used in the tracking corrections.