### PR TITLE
Fixing observing/pointing wait events

### DIFF
--- a/pocs/state/states/default/observing.py
+++ b/pocs/state/states/default/observing.py
@@ -1,7 +1,6 @@
-from astropy import units as u
 from pocs import utils as pocs_utils
 
-MAX_EXTRA_TIME = 60 * u.second
+MAX_EXTRA_TIME = 60  # seconds
 
 
 def on_enter(event_data):

--- a/pocs/state/states/default/pointing.py
+++ b/pocs/state/states/default/pointing.py
@@ -1,7 +1,6 @@
-from astropy import units as u
 from pocs.images import Image
 
-MAX_EXTRA_TIME = 60 * u.second
+MAX_EXTRA_TIME = 60  # second
 
 
 def on_enter(event_data):

--- a/pocs/tests/utils/test_utils.py
+++ b/pocs/tests/utils/test_utils.py
@@ -3,6 +3,7 @@ import pytest
 
 import time
 from datetime import datetime as dt
+from astropy import units as u
 
 from pocs.utils import current_time
 from pocs.utils import listify
@@ -69,6 +70,10 @@ def test_countdown_timer_non_blocking():
     timer = CountdownTimer(0)
     assert timer.is_non_blocking
     assert timer.time_left() == 0
+
+    for arg, expected_duration in [(2, 2.0), (0.5, 0.5), (1 * u.second, 1.0)]:
+        timer = CountdownTimer(arg)
+        assert timer.duration == expected_duration
 
 
 def test_countdown_timer():

--- a/pocs/tests/utils/test_utils.py
+++ b/pocs/tests/utils/test_utils.py
@@ -1,12 +1,13 @@
 import os
 import pytest
 
+import time
 from datetime import datetime as dt
-
 
 from pocs.utils import current_time
 from pocs.utils import listify
 from pocs.utils import load_module
+from pocs.utils import CountdownTimer
 from pocs.utils.error import NotFound
 from pocs.camera import list_connected_cameras
 
@@ -51,3 +52,30 @@ def test_has_camera_ports():
 
     for port in ports:
         assert port.startswith('usb:')
+
+
+def test_countdown_timer_bad_input():
+    with pytest.raises(ValueError):
+        assert CountdownTimer('d')
+
+    with pytest.raises(ValueError):
+        assert CountdownTimer(current_time())
+
+    with pytest.raises(AssertionError):
+        assert CountdownTimer(-1)
+
+
+def test_countdown_timer_non_blocking():
+    timer = CountdownTimer(0)
+    assert timer.is_non_blocking
+    assert timer.time_left() == 0
+
+
+def test_countdown_timer():
+    timer = CountdownTimer(1)
+    assert timer.time_left() > 0
+    assert timer.expired() is False
+    assert timer.is_non_blocking is False
+    time.sleep(1)
+    assert timer.time_left() == 0
+    assert timer.expired() is True

--- a/pocs/tests/utils/test_utils.py
+++ b/pocs/tests/utils/test_utils.py
@@ -77,10 +77,17 @@ def test_countdown_timer_non_blocking():
 
 
 def test_countdown_timer():
-    timer = CountdownTimer(1)
+    count_time = 1
+    timer = CountdownTimer(count_time)
     assert timer.time_left() > 0
     assert timer.expired() is False
     assert timer.is_non_blocking is False
-    time.sleep(1)
+
+    counter = 0.
+    while timer.time_left() > 0:
+        time.sleep(0.1)
+        counter += 0.1
+
+    assert counter == pytest.approx(1)
     assert timer.time_left() == 0
     assert timer.expired() is True

--- a/pocs/utils/__init__.py
+++ b/pocs/utils/__init__.py
@@ -65,7 +65,7 @@ class CountdownTimer(object):
         elif not isinstance(duration, (int, float)):
             raise ValueError(
                 'duration (%r) is not a supported type: %s' % (duration, type(duration)))
-        assert duration >= 0
+        assert duration >= 0, "Duration must be non-negative."
         self.is_non_blocking = (duration == 0)
         self.duration = duration
         self.restart()


### PR DESCRIPTION
Removing units from the MAX_EXTRA_TIME for consistency.

This is fixing a bug introduced in #625.

@jamessynge note that this is fixing those problems with testing the flaws in our testing I was talking about. The bug was causing a shutdown in the pointing state but most of the tests in `test_pocs` report as passing because POCS itself was absorbing the errors.

