### PR TITLE
Decouple serial utils

### DIFF
--- a/pocs/tests/serial_handlers/protocol_buffers.py
+++ b/pocs/tests/serial_handlers/protocol_buffers.py
@@ -44,6 +44,7 @@ def GetWBufferValue():
 
 class BuffersSerial(NoOpSerial):
     def __init__(self, *args, **kwargs):
+        ResetBuffers(b'')
         super().__init__(*args, **kwargs)
 
     @property

--- a/pocs/tests/serial_handlers/protocol_buffers.py
+++ b/pocs/tests/serial_handlers/protocol_buffers.py
@@ -44,7 +44,6 @@ def GetWBufferValue():
 
 class BuffersSerial(NoOpSerial):
     def __init__(self, *args, **kwargs):
-        ResetBuffers(b'')
         super().__init__(*args, **kwargs)
 
     @property

--- a/pocs/tests/test_rs232.py
+++ b/pocs/tests/test_rs232.py
@@ -58,7 +58,7 @@ def test_detect_bogus_scheme(handler):
 
 def test_custom_logger(handler, fake_logger):
     s0 = rs232.SerialData(port='no_op://', logger=fake_logger)
-    s0.debug('Testing logger')
+    s0.logger.debug('Testing logger')
 
 
 def test_basic_no_op(handler):

--- a/pocs/tests/test_rs232.py
+++ b/pocs/tests/test_rs232.py
@@ -16,6 +16,11 @@ def test_missing_port():
         rs232.SerialData()
 
 
+def test_custom_logger(fake_logger):
+    s0 = rs232.SerialData(logger=fake_logger)
+    s0.debug('Testing logger')
+
+
 def test_non_existent_device():
     """Doesn't complain if it can't find the device."""
     port = '/dev/tty12345698765'

--- a/pocs/tests/test_rs232.py
+++ b/pocs/tests/test_rs232.py
@@ -11,6 +11,11 @@ from pocs.tests.serial_handlers import protocol_buffers
 from pocs.tests.serial_handlers import protocol_hooked
 
 
+def test_port_discovery():
+    ports = rs232.get_serial_port_info()
+    assert isinstance(ports, list)
+
+
 def test_missing_port():
     with pytest.raises(ValueError):
         rs232.SerialData()

--- a/pocs/tests/test_rs232.py
+++ b/pocs/tests/test_rs232.py
@@ -16,11 +16,6 @@ def test_missing_port():
         rs232.SerialData()
 
 
-def test_custom_logger(fake_logger):
-    s0 = rs232.SerialData(logger=fake_logger)
-    s0.debug('Testing logger')
-
-
 def test_non_existent_device():
     """Doesn't complain if it can't find the device."""
     port = '/dev/tty12345698765'
@@ -59,6 +54,11 @@ def test_detect_bogus_scheme(handler):
         # a string that can't be a module name.
         rs232.SerialData(port='# bogus #://')
     assert '# bogus #' in repr(excinfo.value)
+
+
+def test_custom_logger(handler, fake_logger):
+    s0 = rs232.SerialData(port='no_op://', logger=fake_logger)
+    s0.debug('Testing logger')
 
 
 def test_basic_no_op(handler):

--- a/pocs/utils/rs232.py
+++ b/pocs/utils/rs232.py
@@ -30,7 +30,7 @@ def _parse_json(line, logger, min_error_pos=0):
 
 # Note: get_serial_port_info is replaced by tests to override the normal
 # behavior, so don't change the name without fixing the tests.
-def get_serial_port_info():
+def get_serial_port_info():  # pragma: no cover
     """Returns the serial ports defined on the system.
 
     Returns: a list of PySerial's ListPortInfo objects. See:

--- a/pocs/utils/rs232.py
+++ b/pocs/utils/rs232.py
@@ -47,6 +47,37 @@ class SerialData(object):
     serial device. Note that for most devices, is_connected will return true if the device is
     turned off/unplugged after a connection is opened; the code will only discover there is a
     problem when we attempt to interact with the device.
+
+    .. doctest::
+
+        >>> import serial
+        # Register our serial simulators
+        >>> serial.protocol_handler_packages.append('pocs.tests.serial_handlers')
+        # Create a fake device
+        >>> from pocs.tests.serial_handlers.protocol_buffers import SetRBufferValue as WriteFakeDevice
+        >>> from pocs.tests.serial_handlers.protocol_buffers import GetWBuffer as ReadFakeDevice
+
+        # Import our serial utils
+        >>> from pocs.utils.rs232 import SerialData
+
+        # Connect to our fake buffered device
+        >>> device_listener = SerialData(port='buffers://')
+        >>> device_listener.is_connected
+        True
+
+        >>> device.port
+        buffers://
+
+        # Device sends event
+        >>> WriteFakeDevice(b'emit event')
+
+        # Listen for event
+        >>> device_listener.read()
+        emit event
+
+        >>> device_listener.write(b'ack event')
+        >>> ReadFakeDevice()
+        ack event
     """
 
     def __init__(self,

--- a/pocs/utils/rs232.py
+++ b/pocs/utils/rs232.py
@@ -6,7 +6,7 @@ import serial
 from serial.tools.list_ports import comports as get_comports
 import time
 
-from pocs.base import PanBase
+from pocs.utils.logger import get_root_logger
 from pocs.utils.error import BadSerialConnection
 
 
@@ -56,7 +56,9 @@ class SerialData(PanBase):
                  timeout=2.0,
                  open_delay=0.0,
                  retry_limit=5,
-                 retry_delay=0.5):
+                 retry_delay=0.5,
+                 logger=None,
+                 ):
         """Create a SerialData instance and attempt to open a connection.
 
         The device need not exist at the time this is called, in which case is_connected will
@@ -73,12 +75,15 @@ class SerialData(PanBase):
             open_delay: Seconds to wait after opening the port.
             retry_limit: Number of times to try readline() calls in read().
             retry_delay: Delay between readline() calls in read().
+            logger (`logging.logger` or None, optional): A logger instance. If left as None
+                then `pocs.utils.logger.get_root_logger` will be called.
 
         Raises:
             ValueError: If the serial parameters are invalid (e.g. a negative baudrate).
 
         """
-        PanBase.__init__(self)
+        if not logger:
+            logger = get_root_logger()
 
         if not port:
             raise ValueError('Must specify port for SerialData')

--- a/pocs/utils/rs232.py
+++ b/pocs/utils/rs232.py
@@ -30,7 +30,7 @@ def _parse_json(line, logger, min_error_pos=0):
 
 # Note: get_serial_port_info is replaced by tests to override the normal
 # behavior, so don't change the name without fixing the tests.
-def get_serial_port_info():  # pragma: no cover
+def get_serial_port_info():
     """Returns the serial ports defined on the system.
 
     Returns: a list of PySerial's ListPortInfo objects. See:

--- a/pocs/utils/rs232.py
+++ b/pocs/utils/rs232.py
@@ -39,7 +39,7 @@ def get_serial_port_info():
     return sorted(get_comports(), key=operator.attrgetter('device'))
 
 
-class SerialData(PanBase):
+class SerialData(object):
     """SerialData wraps a PySerial instance for reading from and writing to a serial device.
 
     Because POCS is intended to be very long running, and hardware may be turned off when unused
@@ -84,6 +84,7 @@ class SerialData(PanBase):
         """
         if not logger:
             logger = get_root_logger()
+        self.logger = logger
 
         if not port:
             raise ValueError('Must specify port for SerialData')


### PR DESCRIPTION
Follow up to #672, this removes the `PanBase` dependency from the serial utilities.

@jamessynge this works well with the tests. Any issues you can think of?