### PR TITLE
Autofocus Plots set to False

### DIFF
--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -301,7 +301,7 @@ class AbstractCamera(PanBase):
                   merit_function_kwargs={},
                   mask_dilations=None,
                   coarse=False,
-                  plots=True,
+                  plots=False,
                   blocking=False,
                   *args, **kwargs):
         """
@@ -336,7 +336,7 @@ class AbstractCamera(PanBase):
             coarse (bool, optional): Whether to begin with coarse focusing,
                 default False
             plots (bool, optional: Whether to write focus plots to images folder,
-                default True.
+                default False.
             blocking (bool, optional): Whether to block until autofocus complete,
                 default False
 

--- a/pocs/focuser/focuser.py
+++ b/pocs/focuser/focuser.py
@@ -178,7 +178,7 @@ class AbstractFocuser(PanBase):
                   merit_function_kwargs=None,
                   mask_dilations=None,
                   coarse=False,
-                  plots=True,
+                  plots=False,
                   blocking=False):
         """
         Focuses the camera using the specified merit function. Optionally performs
@@ -210,7 +210,7 @@ class AbstractFocuser(PanBase):
             mask_dilations (int, optional): Number of iterations of dilation to perform on the
                 saturated pixel mask (determine size of masked regions), default 10
             coarse (bool, optional): Whether to begin with coarse focusing, default False.
-            plots (bool, optional: Whether to write focus plots to images folder, default True.
+            plots (bool, optional: Whether to write focus plots to images folder, default False.
             blocking (bool, optional): Whether to block until autofocus complete, default False.
 
         Returns:

--- a/pocs/observatory.py
+++ b/pocs/observatory.py
@@ -409,7 +409,7 @@ class Observatory(PanBase):
 
         return headers
 
-    def autofocus_cameras(self, camera_list=None, coarse=None):
+    def autofocus_cameras(self, camera_list=None, **kwargs):
         """
         Perform autofocus on all cameras with focus capability, or a named subset
         of these. Optionally will perform a coarse autofocus first, otherwise will
@@ -417,8 +417,7 @@ class Observatory(PanBase):
 
         Args:
             camera_list (list, optional): list containing names of cameras to autofocus.
-            coarse (bool, optional): Whether to performan a coarse autofocus before
-            fine tuning, default False.
+            **kwargs: Options passed to the underlying `Focuser.autofocus` method.
 
         Returns:
             dict of str:threading_Event key:value pairs, containing camera names and
@@ -454,7 +453,7 @@ class Observatory(PanBase):
             else:
                 try:
                     # Start the autofocus
-                    autofocus_event = camera.autofocus(coarse=coarse)
+                    autofocus_event = camera.autofocus(**kwargs)
                 except Exception as e:
                     self.logger.error(
                         "Problem running autofocus: {}".format(e))


### PR DESCRIPTION
* Setting autofocus plots to False by default.
* Pass autofocus params straight through to underlying `focuser.autofocus`.

Closes #632 