### PR TITLE
Camera updates

### DIFF
--- a/pocs/camera/canon_gphoto2.py
+++ b/pocs/camera/canon_gphoto2.py
@@ -35,26 +35,31 @@ class Camera(AbstractGPhotoCamera):
 
         # Properties to be set upon init.
         prop2index = {
+            '/main/actions/viewfinder': 1,                # Screen off
+            '/main/capturesettings/autoexposuremode': 3,  # 3 - Manual; 4 - Bulb
+            '/main/capturesettings/continuousaf': 0,      # No auto-focus
+            '/main/capturesettings/drivemode': 0,         # Single exposure
+            '/main/capturesettings/focusmode': 0,         # Manual (don't try to focus)
+            '/main/capturesettings/shutterspeed': 0,      # Bulb
+            '/main/imgsettings/imageformat': 9,           # RAW
+            '/main/imgsettings/imageformatcf': 9,         # RAW
+            '/main/imgsettings/imageformatsd': 9,         # RAW
+            '/main/imgsettings/iso': 1,                   # ISO 100
+            '/main/settings/autopoweroff': 0,             # Don't power off
+            '/main/settings/capturetarget': 0,            # Capture to RAM, for download
             '/main/settings/datetime': 'now',             # Current datetime
             '/main/settings/datetimeutc': 'now',          # Current datetime
-            '/main/actions/viewfinder': 1,                # Screen off
-            '/main/settings/autopoweroff': 0,             # Don't power off
             '/main/settings/reviewtime': 0,               # Screen off after taking pictures
-            '/main/settings/capturetarget': 0,            # Capture to RAM, for download
-            '/main/imgsettings/imageformat': 9,           # RAW
-            '/main/imgsettings/imageformatsd': 9,         # RAW
-            '/main/imgsettings/imageformatcf': 9,         # RAW
-            '/main/imgsettings/iso': 1,                   # ISO 100
-            '/main/capturesettings/focusmode': 0,         # Manual (don't try to focus)
-            '/main/capturesettings/continuousaf': 0,      # No auto-focus
-            '/main/capturesettings/autoexposuremode': 3,  # 3 - Manual; 4 - Bulb
-            '/main/capturesettings/drivemode': 0,         # Single exposure
-            '/main/capturesettings/shutterspeed': 0,      # Bulb
         }
+
+        owner_name = 'Project PANOPTES'
+        artist_name = self.config.get('unit_id', owner_name)
+        copyright = 'owner_name {}'.format(owner_name, current_time().datetime.year)
+
         prop2value = {
-            '/main/settings/artist': 'Project PANOPTES',
-            '/main/settings/ownername': 'Project PANOPTES',
-            '/main/settings/copyright': 'Project PANOPTES {}'.format(current_time().datetime.year),
+            '/main/settings/artist': artist_name,
+            '/main/settings/copyright': copyright,
+            '/main/settings/ownername': owner_name,
         }
 
         self.set_properties(prop2index, prop2value)

--- a/pocs/camera/canon_gphoto2.py
+++ b/pocs/camera/canon_gphoto2.py
@@ -35,6 +35,8 @@ class Camera(AbstractGPhotoCamera):
 
         # Properties to be set upon init.
         prop2index = {
+            '/main/settings/datetime': 'now',             # Current datetime
+            '/main/settings/datetimeutc': 'now',          # Current datetime
             '/main/actions/viewfinder': 1,                # Screen off
             '/main/settings/autopoweroff': 0,             # Don't power off
             '/main/settings/reviewtime': 0,               # Screen off after taking pictures

--- a/scripts/cr2_to_jpg.sh
+++ b/scripts/cr2_to_jpg.sh
@@ -2,7 +2,7 @@
 
 usage() {
   echo -n "##################################################
-# Make a jpeg from the Canon Raw vs (.CR2) file.
+# Make a jpeg from the Canon Raw v2 (.CR2) file.
 # 
 # If exiftool is present this merely extracts the thumbnail from
 # the CR2 file, otherwise use dcraw to create a jpeg.

--- a/scripts/cr2_to_jpg.sh
+++ b/scripts/cr2_to_jpg.sh
@@ -26,19 +26,19 @@ if [ $# -eq 0 ]; then
 fi
 
 FNAME=$1
-CAPTION=$2
+CAPTION="${2}"
 
-JPG=${FNAME/cr2/jpg}
+JPG="${FNAME%.cr2}.jpg"
 
 echo "Converting ${FNAME} to jpg."
 
 # Use exiftool to extract preview if it exists
 if hash exiftool 2>/dev/null; then
-    exiftool -b -PreviewImage ${FNAME} > ${JPG}
+    exiftool -b -PreviewImage "${FNAME}" > "${JPG}"
 else
     if hash dcraw 2>/dev/null; then
         # Convert CR2 to JPG
-        dcraw -c -q 3 -a -w -H 5 -b 5 ${FNAME} | cjpeg -quality 90 > ${JPG}
+        dcraw -c -q 3 -a -w -H 5 -b 5 "${FNAME}" | cjpeg -quality 90 > "${JPG}"
     else
         echo "Can't find either exiftool or dcraw, cannot proceed"
         exit
@@ -49,8 +49,9 @@ if [[ $CAPTION ]]
   then
   	echo "Adding caption \"${CAPTION}\""
 	# Make thumbnail from jpg.
-	convert ${JPG} -background black -fill red \
-	    -font ubuntu -pointsize 60 label:"${CAPTION}" -gravity South -append ${JPG}
+	convert "${JPG}" -background black -fill red \
+	    -font ubuntu -pointsize 60 label:"${CAPTION}" \
+	    -gravity South -append "${JPG}"
 fi
 
 echo "${JPG}"

--- a/scripts/cr2_to_jpg.sh
+++ b/scripts/cr2_to_jpg.sh
@@ -30,7 +30,7 @@ CAPTION="${2}"
 
 JPG="${FNAME%.cr2}.jpg"
 
-echo "Converting ${FNAME} to jpg."
+echo "Converting CR2 to ${JPG}."
 
 # Use exiftool to extract preview if it exists
 if hash exiftool 2>/dev/null; then
@@ -45,7 +45,7 @@ else
     fi
 fi
 
-if [[ $CAPTION ]]
+if [[ -n "$CAPTION" ]]
   then
   	echo "Adding caption \"${CAPTION}\""
 	# Make thumbnail from jpg.

--- a/scripts/cr2_to_jpg.sh
+++ b/scripts/cr2_to_jpg.sh
@@ -1,9 +1,36 @@
-#!/usr/bin/env bash
+#!/bin/bash -e
+
+usage() {
+  echo -n "##################################################
+# Make a jpeg from the Canon Raw vs (.CR2) file.
+# 
+# If exiftool is present this merely extracts the thumbnail from
+# the CR2 file, otherwise use dcraw to create a jpeg.
+#
+# If present the CAPTION is added as a caption to the jpeg.
+##################################################
+ $ $(basename $0) FILENAME [CAPTION]
+ 
+ Options:
+  FILENAME          Name of CR2 file that holds jpeg.
+  CAPTION           Optional caption to be placed on jpeg.
+
+ Example:
+  scripts/cr2_to_jpg.sh /var/panoptes/images/temp.cr2 \"M42 (Orion's Nebula)\"
+"
+}
+
+if [ $# -eq 0 ]; then
+    usage
+    exit 1
+fi
 
 FNAME=$1
-NAME=$2
+CAPTION=$2
 
 JPG=${FNAME/cr2/jpg}
+
+echo "Converting ${FNAME} to jpg."
 
 # Use exiftool to extract preview if it exists
 if hash exiftool 2>/dev/null; then
@@ -18,6 +45,12 @@ else
     fi
 fi
 
-# Make thumbnail from jpg.
-convert ${JPG} -thumbnail 1280x1024 -background black -fill red \
-    -font ubuntu -pointsize 24 label:"${NAME}" -gravity South -append ${JPG}
+if [[ $CAPTION ]]
+  then
+  	echo "Adding caption \"${CAPTION}\""
+	# Make thumbnail from jpg.
+	convert ${JPG} -background black -fill red \
+	    -font ubuntu -pointsize 60 label:"${CAPTION}" -gravity South -append ${JPG}
+fi
+
+echo "${JPG}"

--- a/scripts/take_pic.sh
+++ b/scripts/take_pic.sh
@@ -13,6 +13,9 @@ usage() {
   PORT              USB port as reported by gphoto2 --auto-detect, e.g. usb:001,004.
   EXPTIME           Exposure time in seconds, should be greater than 1 second.
   OUTFILE           Output filename (with .cr2 extension).
+
+ Example:
+  scripts/take_pic.sh usb:001,005 5 /var/panoptes/images/temp.cr2
 "
 }
 

--- a/scripts/take_pic.sh
+++ b/scripts/take_pic.sh
@@ -34,8 +34,8 @@ echo "FILE = ${FILENAME}"
 
 # Open shutter
 gphoto2 --port=${PORT} \
-        --set-config shutterspeed=0 \
-        --set-config capturetarget=0 \
+        --set-config shutterspeed=0 `#Always set to bulb` \
+        --set-config capturetarget=0 `#Capture to RAM for download` \
         --set-config eosremoterelease=Immediate \
         --wait-event=${EXPTIME}s \
         --set-config eosremoterelease=4 \

--- a/scripts/take_pic.sh
+++ b/scripts/take_pic.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 usage() {
   echo -n "##################################################
@@ -7,7 +7,7 @@ usage() {
 # This will change the camera setting to bulb and then take
 # an exposure for the requested amount of time.
 ##################################################
- $ $(basename $0) PORT EXPTIME FILENAME
+ $ $(basename $0) PORT EXPTIME OUTFILE
  
  Options:
   PORT              USB port as reported by gphoto2 --auto-detect, e.g. usb:001,004.

--- a/scripts/take_pic.sh
+++ b/scripts/take_pic.sh
@@ -1,18 +1,42 @@
 #!/bin/bash
 
-P=$1
-T=$2
-F=$3
+usage() {
+  echo -n "##################################################
+# Take a picture via gphoto2.
+# 
+# This will change the camera setting to bulb and then take
+# an exposure for the requested amount of time.
+##################################################
+ $ $(basename $0) PORT EXPTIME FILENAME
+ 
+ Options:
+  PORT              USB port as reported by gphoto2 --auto-detect, e.g. usb:001,004.
+  EXPTIME			Exposure time in seconds, should be greater than 1 second.
+  OUTFILE           Output filename (with .cr2 extension).
+"
+}
+
+if [ $# -eq 0 ]; then
+    usage
+    exit 1
+fi
+
+PORT=$1
+EXPTIME=$2
+FILENAME=$3
 echo 'Taking picture'
-echo "T = ${T}s"
-
-
-# Make sure bulb is set
-gphoto2 --port=${P} --set-config-index=0 --set-config-index capturetarget=0
+echo "PORT = ${PORT}"
+echo "TIME = ${TIME}s"
+echo "FILE = ${FILENAME}"
 
 # Open shutter
-gphoto2 --port=${P} --set-config eosremoterelease=Immediate \
-         --wait-event=${T}s --set-config eosremoterelease=4 --wait-event-and-download=2s \
-         --filename "${F}"
+gphoto2 --port=${PORT} \
+		--set-config shutterspeed=0 \
+		--set-config capturetarget=0 \
+		--set-config eosremoterelease=Immediate \
+		--wait-event=${EXPTIME}s \
+		--set-config eosremoterelease=4 \
+		--wait-event-and-download=2s \
+		--filename "${FILENAME}"
 
 echo "Done with pic"

--- a/scripts/take_pic.sh
+++ b/scripts/take_pic.sh
@@ -6,13 +6,18 @@ usage() {
 # 
 # This will change the camera setting to bulb and then take
 # an exposure for the requested amount of time.
+# 
+# This script has only been tested with Canon EOS100D models
+# but should be generic to any gphoto2 camera that supports
+# bulb settings.
 ##################################################
  $ $(basename $0) PORT EXPTIME OUTFILE
  
  Options:
   PORT              USB port as reported by gphoto2 --auto-detect, e.g. usb:001,004.
   EXPTIME           Exposure time in seconds, should be greater than 1 second.
-  OUTFILE           Output filename (with .cr2 extension).
+                    Can be either an integer or string.
+  OUTFILE           Output filename with approrpiate extension, e.g. .cr2 for Canon.
 
  Example:
   scripts/take_pic.sh usb:001,005 5 /var/panoptes/images/temp.cr2

--- a/scripts/take_pic.sh
+++ b/scripts/take_pic.sh
@@ -33,11 +33,11 @@ echo "TIME = ${TIME}s"
 echo "FILE = ${FILENAME}"
 
 # Open shutter
-gphoto2 --port=${PORT} \
+gphoto2 --port="${PORT}" \
         --set-config shutterspeed=0 `#Always set to bulb` \
         --set-config capturetarget=0 `#Capture to RAM for download` \
         --set-config eosremoterelease=Immediate \
-        --wait-event=${EXPTIME}s \
+        --wait-event="${EXPTIME}s" \
         --set-config eosremoterelease=4 \
         --wait-event-and-download=2s \
         --filename "${FILENAME}"

--- a/scripts/take_pic.sh
+++ b/scripts/take_pic.sh
@@ -6,6 +6,10 @@ F=$3
 echo 'Taking picture'
 echo "T = ${T}s"
 
+
+# Make sure bulb is set
+gphoto2 --port=${P} --set-config-index=0 --set-config-index capturetarget=0
+
 # Open shutter
 gphoto2 --port=${P} --set-config eosremoterelease=Immediate \
          --wait-event=${T}s --set-config eosremoterelease=4 --wait-event-and-download=2s \

--- a/scripts/take_pic.sh
+++ b/scripts/take_pic.sh
@@ -11,7 +11,7 @@ usage() {
  
  Options:
   PORT              USB port as reported by gphoto2 --auto-detect, e.g. usb:001,004.
-  EXPTIME			Exposure time in seconds, should be greater than 1 second.
+  EXPTIME           Exposure time in seconds, should be greater than 1 second.
   OUTFILE           Output filename (with .cr2 extension).
 "
 }
@@ -31,12 +31,12 @@ echo "FILE = ${FILENAME}"
 
 # Open shutter
 gphoto2 --port=${PORT} \
-		--set-config shutterspeed=0 \
-		--set-config capturetarget=0 \
-		--set-config eosremoterelease=Immediate \
-		--wait-event=${EXPTIME}s \
-		--set-config eosremoterelease=4 \
-		--wait-event-and-download=2s \
-		--filename "${FILENAME}"
+        --set-config shutterspeed=0 \
+        --set-config capturetarget=0 \
+        --set-config eosremoterelease=Immediate \
+        --wait-event=${EXPTIME}s \
+        --set-config eosremoterelease=4 \
+        --wait-event-and-download=2s \
+        --filename "${FILENAME}"
 
 echo "Done with pic"


### PR DESCRIPTION
Ideally the take_pic.sh script will be re-written in python to handle any pictures (e.g. bias and regular) but this is some small cleanup before that time.

* Cleaning up script
* Adding default time for cameras - #503 
* Caption is optional on jpgs (it's a slow operation)
* No resizing of jpg

Note that this was also waiting to get some of the camera hardware testing infrastructure in place but I wanted to make sure to get these updates out.