### PR TITLE
Use unit_id for sequence and image ids

### DIFF
--- a/conf_files/pocs.yaml
+++ b/conf_files/pocs.yaml
@@ -1,6 +1,18 @@
 ---
+######################### PANOPTES UNIT ########################################
+# name:   Can be anything you want it to be. This name is displayed in several
+#         places and should be a "personal" name for the unit.
+#
+# pan_id: This is an identification number assigned by the PANOPTES team and is
+#         the official designator for your unit. This id is used to store image
+#         files and communicate with the Google Cloud network.
+#
+#         Leave the pan_id at `PAN000` for testing until you have been assigned
+#         an official id. Update pocs_local.yaml with offical name once received.
+################################################################################
 name: Generic PANOPTES Unit
-pan_id: PAN000   # This unit's assigned identifier.
+pan_id: PAN000   
+
 location:
     name: Mauna Loa Observatory
     latitude: 19.54 # Degrees
@@ -54,13 +66,13 @@ messaging:
     cmd_port: 6500
     msg_port: 6510
 
-######################## Google Network ####################################
+######################## Google Network ########################################
 # By default all images are stored on googlecloud servers and we also
 # use a few google services to store metadata, communicate with servers, etc.
 #
 # See $POCS/pocs/utils/google/README.md for
 # details about authentication.
-############################################################################
+################################################################################
 panoptes_network:
     image_storage: True
     metadata_storage: True

--- a/conf_files/pocs.yaml
+++ b/conf_files/pocs.yaml
@@ -1,6 +1,6 @@
 ---
 name: Generic PANOPTES Unit
-# pan_id: PANxyz   # This unit's assigned identifier.
+pan_id: PAN000   # This unit's assigned identifier.
 location:
     name: Mauna Loa Observatory
     latitude: 19.54 # Degrees

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -434,15 +434,19 @@ class AbstractCamera(PanBase):
 
             file_path = filename
 
+        unit_id = self.config['pan_id']
+
+        # Make the image_id
         image_id = '{}_{}_{}'.format(
-            self.config['name'],
+            unit_id,
             self.uid,
             start_time
         )
         self.logger.debug("image_id: {}".format(image_id))
 
+        # Make the sequence_id
         sequence_id = '{}_{}_{}'.format(
-            self.config['name'],
+            unit_id,
             self.uid,
             observation.seq_time
         )

--- a/pocs/utils/google/__init__.py
+++ b/pocs/utils/google/__init__.py
@@ -1,6 +1,5 @@
 import warnings
 
-from pocs.utils.error import GoogleCloudError
 from pocs.utils.google.storage import PanStorage
 
 
@@ -20,5 +19,5 @@ def is_authenticated():
             PanStorage('test-bucket')
 
         return True
-    except GoogleCloudError:
+    except Exception:
         return False


### PR DESCRIPTION
* **Behavior Change** Enables `pan_id` in the config by default. `PAN000` as simulator?

Closes #586