### PR TITLE
Get `auto_detect` param from correct spot

### DIFF
--- a/pocs/camera/__init__.py
+++ b/pocs/camera/__init__.py
@@ -80,7 +80,7 @@ def create_cameras_from_config(config=None, logger=None, **kwargs):
     logger.debug("Camera config: {}".format(camera_info))
 
     a_simulator = 'camera' in kwargs_or_config('simulator', default=list())
-    auto_detect = camera_info.get('auto_detect', default=False)
+    auto_detect = camera_info.get('auto_detect', False)
 
     ports = list()
 

--- a/pocs/camera/__init__.py
+++ b/pocs/camera/__init__.py
@@ -80,7 +80,7 @@ def create_cameras_from_config(config=None, logger=None, **kwargs):
     logger.debug("Camera config: {}".format(camera_info))
 
     a_simulator = 'camera' in kwargs_or_config('simulator', default=list())
-    auto_detect = kwargs_or_config('auto_detect', default=False)
+    auto_detect = camera_info.get('auto_detect', default=False)
 
     ports = list()
 


### PR DESCRIPTION
Had a quick look at the camera constructor function and think this should be causing problem in #639.

Closes #639.