### PR TITLE
Lock matplotlib version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ coveralls
 dateparser
 gcloud
 google-cloud-storage
-matplotlib >= 2.0.0
+matplotlib >= 2.0.0,<3.0.0
 mocket
 numpy >= 1.12.1
 pycodestyle == 2.3.1


### PR DESCRIPTION
Don't go to matplotlib 3.0 yet, breaking changes in make_pretty_image.