### PR TITLE
Pretty image title

### DIFF
--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -208,7 +208,8 @@ class AbstractCamera(PanBase):
             observation.exposure_list[image_id] = file_path
 
         # Process the exposure once readout is complete
-        t = Thread(target=self.process_exposure, args=(metadata, observation_event, exposure_event))
+        t = Thread(target=self.process_exposure, args=(
+            metadata, observation_event, exposure_event))
         t.name = '{}Thread'.format(self.name)
         t.start()
 
@@ -238,12 +239,15 @@ class AbstractCamera(PanBase):
         image_id = info['image_id']
         seq_id = info['sequence_id']
         file_path = info['file_path']
-        self.logger.debug("Processing {}".format(image_id))
+        field_name = info['field_name']
+
+        image_title = '{} {} {}'.format(field_name, seq_id.split('_'), current_time(pretty=True))
+        self.logger.debug("Processing {}".format(image_title))
 
         try:
             self.logger.debug("Extracting pretty image")
             img_utils.make_pretty_image(file_path,
-                                        title=info['field_name'],
+                                        title=image_title,
                                         primary=info['is_primary'])
         except Exception as e:
             self.logger.warning('Problem with extracting pretty image: {}'.format(e))

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -239,11 +239,13 @@ class AbstractCamera(PanBase):
         image_id = info['image_id']
         seq_id = info['sequence_id']
         file_path = info['file_path']
+        exptime = info['exp_time']
         field_name = info['field_name']
 
-        image_title = '{} {} {}'.format(field_name,
-                                        seq_id.replace('_', ' '),
-                                        current_time(pretty=True))
+        image_title = '{} [{}] {} {}'.format(field_name,
+                                             exptime,
+                                             seq_id.replace('_', ' '),
+                                             current_time(pretty=True))
 
         try:
             self.logger.debug("Processing {}".format(image_title))

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -241,11 +241,12 @@ class AbstractCamera(PanBase):
         file_path = info['file_path']
         field_name = info['field_name']
 
-        image_title = '{} {} {}'.format(field_name, seq_id.split('_'), current_time(pretty=True))
-        self.logger.debug("Processing {}".format(image_title))
+        image_title = '{} {} {}'.format(field_name,
+                                        seq_id.replace('_', ' '),
+                                        current_time(pretty=True))
 
         try:
-            self.logger.debug("Extracting pretty image")
+            self.logger.debug("Processing {}".format(image_title))
             img_utils.make_pretty_image(file_path,
                                         title=image_title,
                                         primary=info['is_primary'])

--- a/pocs/utils/images/__init__.py
+++ b/pocs/utils/images/__init__.py
@@ -12,6 +12,7 @@ from astropy.visualization import (PercentileInterval, LogStretch, ImageNormaliz
 
 from glob import glob
 from copy import copy
+from dateutil import parser as date_parser
 
 from pocs.utils import current_time
 from pocs.utils import error
@@ -125,10 +126,22 @@ def _make_pretty_from_fits(fname=None,
         wcs = WCS(header)
 
     if not title:
-        field = header.get('FIELD', 'Unknown')
-        exp_time = header.get('EXPTIME', 'Unknown')
+        field = header.get('FIELD', 'Unknown field')
+        exp_time = header.get('EXPTIME', 'Unknown exptime')
         filter_type = header.get('FILTER', 'Unknown filter')
-        date_time = header.get('DATE-OBS', current_time(pretty=True)).replace('T', ' ', 1)
+
+        try:
+            date_time = header['DATE-OBS']
+        except KeyError:
+            # If we don't have DATE-OBS, check filename for date
+            try:
+                basename = os.path.splitext(os.path.basename(fname))[0]
+                date_time = date_parser.parse(basename).isoformat()
+            except Exception:
+                # Otherwise use now
+                date_time = current_time(pretty=True)
+
+        date_time = date_time.replace('T', ' ', 1)
 
         title = '{} ({}s {}) {}'.format(field, exp_time, filter_type, date_time)
 

--- a/pocs/utils/images/__init__.py
+++ b/pocs/utils/images/__init__.py
@@ -69,7 +69,7 @@ def make_pretty_image(fname, title=None, timeout=15, **kwargs):  # pragma: no co
     This will create a jpg file from either a CR2 (Canon) or FITS file.
 
     Notes:
-        See `/scripts/cr2_to_jpg.sh` for CR2 process.
+        See `$POCS/scripts/cr2_to_jpg.sh` for CR2 process.
 
     Arguments:
         fname {str} -- Name of image file, may be either .fits or .cr2

--- a/scripts/cr2_to_jpg.sh
+++ b/scripts/cr2_to_jpg.sh
@@ -7,13 +7,13 @@ usage() {
 # If exiftool is present this merely extracts the thumbnail from
 # the CR2 file, otherwise use dcraw to create a jpeg.
 #
-# If present the CAPTION is added as a caption to the jpeg.
+# If present the TITLE is added as a title to the jpeg.
 ##################################################
- $ $(basename $0) FILENAME [CAPTION]
+ $ $(basename $0) FILENAME [TITLE]
  
  Options:
   FILENAME          Name of CR2 file that holds jpeg.
-  CAPTION           Optional caption to be placed on jpeg.
+  TITLE             Optional tilte to be placed on jpeg.
 
  Example:
   scripts/cr2_to_jpg.sh /var/panoptes/images/temp.cr2 \"M42 (Orion's Nebula)\"
@@ -26,7 +26,7 @@ if [ $# -eq 0 ]; then
 fi
 
 FNAME=$1
-CAPTION="${2}"
+TITLE="${2}"
 
 JPG="${FNAME%.cr2}.jpg"
 
@@ -45,12 +45,12 @@ else
     fi
 fi
 
-if [[ -n "$CAPTION" ]]
+if [[ -n "$TITLE" ]]
   then
-  	echo "Adding caption \"${CAPTION}\""
+  	echo "Adding title \"${TITLE}\""
 	# Make thumbnail from jpg.
 	convert "${JPG}" -background black -fill red \
-	    -font ubuntu -pointsize 60 label:"${CAPTION}" \
+	    -font ubuntu -pointsize 60 label:"${TITLE}" \
 	    -gravity South -append "${JPG}"
 fi
 


### PR DESCRIPTION
Some fixes to the making of the image title. Follow up from comment in #493 

* Consistency with `title` parameter.
* No default title if nothing passed (making a title is very slow on a raspberry pi).
* Sneaking a few cleanup items in.

@jamessynge this does not add any coordinates to the title. The `info` dictionary has the coordinates for the field but I'm not sure that makes the most sense as pointing could be off. Coordinates for the center don't exist yet because this comes before plate-solve.