### PR TITLE
Decouple custom exceptions from PanBase

### DIFF
--- a/pocs/tests/utils/test_utils.py
+++ b/pocs/tests/utils/test_utils.py
@@ -24,6 +24,11 @@ def test_error():
 
     assert str(e_info.value) == 'PanError'
 
+    with pytest.raises(SystemExit) as e_info:
+        raise error.PanError(msg="Testing exit", exit=True)
+    assert e_info.type == SystemExit
+    assert str(e_info.value) == 'PanError: Testing exit'
+
 
 def test_bad_load_module():
     with pytest.raises(error.NotFound):

--- a/pocs/tests/utils/test_utils.py
+++ b/pocs/tests/utils/test_utils.py
@@ -14,12 +14,12 @@ from pocs.camera import list_connected_cameras
 
 
 def test_error(capsys):
-    with pytest.raises(Exception) as e_info:
+    with pytest.raises(error.PanError) as e_info:
         raise error.PanError(msg='Testing message')
 
     assert str(e_info.value) == 'PanError: Testing message'
 
-    with pytest.raises(Exception) as e_info:
+    with pytest.raises(error.PanError) as e_info:
         raise error.PanError()
 
     assert str(e_info.value) == 'PanError'

--- a/pocs/tests/utils/test_utils.py
+++ b/pocs/tests/utils/test_utils.py
@@ -17,12 +17,12 @@ def test_error():
     with pytest.raises(Exception) as e_info:
         raise error.PanError(msg='Testing message')
 
-    assert 'PanError: Testing message' == str(e_info.value)
+    assert str(e_info.value) == 'PanError: Testing message'
 
     with pytest.raises(Exception) as e_info:
         raise error.PanError()
 
-    assert 'Testing message' not in str(e_info.value)
+    assert str(e_info.value) == 'PanError'
 
 
 def test_bad_load_module():

--- a/pocs/tests/utils/test_utils.py
+++ b/pocs/tests/utils/test_utils.py
@@ -9,12 +9,24 @@ from pocs.utils import current_time
 from pocs.utils import listify
 from pocs.utils import load_module
 from pocs.utils import CountdownTimer
-from pocs.utils.error import NotFound
+from pocs.utils import error
 from pocs.camera import list_connected_cameras
 
 
+def test_error():
+    with pytest.raises(Exception) as e_info:
+        raise error.PanError(msg='Testing message')
+
+    assert 'PanError: Testing message' == str(e_info.value)
+
+    with pytest.raises(Exception) as e_info:
+        raise error.PanError()
+
+    assert 'Testing message' not in str(e_info.value)
+
+
 def test_bad_load_module():
-    with pytest.raises(NotFound):
+    with pytest.raises(error.NotFound):
         load_module('FOOBAR')
 
 

--- a/pocs/tests/utils/test_utils.py
+++ b/pocs/tests/utils/test_utils.py
@@ -13,7 +13,7 @@ from pocs.utils import error
 from pocs.camera import list_connected_cameras
 
 
-def test_error():
+def test_error(capsys):
     with pytest.raises(Exception) as e_info:
         raise error.PanError(msg='Testing message')
 
@@ -27,7 +27,12 @@ def test_error():
     with pytest.raises(SystemExit) as e_info:
         raise error.PanError(msg="Testing exit", exit=True)
     assert e_info.type == SystemExit
-    assert str(e_info.value) == 'PanError: Testing exit'
+    assert capsys.readouterr().out.strip() == 'TERMINATING: Testing exit'
+
+    with pytest.raises(SystemExit) as e_info:
+        raise error.PanError(exit=True)
+    assert e_info.type == SystemExit
+    assert capsys.readouterr().out.strip() == 'TERMINATING: No reason specified'
 
 
 def test_bad_load_module():

--- a/pocs/utils/error.py
+++ b/pocs/utils/error.py
@@ -22,6 +22,14 @@ class PanError(Exception):
         print("TERMINATING: {}".format(msg))
         sys.exit(1)
 
+    def __str__(self):
+        error_str = 'PanError'
+
+        if hasattr(self, 'msg'):
+            error_str += ': {}'.format(self.msg)
+
+        return error_str
+
 
 class InvalidSystemCommand(PanError):
 

--- a/pocs/utils/error.py
+++ b/pocs/utils/error.py
@@ -10,27 +10,26 @@ class PanError(Exception):
     """ Base class for Panoptes errors """
 
     def __init__(self, msg=None, exit=False):
-        if msg:
-            logger.error('{}: {}'.format(self.__class__.__name__, msg))
+        self.msg = msg
+
+        if self.msg:
+            logger.error(str(self))
 
         if exit:
             self.exit_program(msg)
 
-        self.msg = msg
-
     def exit_program(self, msg=None):
         """ Kills running program """
         if not msg:
-            msg = 'No reason specified'
-        print("TERMINATING: {}".format(msg))
+            self.msg = 'No reason specified'
+
+        print("TERMINATING: {}".format(self.msg))
         sys.exit(1)
 
     def __str__(self):
-        error_str = 'PanError'
-
-        # Add the custom message if we have one
+        error_str = str(self.__class__.__name__)
         if self.msg:
-            error_str += ': {}'.format(self.msg)
+            error_str += ': ' + self.msg
 
         return error_str
 

--- a/pocs/utils/error.py
+++ b/pocs/utils/error.py
@@ -29,7 +29,7 @@ class PanError(Exception):
     def __str__(self):
         error_str = str(self.__class__.__name__)
         if self.msg:
-            error_str += ': ' + self.msg
+            error_str += ': {}'.format(self.msg)
 
         return error_str
 

--- a/pocs/utils/error.py
+++ b/pocs/utils/error.py
@@ -1,5 +1,4 @@
 import sys
-from contextlib import suppress
 
 from pocs.utils.logger import get_root_logger
 
@@ -12,14 +11,17 @@ class PanError(Exception):
 
     def __init__(self, msg=None, exit=False):
         if msg:
-            if exit:
-                self.exit_program(msg)
-            else:
-                logger.error('{}: {}'.format(self.__class__.__name__, msg))
-                self.msg = msg
+            logger.error('{}: {}'.format(self.__class__.__name__, msg))
 
-    def exit_program(self, msg='No reason specified'):
+        if exit:
+            self.exit_program(msg)
+
+        self.msg = msg
+
+    def exit_program(self, msg=None):
         """ Kills running program """
+        if not msg:
+            msg = 'No reason specified'
         print("TERMINATING: {}".format(msg))
         sys.exit(1)
 
@@ -27,7 +29,7 @@ class PanError(Exception):
         error_str = 'PanError'
 
         # Add the custom message if we have one
-        with suppress(AttributeError):
+        if self.msg:
             error_str += ': {}'.format(self.msg)
 
         return error_str

--- a/pocs/utils/error.py
+++ b/pocs/utils/error.py
@@ -1,5 +1,9 @@
 import sys
 
+from pocs.utils.logger import get_root_logger
+
+logger = get_root_logger()
+
 
 class PanError(Exception):
 
@@ -10,7 +14,7 @@ class PanError(Exception):
             if exit:
                 self.exit_program(msg)
             else:
-                print('{}: {}'.format(self.__class__.__name__, msg))
+                logger.error('{}: {}'.format(self.__class__.__name__, msg))
                 self.msg = msg
 
     def exit_program(self, msg='No reason specified'):

--- a/pocs/utils/error.py
+++ b/pocs/utils/error.py
@@ -16,7 +16,7 @@ class PanError(Exception):
             logger.error(str(self))
 
         if exit:
-            self.exit_program(msg)
+            self.exit_program(self.msg)
 
     def exit_program(self, msg=None):
         """ Kills running program """
@@ -109,7 +109,7 @@ class MountNotFound(NotFound):
     """ Mount cannot be import """
 
     def __init__(self, msg='Mount Not Found'):
-        self.exit_program(msg=msg)
+        super().__init__(msg, exit=True)
 
 
 class CameraNotFound(NotFound):

--- a/pocs/utils/error.py
+++ b/pocs/utils/error.py
@@ -1,21 +1,16 @@
 import sys
 
-from astropy.utils.exceptions import AstropyWarning
 
-from pocs.base import PanBase
-
-
-class PanError(AstropyWarning, PanBase):
+class PanError(Exception):
 
     """ Base class for Panoptes errors """
 
     def __init__(self, msg=None, exit=False):
-        PanBase.__init__(self)
         if msg:
             if exit:
                 self.exit_program(msg)
             else:
-                self.logger.error('{}: {}'.format(self.__class__.__name__, msg))
+                print('{}: {}'.format(self.__class__.__name__, msg))
                 self.msg = msg
 
     def exit_program(self, msg='No reason specified'):

--- a/pocs/utils/error.py
+++ b/pocs/utils/error.py
@@ -1,4 +1,5 @@
 import sys
+from contextlib import suppress
 
 from pocs.utils.logger import get_root_logger
 
@@ -25,7 +26,8 @@ class PanError(Exception):
     def __str__(self):
         error_str = 'PanError'
 
-        if hasattr(self, 'msg'):
+        # Add the custom message if we have one
+        with suppress(AttributeError):
             error_str += ': {}'.format(self.msg)
 
         return error_str


### PR DESCRIPTION
We have some dependencies in the custom exceptions file that make them hard to use outside of a full install of all POCS dependencies. In particular, I want to be able to load anything from `pocs.utils` without having to import `PanBase`. This is useful for, e.g. Cloud Functions.

It is unclear if we were using anything from `AstropyWarning` to our advantage but if so we are not testing for it.

Edit: Oh wow, I think this got rid of our surplus of astropy warnings. Go figure.