### PR TITLE
Only use Mongo DB type during local testing - Local Testing with 1/3rd the wait!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ script:
   - arduino --verify --board $BOARD resources/arduino_files/telemetry_board/telemetry_board.ino
   - export PYTHONPATH="$PYTHONPATH:$TRAVIS_BUILD_DIR/scripts/coverage"
   - export COVERAGE_PROCESS_START=.coveragerc
-  - coverage run $(which pytest) -v
+  - coverage run $(which pytest) -v --test-all-databases
   - coverage combine
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ script:
   - arduino --verify --board $BOARD resources/arduino_files/telemetry_board/telemetry_board.ino
   - export PYTHONPATH="$PYTHONPATH:$TRAVIS_BUILD_DIR/scripts/coverage"
   - export COVERAGE_PROCESS_START=.coveragerc
-  - coverage run $(which pytest) -v --test-all-databases
+  - coverage run $(which pytest) -v --test-databases all
   - coverage combine
 
 after_success:

--- a/conftest.py
+++ b/conftest.py
@@ -47,10 +47,10 @@ def pytest_addoption(parser):
         help="Tests cloud strorage functions." +
         "Requires $PANOPTES_CLOUD_KEY to be set to path of valid json service key")
     group.addoption(
-        "--test-all-databases",
-        action="store_true",
-        default=False,
-        help="If all the database types should be tested, default False uses mongo")
+        "--test-databases",
+        nargs="+",
+        default=['mongo'],
+        help="Test databases in the list. Note that travis-ci will test all of them by default.")
 
 
 def pytest_collection_modifyitems(config, items):
@@ -220,7 +220,8 @@ def can_connect_to_mongo():
 @pytest.fixture(scope='function', params=['mongo', 'file', 'memory'])
 def db_type(request):
 
-    if not pytest.config.option.test_all_databases and request.param != 'mongo':
+    db_list = pytest.config.option.test_databases
+    if request.param not in db_list and 'all' not in db_list:
         pytest.skip("Skipping {} DB, set --test-all-databases=True".format(request.param))
 
     # If testing mongo, make sure we can connect, otherwise skip.

--- a/conftest.py
+++ b/conftest.py
@@ -46,6 +46,11 @@ def pytest_addoption(parser):
         dest="test_cloud_storage",
         help="Tests cloud strorage functions." +
         "Requires $PANOPTES_CLOUD_KEY to be set to path of valid json service key")
+    group.addoption(
+        "--test-all-databases",
+        action="store_true",
+        default=False,
+        help="If all the database types should be tested, default False uses mongo")
 
 
 def pytest_collection_modifyitems(config, items):
@@ -214,6 +219,10 @@ def can_connect_to_mongo():
 
 @pytest.fixture(scope='function', params=['mongo', 'file', 'memory'])
 def db_type(request):
+
+    if not pytest.config.option.test_all_databases and request.param != 'mongo':
+        pytest.skip("Skipping {} DB, set --test-all-databases=True".format(request.param))
+
     # If testing mongo, make sure we can connect, otherwise skip.
     if request.param == 'mongo' and not can_connect_to_mongo():
         pytest.skip("Can't connect to {} DB, skipping".format(request.param))


### PR DESCRIPTION
~~* Adds `--test-all-databases` option which is False by default but enabled for travis tests.~~

Edit: Added `--test-databases [<db_name>]` option to support testing of certain db types.

Call with, e.g. `pytest -xv --test-databases file memory`. Supports an all option (which travis uses). Default 'mongo' only.

Helps with #191 .