### PR TITLE
Dome Simulator in local config test failure.

### DIFF
--- a/pocs/tests/test_observatory.py
+++ b/pocs/tests/test_observatory.py
@@ -27,11 +27,13 @@ def simulator():
 @pytest.fixture
 def observatory(config, simulator):
     """Return a valid Observatory instance with a specific config."""
-    cameras = create_cameras_from_config(config)
     obs = Observatory(config=config,
                       simulator=simulator,
-                      cameras=cameras,
                       ignore_local_config=True)
+    cameras = create_cameras_from_config(config)
+    for cam_name, cam in cameras.items():
+        obs.add_camera(cam_name, cam)
+
     return obs
 
 


### PR DESCRIPTION
If a dome simulator is explicitly added to the `pocs_local.yaml` file it breaks the testing, revealing deeper problems with the load config.

The issue is that the config is stored globablly, so with the move to hardware that is created before the Observatory we now can have the config loaded in a global way by hardware.

This is a temporary fix to an issue reported privately by @jamessynge. A deeper examination of the config loading w.r.t. local files is warranted.