### PR TITLE
Minor debug log output changes

### DIFF
--- a/pocs/core.py
+++ b/pocs/core.py
@@ -372,8 +372,10 @@ class POCS(PanStateMachine, PanBase):
             timestamp = record['date'].replace(tzinfo=None)  # current_time is timezone naive
             age = (current_time().datetime - timestamp).total_seconds()
 
-            self.logger.debug(
-                "Weather Safety: {} [{:.0f} sec old - {}]".format(is_safe, age, timestamp))
+            self.logger.debug("Weather Safety: {} [{:.0f} sec old - {:%d-%m-%Y %H:%M:%S}]",
+                              is_safe,
+                              age,
+                              timestamp)
 
         except (TypeError, KeyError) as e:
             self.logger.warning("No record found in DB: {}", e)

--- a/pocs/core.py
+++ b/pocs/core.py
@@ -372,7 +372,7 @@ class POCS(PanStateMachine, PanBase):
             timestamp = record['date'].replace(tzinfo=None)  # current_time is timezone naive
             age = (current_time().datetime - timestamp).total_seconds()
 
-            self.logger.debug("Weather Safety: {} [{:.0f} sec old - {:%d-%m-%Y %H:%M:%S}]",
+            self.logger.debug("Weather Safety: {} [{:.0f} sec old - {:%Y-%m-%d %H:%M:%S}]",
                               is_safe,
                               age,
                               timestamp)

--- a/pocs/core.py
+++ b/pocs/core.py
@@ -504,7 +504,6 @@ class POCS(PanStateMachine, PanBase):
                 now = current_time()
 
             if now >= next_status_time:
-                self.logger.debug('Inside waiting for events, checking status')
                 self.status()
                 next_status_time += status_interval
                 now = current_time()


### PR DESCRIPTION
* Removing debug statement that was used for testing. Currently it defies the whole point of having the `msg_interval` if we just print debug items anyway.
* Get rid of silly precision in weather reading:
    ```
    Weather Safety: True [74 sec old - 2018-10-03 06:13:07.759000]
    ```
    to
    ```
    Weather Safety: True [74 sec old - 2018-10-03 06:13:07]
    ```