### PR TITLE
Parking cleanups

### DIFF
--- a/bin/pocs_shell
+++ b/bin/pocs_shell
@@ -193,9 +193,12 @@ Hardware names: {}   (or all for all hardware)'''.format(
             try:
                 self.pocs.run()
             except KeyboardInterrupt:
-                print_warning('POCS interrupted, skipping states and parking')
-                self.pocs.observatory.mount.home_and_park()
-                self._running = False
+                print_warning('POCS interrupted, parking')
+                if self.pocs.state not in ['sleeping', 'housekeeping', 'parked', 'parking']:
+                    self.pocs.park()
+                else:
+                    self.pocs.observatory.mount.home_and_park()
+                self._obs_run_retries = 0  # Don't retry
             finally:
                 print_info('POCS stopped.')
         else:

--- a/pocs/state/states/default/parked.py
+++ b/pocs/state/states/default/parked.py
@@ -4,24 +4,26 @@ def on_enter(event_data):
     pocs = event_data.model
     pocs.say("I'm parked now. Phew.")
 
-    has_valid_observations = pocs.observatory.scheduler.has_valid_observations
+    if pocs.run_once is True:
+        pocs.say("Done running loop, going to clean up and sleep!")
+        pocs.next_state = 'housekeeping'
+    elif pocs.should_retry is False:
+        pocs.say("Done with retrying loop, going to clean up and sleep!")
+        pocs.next_state = 'housekeeping'
+    else:
+        has_valid_observations = pocs.observatory.scheduler.has_valid_observations
 
-    if has_valid_observations:
-        if pocs.is_safe():
-            if pocs.should_retry is False or pocs.run_once is True:
-                pocs.say("Done retrying for this run, going to clean up and shut down!")
-                pocs.next_state = 'housekeeping'
-            else:  # This branch will only happen if there is an error causing a shutdown
+        if has_valid_observations:
+            if pocs.is_safe():
                 pocs.say("Things look okay for now. I'm going to try again.")
                 pocs.next_state = 'ready'
-        else:  # Normal end of night
-            pocs.say("Cleaning up for the night!")
-            pocs.next_state = 'housekeeping'
-    else:
-        pocs.say("No observations found.")
-        # TODO Should check if we are close to morning and if so do some morning
-        # calibration frames rather than just waiting for 30 minutes then shutting down.
-        if pocs.run_once is False:
+            else:  # Normal end of night
+                pocs.say("Cleaning up for the night!")
+                pocs.next_state = 'housekeeping'
+        else:
+            pocs.say("No observations found.")
+            # TODO Should check if we are close to morning and if so do some morning
+            # calibration frames rather than just waiting for 30 minutes then shutting down.
             pocs.say("Going to stay parked for half an hour then will try again.")
 
             while True:
@@ -40,6 +42,3 @@ def on_enter(event_data):
                     break
                 else:
                     pocs.say("Seems to be bad weather. I'll wait another 30 minutes.")
-        else:
-            pocs.say("Only wanted to run once so cleaning up!")
-            pocs.next_state = 'housekeeping'

--- a/pocs/state/states/default/parked.py
+++ b/pocs/state/states/default/parked.py
@@ -2,7 +2,7 @@
 def on_enter(event_data):
     """ """
     pocs = event_data.model
-    pocs.say("I'm parked now. Phew.")
+    pocs.say("I'm parked now.")
 
     if pocs.run_once is True:
         pocs.say("Done running loop, going to clean up and sleep!")
@@ -11,9 +11,7 @@ def on_enter(event_data):
         pocs.say("Done with retrying loop, going to clean up and sleep!")
         pocs.next_state = 'housekeeping'
     else:
-        has_valid_observations = pocs.observatory.scheduler.has_valid_observations
-
-        if has_valid_observations:
+        if pocs.observatory.scheduler.has_valid_observations:
             if pocs.is_safe():
                 pocs.say("Things look okay for now. I'm going to try again.")
                 pocs.next_state = 'ready'


### PR DESCRIPTION
* Cleanup to `parked` state to make it easier to understand
* Ctrl-c while pocs_shell is running will finish loop through state
machine rather than call park directly on the mount. This allows for
housekeeping (including uploading) of observations even when machine
is manually killed.

Edit: ~~Note: in future might be worth adding an option such that when you
press Ctrl-c you are prompted for if you want immediate park and shutdown
or if should run through states.~~ I think I would prefer to move to #592 