### PR TITLE
Make sure the merit gets added to the best observations list.

### DIFF
--- a/pocs/scheduler/dispatch.py
+++ b/pocs/scheduler/dispatch.py
@@ -89,7 +89,8 @@ class Scheduler(BaseScheduler):
 
                     # If current is better or equal to top, use it
                     if self.current_observation.merit >= top_obs_merit:
-                        best_obs.insert(0, self.current_observation)
+                        best_obs.insert(0, (self.current_observation,
+                                            self.current_observation.merit))
 
             # Set the current
             self.current_observation = self.observations[top_obs_name]


### PR DESCRIPTION
Fix an inconsistency in assigning to the list of best observations. Because `self.current_observation` is assigned as well (which has a `.merit` property), this list is not actually used for anything during operations and we don't even capture the return value. But should be consistent regardless.

Closes #629.