### PR TITLE
Reduce pocs test redundancy (and fix camera simulator)

### DIFF
--- a/pocs/camera/simulator.py
+++ b/pocs/camera/simulator.py
@@ -38,6 +38,11 @@ class Camera(AbstractCamera):
             kwargs['exp_time'] = 1
             self.logger.debug("Trimming camera simulator exposure to 1 s")
 
+        # If POCSTIME is set for testing then the simulator will generate
+        # duplicate filenames each time so we pass a filename here. Full path
+        # is added in `camera._setup_obseravtion`.
+        filename = 'simulator_{:02d}.{}'.format(self.file_extension)
+
         return super().take_observation(observation,
                                         headers,
                                         filename,

--- a/pocs/camera/simulator.py
+++ b/pocs/camera/simulator.py
@@ -41,7 +41,7 @@ class Camera(AbstractCamera):
         # If POCSTIME is set for testing then the simulator will generate
         # duplicate filenames each time so we pass a filename here. Full path
         # is added in `camera._setup_obseravtion`.
-        filename = 'simulator_{:02d}.{}'.format(self.file_extension)
+        filename = 'simulator_{:02d}.{}'.format(observation.current_exp, self.file_extension)
 
         return super().take_observation(observation,
                                         headers,

--- a/pocs/camera/simulator.py
+++ b/pocs/camera/simulator.py
@@ -34,9 +34,9 @@ class Camera(AbstractCamera):
     def take_observation(self, observation, headers=None, filename=None, *args, **kwargs):
 
         exp_time = kwargs.get('exp_time', observation.exp_time.value)
-        if exp_time > 2:
-            kwargs['exp_time'] = 2
-            self.logger.debug("Trimming camera simulator exposure to 2 s")
+        if exp_time > 1:
+            kwargs['exp_time'] = 1
+            self.logger.debug("Trimming camera simulator exposure to 1 s")
 
         return super().take_observation(observation,
                                         headers,

--- a/pocs/camera/simulator.py
+++ b/pocs/camera/simulator.py
@@ -40,7 +40,7 @@ class Camera(AbstractCamera):
 
         # If POCSTIME is set for testing then the simulator will generate
         # duplicate filenames each time so we pass a filename here. Full path
-        # is added in `camera._setup_obseravtion`.
+        # is added in `camera._setup_observation`.
         filename = 'simulator_{:02d}.{}'.format(observation.current_exp, self.file_extension)
 
         return super().take_observation(observation,

--- a/pocs/scheduler/scheduler.py
+++ b/pocs/scheduler/scheduler.py
@@ -7,6 +7,7 @@ from astroplan import Observer
 from astropy import units as u
 
 from pocs.base import PanBase
+from pocs.utils import error
 from pocs.utils import current_time
 from pocs.scheduler.field import Field
 from pocs.scheduler.observation import Observation
@@ -231,9 +232,9 @@ class BaseScheduler(PanBase):
 
         try:
             obs = Observation(field, **field_config)
-        except Exception as e:
-            self.logger.warning("Skipping invalid field config: {}".format(field_config))
-            self.logger.warning(e)
+        except Exception:
+            raise error.InvalidObservation(
+                "Skipping invalid field config: {}".format(field_config))
         else:
             if field.name in self._observations:
                 self.logger.debug("Overriding existing entry for {}".format(field.name))

--- a/pocs/tests/conftest.py
+++ b/pocs/tests/conftest.py
@@ -23,6 +23,7 @@ def config():
     if not _one_time_config:
         _one_time_config = load_config(ignore_local=True, simulator=['all'])
         _one_time_config['db']['name'] = 'panoptes_testing'
+        _one_time_config['scheduler']['fields_file'] = 'simulator.yaml'
 
     return copy.deepcopy(_one_time_config)
 

--- a/pocs/tests/conftest.py
+++ b/pocs/tests/conftest.py
@@ -15,14 +15,21 @@ from pocs.utils.config import load_config
 _one_time_config = None
 
 
+@pytest.fixture(scope='module')
+def images_dir(tmpdir_factory):
+    directory = tmpdir_factory.mktemp('images')
+    return str(directory)
+
+
 @pytest.fixture(scope='function')
-def config():
+def config(images_dir):
     pocs.base.reset_global_config()
 
     global _one_time_config
     if not _one_time_config:
         _one_time_config = load_config(ignore_local=True, simulator=['all'])
         _one_time_config['db']['name'] = 'panoptes_testing'
+        _one_time_config['directories']['images'] = images_dir
         _one_time_config['scheduler']['fields_file'] = 'simulator.yaml'
 
     return copy.deepcopy(_one_time_config)

--- a/pocs/tests/conftest.py
+++ b/pocs/tests/conftest.py
@@ -29,8 +29,9 @@ def config(images_dir):
     if not _one_time_config:
         _one_time_config = load_config(ignore_local=True, simulator=['all'])
         _one_time_config['db']['name'] = 'panoptes_testing'
-        _one_time_config['directories']['images'] = images_dir
-        _one_time_config['scheduler']['fields_file'] = 'simulator.yaml'
+
+    _one_time_config['directories']['images'] = images_dir
+    _one_time_config['scheduler']['fields_file'] = 'simulator.yaml'
 
     return copy.deepcopy(_one_time_config)
 

--- a/pocs/tests/test_astrohaven_dome.py
+++ b/pocs/tests/test_astrohaven_dome.py
@@ -67,8 +67,14 @@ def test_open_and_close_slit(dome):
     assert dome.status == 'Both sides open'
     assert dome.is_open is True
 
+    # Try to open shutter
+    assert dome.open() is True
+
     assert dome.close() is True
     assert dome.status == 'Both sides closed'
     assert dome.is_closed is True
+
+    # Try to close again
+    assert dome.close() is True
 
     dome.disconnect()

--- a/pocs/tests/test_base_scheduler.py
+++ b/pocs/tests/test_base_scheduler.py
@@ -19,7 +19,7 @@ def constraints():
 
 @pytest.fixture
 def simple_fields_file(config):
-    return config['directories']['targets'] + '/simple.yaml'
+    return config['directories']['targets'] + '/simulator.yaml'
 
 
 @pytest.fixture

--- a/pocs/tests/test_base_scheduler.py
+++ b/pocs/tests/test_base_scheduler.py
@@ -6,8 +6,8 @@ from astropy.coordinates import EarthLocation
 
 from astroplan import Observer
 
+from pocs.utils import error
 from pocs.scheduler import BaseScheduler as Scheduler
-
 from pocs.scheduler.constraint import Duration
 from pocs.scheduler.constraint import MoonAvoidance
 
@@ -170,11 +170,13 @@ def test_scheduler_add_field(scheduler):
 def test_scheduler_add_bad_field(scheduler):
 
     orig_length = len(scheduler.observations)
-    scheduler.add_observation({
-        'name': 'Duplicate Field',
-        'position': '12h30m01s +08d08m08s',
-        'exp_time': -10
-    })
+    with pytest.raises(error.InvalidObservation):
+        scheduler.add_observation({
+            'name': 'Duplicate Field',
+            'position': '12h30m01s +08d08m08s',
+            'exp_time': -10
+        })
+
     assert orig_length == len(scheduler.observations)
 
 

--- a/pocs/tests/test_observatory.py
+++ b/pocs/tests/test_observatory.py
@@ -25,7 +25,7 @@ def simulator():
 
 
 @pytest.fixture
-def observatory(config, simulator):
+def observatory(config, simulator, images_dir):
     """Return a valid Observatory instance with a specific config."""
     cameras = create_cameras_from_config(config)
     obs = Observatory(config=config,
@@ -33,12 +33,6 @@ def observatory(config, simulator):
                       cameras=cameras,
                       ignore_local_config=True)
     return obs
-
-
-@pytest.fixture(scope='module')
-def images_dir(tmpdir_factory):
-    directory = tmpdir_factory.mktemp('images')
-    return str(directory)
 
 
 def test_error_exit(config):

--- a/pocs/tests/test_observatory.py
+++ b/pocs/tests/test_observatory.py
@@ -207,6 +207,7 @@ def test_sidereal_time(observatory):
 
 
 def test_get_observation(observatory):
+    os.environ['POCSTIME'] = '2016-08-13 15:00:00'
     observation = observatory.get_observation()
     assert isinstance(observation, Observation)
 
@@ -218,14 +219,8 @@ def test_observe(observatory):
     assert observatory.current_observation is None
     assert len(observatory.scheduler.observed_list) == 0
 
-    t0 = Time('2016-08-13 10:00:00')
-    observatory.scheduler.fields_list = [
-        {'name': 'Kepler 1100',
-         'priority': '100',
-         'position': '19h27m29.10s +44d05m15.00s',
-         'exp_time': 10,
-         },
-    ]
+    t0 = '2016-08-13 15:00:00'
+
     observatory.get_observation(time=t0)
     assert observatory.current_observation is not None
 
@@ -240,16 +235,9 @@ def test_observe(observatory):
 
 
 def test_cleanup_fails(observatory):
-    t0 = Time('2016-08-13 10:00:00')
-    fields_list = [
-        {'name': 'Kepler 1100',
-         'priority': '100',
-         'position': '19h27m29.10s +44d05m15.00s',
-         'exp_time': 10,
-         },
-    ]
-    observatory.scheduler.fields_list = fields_list
-    observatory.get_observation(time=t0)
+    os.environ['POCSTIME'] = '2016-08-13 15:00:00'
+
+    observatory.get_observation()
     camera_events = observatory.observe()
 
     while not all([event.is_set() for name, event in camera_events.items()]):
@@ -259,22 +247,19 @@ def test_cleanup_fails(observatory):
     del observatory.config['panoptes_network']
     observatory.cleanup_observations()
 
-    observatory.scheduler.fields_list = fields_list
-    observatory.get_observation(time=t0)
+    observatory.get_observation()
 
     observatory.cleanup_observations()
     del observatory.config['observations']['make_timelapse']
     observatory.cleanup_observations()
 
-    observatory.scheduler.fields_list = fields_list
-    observatory.get_observation(time=t0)
+    observatory.get_observation()
 
     observatory.cleanup_observations()
     del observatory.config['observations']['keep_jpgs']
     observatory.cleanup_observations()
 
-    observatory.scheduler.fields_list = fields_list
-    observatory.get_observation(time=t0)
+    observatory.get_observation()
 
     observatory.cleanup_observations()
     del observatory.config['pan_id']

--- a/pocs/tests/test_observatory.py
+++ b/pocs/tests/test_observatory.py
@@ -163,6 +163,7 @@ def test_is_dark(observatory):
 def test_standard_headers(observatory):
     os.environ['POCSTIME'] = '2016-08-13 22:00:00'
 
+    observatory.scheduler.fields_file = None
     observatory.scheduler.fields_list = [
         {'name': 'HAT-P-20',
          'priority': '100',

--- a/pocs/tests/test_observatory.py
+++ b/pocs/tests/test_observatory.py
@@ -121,7 +121,7 @@ def test_primary_camera(observatory):
 
 
 def test_status(observatory):
-    os.environ['POCSTIME'] = '2016-08-13 10:00:00'
+    os.environ['POCSTIME'] = '2016-08-13 15:00:00'
     status = observatory.status()
     assert 'mount' not in status
     assert 'observation' not in status

--- a/pocs/tests/test_pocs.py
+++ b/pocs/tests/test_pocs.py
@@ -62,17 +62,6 @@ def pocs(config, observatory):
                 config=config,
                 ignore_local_config=True)
 
-    pocs.observatory.scheduler.fields_file = None
-    pocs.observatory.scheduler.fields_list = [
-        {'name': 'Wasp 33',
-         'position': '02h26m51.0582s +37d33m01.733s',
-         'priority': '100',
-         'exp_time': 2,
-         'min_nexp': 2,
-         'exp_set_size': 2,
-         },
-    ]
-
     yield pocs
 
     pocs.power_down()
@@ -92,16 +81,6 @@ def pocs_with_dome(config_with_simulated_dome, db_type):
                 run_once=True,
                 config=config_with_simulated_dome,
                 ignore_local_config=True)
-
-    pocs.observatory.scheduler.fields_list = [
-        {'name': 'Wasp 33',
-         'position': '02h26m51.0582s +37d33m01.733s',
-         'priority': '100',
-         'exp_time': 2,
-         'min_nexp': 2,
-         'exp_set_size': 2,
-         },
-    ]
 
     yield pocs
 
@@ -141,22 +120,14 @@ def test_make_log_dir(pocs):
 def test_simple_simulator(pocs):
     assert isinstance(pocs, POCS)
 
-
-def test_not_initialized(pocs):
     assert pocs.is_initialized is not True
 
-
-def test_run_without_initialize(pocs):
     with pytest.raises(AssertionError):
         pocs.run()
 
-
-def test_initialization(pocs):
     pocs.initialize()
     assert pocs.is_initialized
 
-
-def test_default_lookup_trigger(pocs):
     pocs.state = 'parking'
     pocs.next_state = 'parking'
 
@@ -166,8 +137,6 @@ def test_default_lookup_trigger(pocs):
 
     assert pocs._lookup_trigger() == 'parking'
 
-
-def test_free_space(pocs):
     assert pocs.has_free_space() is True
 
     # Test something ridiculous
@@ -176,7 +145,7 @@ def test_free_space(pocs):
     assert pocs.is_safe() is True
 
 
-def test_is_dark_simulator(pocs):
+def test_is_weather_and_dark_simulator(pocs):
     pocs.initialize()
     pocs.config['simulator'] = ['camera', 'mount', 'weather', 'night']
     os.environ['POCSTIME'] = '2016-08-13 13:00:00'
@@ -185,24 +154,14 @@ def test_is_dark_simulator(pocs):
     os.environ['POCSTIME'] = '2016-08-13 23:00:00'
     assert pocs.is_dark() is True
 
-
-def test_is_dark_no_simulator_01(pocs):
-    pocs.initialize()
     pocs.config['simulator'] = ['camera', 'mount', 'weather']
     os.environ['POCSTIME'] = '2016-08-13 13:00:00'
     assert pocs.is_dark() is True
 
-
-def test_is_dark_no_simulator_02(pocs):
-    pocs.initialize()
-    pocs.config['simulator'] = ['camera', 'mount', 'weather']
     os.environ['POCSTIME'] = '2016-08-13 23:00:00'
     assert pocs.is_dark() is False
 
-
-def test_is_weather_safe_simulator(pocs):
-    pocs.initialize()
-    pocs.config['simulator'] = ['camera', 'mount', 'weather']
+    pocs.config['simulator'] = ['camera', 'mount', 'weather', 'night']
     assert pocs.is_weather_safe() is True
 
 
@@ -218,9 +177,6 @@ def test_wait_for_events_timeout(pocs):
     with pytest.raises(error.Timeout):
         pocs.wait_for_events(test_event, 5 * u.second, sleep_delay=1)
 
-
-def test_wait_for_events(pocs):
-    del os.environ['POCSTIME']
     test_event = threading.Event()
 
     def set_event():
@@ -234,9 +190,6 @@ def test_wait_for_events(pocs):
     pocs.wait_for_events(test_event, 10)
     assert test_event.is_set()
 
-
-def test_wait_for_events_interrupt(pocs):
-    del os.environ['POCSTIME']
     test_event = threading.Event()
 
     def set_event():

--- a/pocs/utils/error.py
+++ b/pocs/utils/error.py
@@ -87,6 +87,11 @@ class InvalidMountCommand(PanError):
     pass
 
 
+class InvalidObservation(NotFound):
+    """PanError raised if a field is invalid."""
+    pass
+
+
 class BadConnection(PanError):
 
     """ PanError raised when a connection is bad """

--- a/resources/targets/simulator.yaml
+++ b/resources/targets/simulator.yaml
@@ -1,7 +1,7 @@
-- epoch: 2014.58
-  equinox: J2000
-  frame: icrs
-  name: Kelt-3
-  position: 09h54m34.391s +40d23m16.98s
-  priority: 125
-  proper_motion: 0.0 0.0
+-
+    name: Wasp 33
+    position: 02h26m51.0582s +37d33m01.733s
+    priority: 100
+    exp_time: 2
+    min_nexp: 2
+    exp_set_size: 2


### PR DESCRIPTION
This changes and fixes a few things related to testing and the simulators:

* Make sure camera simulator is always using temp dir, not just during testing.
* Use a `simulator.yaml` targets file. We spend a *lot* of time loading the targets, especially in test_observatory.py. This reduces that a lot.
* Combined some tests in test_pocs that were causing the entire POCS object to be created for simple property tests. Should keep same coverage.
* Camera simulator exposure times reduced to 1s.