### PR TITLE
CloudSQL Proxy Startup

### DIFF
--- a/scripts/startup/start_cloudsql_proxy.sh
+++ b/scripts/startup/start_cloudsql_proxy.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -ex
+
+WINDOW="${1}"
+DB="${2:-meta}"
+echo "Running $(basename "${0}") at $(date), WINDOW=${WINDOW}"
+echo "Creating proxy connection to ${DB} database"
+
+tmux send-keys -t "${WINDOW}" "date" C-m
+sleep 0.5s
+tmux send-keys -t "${WINDOW}" \
+     "python $POCS/scripts/connect_clouddb_proxy --database ${DB} --verbose" C-m
+
+echo "Done at $(date)"

--- a/scripts/startup/start_panoptes_in_tmux.sh
+++ b/scripts/startup/start_panoptes_in_tmux.sh
@@ -99,6 +99,10 @@ set -x
 # These provide connections between message publishers and subscribers.
 create_and_init_window msg_hub start_messaging_hub.sh
 
+# Create a window running the Google CloudSQL proxy script, connecting
+# to the meta database.
+create_and_init_window meta_db start_cloudsql_proxy.sh meta
+
 # Create a window running the social messaging program. It subscribes to
 # zeromq and posts some messages to Twitter or Slack, if
 # conf_files/pocs_local.yaml has the appropriate config values; if not,


### PR DESCRIPTION
Adding a script for starting the google cloudsql proxy, connecting to the meta db by default.

@jamessynge is there any way to test these startup scripts?

Part of #599 