### PR TITLE
Fixing tests related to image solving with simulator

### DIFF
--- a/pocs/camera/simulator.py
+++ b/pocs/camera/simulator.py
@@ -83,7 +83,7 @@ class Camera(AbstractCamera):
 
     def _fake_exposure(self, filename, header, exposure_event):
         # Get example FITS file from test data directory
-        file_path = "{}/pocs/tests/data/{}".format(os.getenv('POCS'), 'solved.fits')
+        file_path = os.path.join(os.getenv('POCS'), 'pocs', 'tests', 'data', 'unsolved.fits')
         fake_data = fits.getdata(file_path)
 
         if header['IMAGETYP'] == 'Dark Frame':

--- a/pocs/observatory.py
+++ b/pocs/observatory.py
@@ -264,8 +264,7 @@ class Observatory(PanBase):
 
             try:
                 # Start the exposures
-                cam_event = camera.take_observation(
-                    self.current_observation, headers)
+                cam_event = camera.take_observation(self.current_observation, headers)
 
                 camera_events[cam_name] = cam_event
 
@@ -287,6 +286,8 @@ class Observatory(PanBase):
         self.current_offset_info = None
 
         pointing_image = self.current_observation.pointing_image
+        self.logger.debug(
+            "Analyzing recent image using pointing image: '{}'".format(pointing_image))
 
         try:
             # Get the image to compare
@@ -294,15 +295,13 @@ class Observatory(PanBase):
 
             current_image = Image(image_path, location=self.earth_location)
 
-            solve_info = current_image.solve_field()
+            solve_info = current_image.solve_field(skip_solved=False)
 
             self.logger.debug("Solve Info: {}".format(solve_info))
 
             # Get the offset between the two
-            self.current_offset_info = current_image.compute_offset(
-                pointing_image)
-            self.logger.debug('Offset Info: {}'.format(
-                self.current_offset_info))
+            self.current_offset_info = current_image.compute_offset(pointing_image)
+            self.logger.debug('Offset Info: {}'.format(self.current_offset_info))
 
             # Store the offset information
             self.db.insert('offset_info', {
@@ -733,7 +732,8 @@ class Observatory(PanBase):
             raise error.CameraNotFound(
                 msg="No cameras available. Exiting.", exit=True)
 
-        self.logger.debug("Cameras created")
+        self.logger.debug("Primary camera: {}", self.primary_camera)
+        self.logger.debug("{} cameras created", len(self.cameras))
 
     def _create_scheduler(self):
         """ Sets up the scheduler that will be used by the observatory """

--- a/pocs/scheduler/dispatch.py
+++ b/pocs/scheduler/dispatch.py
@@ -77,23 +77,23 @@ class Scheduler(BaseScheduler):
             # Sort the list by highest score (reverse puts in correct order)
             best_obs = sorted(valid_obs.items(), key=lambda x: x[1])[::-1]
 
-            top_obs = best_obs[0]
+            top_obs_name, top_obs_merit = best_obs[0]
 
             # Check new best against current_observation
             if self.current_observation is not None \
-                    and top_obs[0] != self.current_observation.name:
+                    and top_obs_name != self.current_observation.name:
 
                 # Favor the current observation if still available
                 end_of_next_set = time + self.current_observation.set_duration
                 if self.observation_available(self.current_observation, end_of_next_set):
 
                     # If current is better or equal to top, use it
-                    if self.current_observation.merit >= top_obs[1]:
+                    if self.current_observation.merit >= top_obs_merit:
                         best_obs.insert(0, self.current_observation)
 
             # Set the current
-            self.current_observation = self.observations[top_obs[0]]
-            self.current_observation.merit = top_obs[1]
+            self.current_observation = self.observations[top_obs_name]
+            self.current_observation.merit = top_obs_merit
         else:
             if self.current_observation is not None:
                 # Favor the current observation if still available


### PR DESCRIPTION
* Use unsolved image so we can test solving
* Pass `skip_solved=False` during `analyze_recent`. Helps with testing when
the same image is used repeatedly, shouldn't affect normal usage.
* Add some extra logging
* Misc cleanup