### PR TITLE
Remove support for the 'fileline' attribute in log formats

### DIFF
--- a/conf_files/log.yaml
+++ b/conf_files/log.yaml
@@ -7,8 +7,7 @@ logger:
         datefmt: '%H:%M:%S'
       detail:
         style: '{'
-        # See FilenameLineFilter in logger.py for fileline description
-        format: '{levelname:.1s}{asctime}.{msecs:03.0f} {fileline:20s} {message}'
+        format: '{levelname:.1s}{asctime}.{msecs:03.0f} {filename} {lineno} {message}'
         datefmt: '%m%d %H:%M:%S'
     handlers:
       all:

--- a/conf_files/log.yaml
+++ b/conf_files/log.yaml
@@ -7,7 +7,7 @@ logger:
         datefmt: '%H:%M:%S'
       detail:
         style: '{'
-        format: '{levelname:.1s}{asctime}.{msecs:03.0f} {filename:>25s}:{lineno:03d} {message}'
+        format: '{levelname:.1s}{asctime}.{msecs:03.0f} {filename:>25s}:{lineno:03d}] {message}'
         datefmt: '%m%d %H:%M:%S'
     handlers:
       all:

--- a/conf_files/log.yaml
+++ b/conf_files/log.yaml
@@ -7,7 +7,7 @@ logger:
         datefmt: '%H:%M:%S'
       detail:
         style: '{'
-        format: '{levelname:.1s}{asctime}.{msecs:03.0f} {filename} {lineno} {message}'
+        format: '{levelname:.1s}{asctime}.{msecs:03.0f} {filename:>25s}:{lineno:03d} {message}'
         datefmt: '%m%d %H:%M:%S'
     handlers:
       all:

--- a/pocs/utils/logger.py
+++ b/pocs/utils/logger.py
@@ -127,9 +127,6 @@ def get_root_logger(profile='panoptes', log_config=None):
     # Set custom LogRecord
     logging.setLogRecordFactory(StrFormatLogRecord)
 
-    # Add a filter for better filename/lineno
-    logger.addFilter(FilenameLineFilter())
-
     logger.info('{:*^80}'.format(' Starting PanLogger '))
     # TODO(jamessynge) Output name of script, cmdline args, etc. And do son
     # when the log rotates too!
@@ -141,12 +138,3 @@ class _UTCFormatter(logging.Formatter):
 
     """ Simple class to convert times to UTC in the logger """
     converter = time.gmtime
-
-
-class FilenameLineFilter(logging.Filter):
-    """Adds a simple concatenation of filename and lineno for fixed length """
-
-    def filter(self, record):
-
-        record.fileline = '{}:{}'.format(record.filename, record.lineno)
-        return True

--- a/scripts/run_social_messaging.py
+++ b/scripts/run_social_messaging.py
@@ -97,7 +97,7 @@ if __name__ == '__main__':
     # This is early in startup to ensure the PANOPTES logging code is
     # installed early. Unfortunately this doesn't (yet) prevent the
     # problem with our format keyword 'fileline' causing problems for
-    # other loggers.
+    # other loggers. See issue #393.
     pocs_config = load_config()
     the_root_logger = get_root_logger()
 


### PR DESCRIPTION
This non-standard attribute has been the cause of many problems,
so reverting back to using only the default attributes.