### PR TITLE
Fix breaking bug in Birger focuser

### DIFF
--- a/pocs/camera/sbig.py
+++ b/pocs/camera/sbig.py
@@ -39,7 +39,7 @@ class Camera(AbstractCamera):
                 self.ccd_cooling_enabled = True
             else:
                 self.ccd_cooling_enabled = False
-            self.logger.info('\t\t\t {} initialised'.format(self))
+            self.logger.info('{} initialised'.format(self))
 
 # Properties
 

--- a/pocs/focuser/birger.py
+++ b/pocs/focuser/birger.py
@@ -455,7 +455,7 @@ class Focuser(AbstractFocuser):
             self.logger.error("{} got '{}', expected 'DONE:LA'!".format(self, response))
 
     def _move_inf(self):
-        response = self._send_command('mi', response_length=1).rstrip()
+        response = self._send_command('mi', response_length=1)[0].rstrip()
         if response[:4] != 'DONE':
             self.logger.error("{} got '{}', expected 'DONENNNNN,1'!".format(self, response))
         else:


### PR DESCRIPTION
At some point in recent changes a `[0]` was accidentally removed from a line in `pocs/focuser/birger.py`. The effect of this is to cause the initialisation of the Birger focuser to fail. This was discovered today when attempting to run on real hardware.

I've also taken the liberty of removing a `\t\t\t` from a log message in `pocs/camera/sbig.py` which was a leftover from back when we were using lots of tabs to format our logging.