### PR TITLE
Default for check_file

### DIFF
--- a/pocs/scheduler/scheduler.py
+++ b/pocs/scheduler/scheduler.py
@@ -53,7 +53,7 @@ class BaseScheduler(PanBase):
         self._current_observation = None
         self.observed_list = OrderedDict()
 
-        if not self.config['scheduler']['check_file']:
+        if not self.config['scheduler'].get('check_file', False):
             self.logger.debug("Reading initial set of fields")
             self.read_field_list()
 


### PR DESCRIPTION
Note that the root cause of seeing this was that options in a local config don't come through. Makes it hard to test without a local config.

Fixes #657 