### PR TITLE
Bumping minor version number.

### DIFF
--- a/pocs/version.py
+++ b/pocs/version.py
@@ -1,5 +1,5 @@
 major = 0
 minor = 6
-patch = 0
+patch = 1
 
 __version__ = '{}.{}.{}'.format(major, minor, patch)


### PR DESCRIPTION
We have made some changes recently that should be marked with different
version number. Specifically, #589 will standardize the DATE-OBS headers
in the images. At some point we will need to scrub the data created
prior to that so we want to be able to delineate.