### PR TITLE
Add a config file for test_codestyle.py

### DIFF
--- a/.pycodestyle.cfg
+++ b/.pycodestyle.cfg
@@ -1,0 +1,16 @@
+[pycodestyle]
+; Pycodestyle config options are:
+;  exclude, filename, select, ignore, max-line-length, max-doc-length,
+;  hang-closing, count, format, quiet, show-pep8, show-source,
+;  statistics, verbose
+
+; Style violations to ignore.
+;
+; E501: line too long (82 > 79 characters)
+;
+; For the full list, see:
+; https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
+
+ignore = E501
+
+max-line-length = 99

--- a/pocs/tests/test_codestyle.py
+++ b/pocs/tests/test_codestyle.py
@@ -1,3 +1,5 @@
+import os
+
 import pycodestyle
 import pytest
 
@@ -9,7 +11,8 @@ def dirs_to_check(request):
 
 def test_conformance(dirs_to_check):
     """Test that we conform to PEP-8."""
-    style = pycodestyle.StyleGuide(quiet=False, ignore=['E501', 'E402'])
+    config_file = os.path.join(os.environ['POCS'], '.pycodestyle.cfg')
+    style = pycodestyle.StyleGuide(quiet=False, config_file=config_file)
 
     print(dirs_to_check)
     style.input_dir(dirs_to_check)


### PR DESCRIPTION
pycodestyle supports reading config options from a file.
This change adds such a file and modifies test_codestyle.py
to reference it.

Removes ignoring of E402 (module level import not at top of file)
because we don't violate it now.

Sets the line length to 99, but continues to ignore E501 (line
too long) because we have a lot of those.