### PR TITLE
Fix some bugs and lots of warnings reported by pyflakes

### DIFF
--- a/peas/sensors.py
+++ b/peas/sensors.py
@@ -64,7 +64,7 @@ class ArduinoSerialMonitor(object):
             serial_reader.connect()
             self.logger.debug('Connected to {}', port)
             return serial_reader
-        except Exception as e:
+        except Exception:
             self.logger.warning('Could not connect to port: {}'.format(port))
             return None
 
@@ -165,7 +165,7 @@ def detect_board_on_port(port, logger=None):
         if not serial_reader.is_connected:
             serial_reader.connect()
         logger.debug('Connected to {}', port)
-    except Exception as e:
+    except Exception:
         logger.warning('Could not connect to port: {}'.format(port))
         return None
     try:

--- a/pocs/camera/__init__.py
+++ b/pocs/camera/__init__.py
@@ -1,2 +1,2 @@
-from pocs.camera.camera import AbstractCamera
-from pocs.camera.camera import AbstractGPhotoCamera
+from pocs.camera.camera import AbstractCamera  # pragma: no flakes
+from pocs.camera.camera import AbstractGPhotoCamera  # pragma: no flakes

--- a/pocs/camera/fli.py
+++ b/pocs/camera/fli.py
@@ -1,5 +1,4 @@
 import time
-import os
 import re
 from warnings import warn
 from threading import Event
@@ -9,14 +8,13 @@ from threading import Lock
 import numpy as np
 
 from astropy import units as u
-from astropy.io import fits
 
 from pocs.camera.camera import AbstractCamera
 from pocs.camera import libfli
 from pocs.utils.images import fits as fits_utils
 
 # FLI camera serial numbers have pairs of letters followed by a sequence of numbers
-serial_number_pattern = re.compile('^(ML|PL|KL|HP)\d+$')
+serial_number_pattern = re.compile(r'^(ML|PL|KL|HP)\d+$')
 
 
 class Camera(AbstractCamera):

--- a/pocs/camera/libfli.py
+++ b/pocs/camera/libfli.py
@@ -12,24 +12,24 @@ import numpy as np
 import astropy.units as u
 
 from pocs.base import PanBase
-from pocs.camera.libfliconstants import *  # Bad form, but done for readability
+import pocs.camera.libfliconstants as c
 
-valid_values = {'interface type': (FLIDOMAIN_PARALLEL_PORT,
-                                   FLIDOMAIN_USB,
-                                   FLIDOMAIN_SERIAL,
-                                   FLIDOMAIN_INET,
-                                   FLIDOMAIN_SERIAL_1200,
-                                   FLIDOMAIN_SERIAL_19200),
-                'device type': (FLIDEVICE_CAMERA,
-                                FLIDEVICE_FILTERWHEEL,
-                                FLIDEVICE_FOCUSER,
-                                FLIDEVICE_HS_FILTERWHEEL,
-                                FLIDEVICE_RAW,
-                                FLIDEVICE_ENUMERATE_BY_CONNECTION),
-                'frame type': (FLI_FRAME_TYPE_NORMAL,
-                               FLI_FRAME_TYPE_DARK,
-                               FLI_FRAME_TYPE_FLOOD,
-                               FLI_FRAME_TYPE_RBI_FLUSH)}
+valid_values = {'interface type': (c.FLIDOMAIN_PARALLEL_PORT,
+                                   c.FLIDOMAIN_USB,
+                                   c.FLIDOMAIN_SERIAL,
+                                   c.FLIDOMAIN_INET,
+                                   c.FLIDOMAIN_SERIAL_1200,
+                                   c.FLIDOMAIN_SERIAL_19200),
+                'device type': (c.FLIDEVICE_CAMERA,
+                                c.FLIDEVICE_FILTERWHEEL,
+                                c.FLIDEVICE_FOCUSER,
+                                c.FLIDEVICE_HS_FILTERWHEEL,
+                                c.FLIDEVICE_RAW,
+                                c.FLIDEVICE_ENUMERATE_BY_CONNECTION),
+                'frame type': (c.FLI_FRAME_TYPE_NORMAL,
+                               c.FLI_FRAME_TYPE_DARK,
+                               c.FLI_FRAME_TYPE_FLOOD,
+                               c.FLI_FRAME_TYPE_RBI_FLUSH)}
 
 ################################################################################
 # Main SBIGDriver class
@@ -84,7 +84,7 @@ class FLIDriver(PanBase):
 
     # Public methods
 
-    def FLIList(self, interface_type=FLIDOMAIN_USB, device_type=FLIDEVICE_CAMERA):
+    def FLIList(self, interface_type=c.FLIDOMAIN_USB, device_type=c.FLIDEVICE_CAMERA):
         """
         List available devices.
 
@@ -120,7 +120,7 @@ class FLIDriver(PanBase):
 
         return available_devices
 
-    def FLIOpen(self, port, interface_type=FLIDOMAIN_USB, device_type=FLIDEVICE_CAMERA):
+    def FLIOpen(self, port, interface_type=c.FLIDOMAIN_USB, device_type=c.FLIDEVICE_CAMERA):
         """
         Get a handle to an FLI device.
 

--- a/pocs/camera/sbigudrv.py
+++ b/pocs/camera/sbigudrv.py
@@ -8,20 +8,15 @@ enums and structs defined in the library C-header to Python dicts and
 ctypes.Structures, plus a class (SBIGDriver) to load the library
 and call the single command function (SBIGDriver._send_command()).
 """
-import platform
 import ctypes
 from ctypes.util import find_library
 from warnings import warn
-import _ctypes
-import os
 import time
 from threading import Timer, Lock
 
 import numpy as np
 from numpy.ctypeslib import as_ctypes
 from astropy import units as u
-from astropy.io import fits
-from astropy.time import Time
 
 from pocs.base import PanBase
 from pocs.utils.images import fits as fits_utils

--- a/pocs/dome/bisque.py
+++ b/pocs/dome/bisque.py
@@ -163,7 +163,7 @@ class Dome(pocs.dome.AbstractDome):
             response_obj = json.loads(response)
         except TypeError as e:
             self.logger.warning("Error: {}".format(e, response))
-        except json.JSONDecodeError as e:
+        except json.JSONDecodeError:
             response_obj = {
                 "response": response,
                 "success": False,

--- a/pocs/dome/protocol_astrohaven_simulator.py
+++ b/pocs/dome/protocol_astrohaven_simulator.py
@@ -1,7 +1,6 @@
 import datetime
 import queue
 from serial import serialutil
-import sys
 import threading
 import time
 
@@ -38,8 +37,6 @@ class Shutter(object):
         self.max_position = max(CLOSED_POSITION, OPEN_POSITION)
 
     def handle_input(self, input_char):
-        ts = datetime.datetime.now()
-        msg = ts.strftime('%M:%S.%f')
         if input_char in self.open_commands:
             if self.is_open:
                 return (False, self.is_open_char)

--- a/pocs/focuser/__init__.py
+++ b/pocs/focuser/__init__.py
@@ -1,1 +1,1 @@
-from pocs.focuser.focuser import AbstractFocuser
+from pocs.focuser.focuser import AbstractFocuser  # pragma: no flakes

--- a/pocs/focuser/birger.py
+++ b/pocs/focuser/birger.py
@@ -7,10 +7,10 @@ from warnings import warn
 from pocs.focuser import AbstractFocuser
 
 # Birger adaptor serial numbers should be 5 digits
-serial_number_pattern = re.compile('^\d{5}$')
+serial_number_pattern = re.compile(r'^\d{5}$')
 
 # Error codes should be 'ERR' followed by 1-2 digits
-error_pattern = re.compile('(?<=ERR)\d{1,2}')
+error_pattern = re.compile(r'(?<=ERR)\d{1,2}')
 
 error_messages = ('No error',
                   'Unrecognised command',
@@ -127,7 +127,7 @@ class Focuser(AbstractFocuser):
         except (serial.SerialException,
                 serial.SerialTimeoutException,
                 AssertionError) as err:
-            message = 'Error connecting to {} on {}: {}'.format(self.name, port, err)
+            message = 'Error connecting to {} on {}: {}'.format(self.name, self.port, err)
             self.logger.error(message)
             warn(message)
             return

--- a/pocs/focuser/focuslynx.py
+++ b/pocs/focuser/focuslynx.py
@@ -98,7 +98,7 @@ class Focuser(AbstractFocuser):
             self.logger.warning('Truncated nickname {} to {} (must be <= 16 characters)'.format(nickname,
                                                                                                 nickname[:16]))
             nickname = nickname[:16]
-        command_str = '<F{:1d}SCNN{}>'.format(self._focuser_number, nicpositionkname)
+        command_str = '<F{:1d}SCNN{}>'.format(self._focuser_number, nickname)
         self._send_command(command_str, expected_reply='SET')
         self._get_focuser_config()
 

--- a/pocs/images.py
+++ b/pocs/images.py
@@ -151,7 +151,7 @@ class Image(PanBase):
 
             try:
                 self.header_ha = float(self.header['HA-MNT']) * u.hourangle
-            except KeyError as e:
+            except KeyError:
                 # Compute the HA from the RA and sidereal time.
                 # Precess to the current equinox otherwise the
                 # RA - LST method will be off.

--- a/pocs/mount/__init__.py
+++ b/pocs/mount/__init__.py
@@ -1,1 +1,1 @@
-from pocs.mount.mount import AbstractMount
+from pocs.mount.mount import AbstractMount  # pragma: no flakes

--- a/pocs/mount/bisque.py
+++ b/pocs/mount/bisque.py
@@ -320,6 +320,7 @@ class Mount(AbstractMount):
             response_obj = {
                 "response": response,
                 "success": False,
+                "error": e,
             }
 
         return response_obj

--- a/pocs/scheduler/__init__.py
+++ b/pocs/scheduler/__init__.py
@@ -1,1 +1,1 @@
-from pocs.scheduler.scheduler import BaseScheduler
+from pocs.scheduler.scheduler import BaseScheduler  # pragma: no flakes

--- a/pocs/scheduler/observation.py
+++ b/pocs/scheduler/observation.py
@@ -155,7 +155,7 @@ class Observation(PanBase):
             equinox = self.field.coord.equinox.value
         except AttributeError:
             equinox = self.field.coord.equinox
-        except Exception as e:
+        except Exception:
             equinox = 'J2000'
 
         status = {

--- a/pocs/sensors/arduino_io.py
+++ b/pocs/sensors/arduino_io.py
@@ -63,7 +63,7 @@ def detect_board_on_port(port, logger=None):
             if not serial_reader.is_connected:
                 serial_reader.connect()
             logger.debug('Connected to {}', port)
-        except Exception as e:
+        except Exception:
             logger.warning('Could not connect to port: {}'.format(port))
             return None
         try:

--- a/pocs/serial_handlers/protocol_arduinosimulator.py
+++ b/pocs/serial_handlers/protocol_arduinosimulator.py
@@ -6,7 +6,6 @@ import json
 import queue
 import random
 from serial import serialutil
-import sys
 import threading
 import time
 import urllib

--- a/pocs/state/machine.py
+++ b/pocs/state/machine.py
@@ -9,7 +9,7 @@ from pocs.utils import load_module
 
 can_graph = False
 try:  # pragma: no cover
-    import pygraphviz
+    import pygraphviz  # pragma: no flakes
     from transitions.extensions import GraphMachine as Machine
     can_graph = True
 except ImportError:  # pragma: no cover

--- a/pocs/state/states/default/observing.py
+++ b/pocs/state/states/default/observing.py
@@ -55,7 +55,7 @@ def on_enter(event_data):
             # Sleep for a little bit.
             time.sleep(SLEEP_SECONDS)
 
-    except pocs_utils.error.Timeout as e:
+    except pocs_utils.error.Timeout:
         pocs.logger.warning(
             "Timeout while waiting for images. Something wrong with camera, going to park.")
     except Exception as e:

--- a/pocs/state/states/default/scheduling.py
+++ b/pocs/state/states/default/scheduling.py
@@ -24,7 +24,7 @@ def on_enter(event_data):
         try:
             observation = pocs.observatory.get_observation()
             pocs.logger.info("Observation: {}".format(observation))
-        except error.NoObservation as e:
+        except error.NoObservation:
             pocs.say("No valid observations found. Can't schedule. Going to park.")
         except Exception as e:
             pocs.logger.warning("Error in scheduling: {}".format(e))

--- a/pocs/tests/serial_handlers/protocol_buffers.py
+++ b/pocs/tests/serial_handlers/protocol_buffers.py
@@ -3,6 +3,7 @@
 from pocs.tests.serial_handlers import NoOpSerial
 
 import io
+from serial import serialutil
 import threading
 
 # r_buffer and w_buffer are binary I/O buffers. read(size=N) on an instance

--- a/pocs/tests/test_arduino_io.py
+++ b/pocs/tests/test_arduino_io.py
@@ -3,12 +3,9 @@
 import collections
 import datetime
 import pytest
-import queue as queue_module
 import serial
-import time
 
 from pocs.sensors import arduino_io
-from pocs.utils.database import AbstractPanDB
 import pocs.utils.error as error
 from pocs.utils.logger import get_root_logger
 from pocs.utils import rs232

--- a/pocs/tests/test_dome_simulator.py
+++ b/pocs/tests/test_dome_simulator.py
@@ -1,11 +1,8 @@
 import copy
-import os
 import pytest
 
 import pocs.dome
 from pocs.dome import simulator
-
-# Dome as DomeSimulator
 
 
 # Yields two different dome controllers configurations,

--- a/pocs/tests/test_rs232.py
+++ b/pocs/tests/test_rs232.py
@@ -1,14 +1,13 @@
 import io
 import pytest
 import serial
+from serial import serialutil
 
 from pocs.utils import error
 from pocs.utils import rs232
-from pocs.utils.config import load_config
 
 from pocs.tests.serial_handlers import NoOpSerial
 from pocs.tests.serial_handlers import protocol_buffers
-from pocs.tests.serial_handlers import protocol_no_op
 from pocs.tests.serial_handlers import protocol_hooked
 
 
@@ -174,7 +173,6 @@ class HookedSerialHandler(NoOpSerial):
         if not self.is_open:
             raise serialutil.portNotOpenError
         # If at end of the stream, reset the stream.
-        avail = self.in_waiting
         return self.r_buffer.read(min(size, self.in_waiting))
 
     def write(self, data):

--- a/pocs/tests/test_social_messaging.py
+++ b/pocs/tests/test_social_messaging.py
@@ -23,29 +23,33 @@ def slack_config():
 def test_no_consumer_key(twitter_config):
     with unittest.mock.patch.dict(twitter_config), pytest.raises(ValueError) as ve:
         del twitter_config['consumer_key']
-        social_twitter = SocialTwitter(**twitter_config)
-        assert 'consumer_key parameter is not defined.' == str(ve.value)
+        SocialTwitter(**twitter_config)
+        assert False  # We don't reach this point
+    assert 'consumer_key parameter is not defined.' == str(ve.value)
 
 
 def test_no_consumer_secret(twitter_config):
     with unittest.mock.patch.dict(twitter_config), pytest.raises(ValueError) as ve:
         del twitter_config['consumer_secret']
-        social_twitter = SocialTwitter(**twitter_config)
-        assert 'consumer_secret parameter is not defined.' == str(ve.value)
+        SocialTwitter(**twitter_config)
+        assert False  # We don't reach this point
+    assert 'consumer_secret parameter is not defined.' == str(ve.value)
 
 
 def test_no_access_token(twitter_config):
     with unittest.mock.patch.dict(twitter_config), pytest.raises(ValueError) as ve:
         del twitter_config['access_token']
-        social_twitter = SocialTwitter(**twitter_config)
-        assert 'access_token parameter is not defined.' == str(ve.value)
+        SocialTwitter(**twitter_config)
+        assert False  # We don't reach this point
+    assert 'access_token parameter is not defined.' == str(ve.value)
 
 
 def test_no_access_token_secret(twitter_config):
     with unittest.mock.patch.dict(twitter_config), pytest.raises(ValueError) as ve:
         del twitter_config['access_token_secret']
-        social_twitter = SocialTwitter(**twitter_config)
-        assert 'access_token_secret parameter is not defined.' == str(ve.value)
+        SocialTwitter(**twitter_config)
+        assert False  # We don't reach this point
+    assert 'access_token_secret parameter is not defined.' == str(ve.value)
 
 
 def test_send_message_twitter(twitter_config):
@@ -73,7 +77,7 @@ def test_no_webhook_url(slack_config):
     with unittest.mock.patch.dict(slack_config), pytest.raises(ValueError) as ve:
         del slack_config['webhook_url']
         slack_config = SocialSlack(**slack_config)
-        assert 'webhook_url parameter is not defined.' == str(ve.value)
+    assert 'webhook_url parameter is not defined.' == str(ve.value)
 
 
 def test_send_message_slack(slack_config):

--- a/pocs/utils/database.py
+++ b/pocs/utils/database.py
@@ -366,7 +366,7 @@ class PanFileDB(AbstractPanDB):
 
         try:
             return json_util.loads_file(current_fn)
-        except FileNotFoundError as e:
+        except FileNotFoundError:
             self._warn("No record found for {}".format(collection))
             return None
 
@@ -387,7 +387,7 @@ class PanFileDB(AbstractPanDB):
         current_f = os.path.join(self._storage_dir, 'current_{}.json'.format(type))
         try:
             os.remove(current_f)
-        except FileNotFoundError as e:
+        except FileNotFoundError:
             pass
 
     def _get_file(self, collection, permanent=True):

--- a/pocs/utils/google/storage.py
+++ b/pocs/utils/google/storage.py
@@ -39,7 +39,7 @@ class PanStorage(object):
         super(PanStorage, self).__init__()
 
         self.unit_id = load_config()['pan_id']
-        assert re.match('PAN\d\d\d', self.unit_id) is not None
+        assert re.match(r'PAN\d\d\d', self.unit_id) is not None
 
         self.project_id = project_id
         self.bucket_name = bucket_name
@@ -51,10 +51,11 @@ class PanStorage(object):
 
         try:
             self.bucket = self.client.get_bucket(bucket_name)
-        except Forbidden as e:
+        except Forbidden:
             raise error.GoogleCloudError(
-                "Storage bucket does not exist or no permissions. " +
-                "Ensure that the PANOPTES_CLOUD_KEY variable is properly set"
+                "Storage bucket does not exist or no permissions. "
+                "Ensure that the PANOPTES_CLOUD_KEY variable is properly set "
+                "or that you have executed 'gcloud auth'"
             )
 
         self.logger.info("Connected to storage bucket {}", self.bucket_name)

--- a/pocs/utils/images/__init__.py
+++ b/pocs/utils/images/__init__.py
@@ -6,7 +6,6 @@ import re
 from matplotlib import pyplot as plt
 from warnings import warn
 
-from astropy import units as u
 from astropy.wcs import WCS
 from astropy.io.fits import open as open_fits
 from astropy.visualization import (PercentileInterval, LogStretch, ImageNormalize)
@@ -337,7 +336,7 @@ def upload_observation_dir(pan_id, dir_name, bucket='panoptes-survey', **kwargs)
         **kwargs: Optional keywords: verbose
     """
     assert os.path.exists(dir_name)
-    assert re.match('PAN\d\d\d', pan_id) is not None
+    assert re.match(r'PAN\d\d\d', pan_id) is not None
 
     verbose = kwargs.get('verbose', False)
 

--- a/pocs/utils/social_slack.py
+++ b/pocs/utils/social_slack.py
@@ -23,6 +23,7 @@ class SocialSlack(object):
             else:
                 post_msg = msg
 
-            response = requests.post(self.web_hook, json={'text': post_msg})
+            # We ignore the response body and headers of a successful post.
+            requests.post(self.web_hook, json={'text': post_msg})
         except Exception as e:
             self.logger.debug('Error posting to slack: {}'.format(e))

--- a/pocs/utils/social_twitter.py
+++ b/pocs/utils/social_twitter.py
@@ -32,16 +32,19 @@ class SocialTwitter(object):
             auth.set_access_token(access_token, access_token_secret)
 
             self.api = tweepy.API(auth)
-        except tweepy.TweepError as e:
+        except tweepy.TweepError:
             msg = 'Error authenicating with Twitter. Please check your Twitter configuration.'
             self.logger.warning(msg)
             raise ValueError(msg)
 
     def send_message(self, msg, timestamp):
         try:
+            # update_status returns a tweepy Status instance, but we
+            # drop it on the floor because we don't have anything we
+            # can do with it.
             if self.output_timestamp:
-                retStatus = self.api.update_status('{} - {}'.format(msg, timestamp))
+                self.api.update_status('{} - {}'.format(msg, timestamp))
             else:
-                retStatus = self.api.update_status(msg)
-        except tweepy.TweepError as e:
+                self.api.update_status(msg)
+        except tweepy.TweepError:
             self.logger.debug('Error tweeting message. Please check your Twitter configuration.')


### PR DESCRIPTION
Fixed some "unknown variable" errors, such as port when
it should have been self.port, or the corruption of
nickname by someone pasting the word position into the
middle of it.

Converted some string literals to raw string literals so
that the regular expression is not invalid; e.g 'PAN\d\d\d'
is invalid because \d is not a valid escape sequence. The
author likely meant \d to be the regular expression for
matching digits, which should either be '\\d' or r'\d'.

Removed unused imports. Marked some imports in __init__.py
files with "# pragma: no flakes" so that they can be exported
cleanly.

Replaced "from x import *" with explicit imports in libfli.py.

Removed many unused variables 'e' in statements of
the form: except Name as e.

Fixed uses of pytest.raises in test_social_messaging where
the asserts about the contents of the raised exception were
at the wrong indentation level, so were never executed.