### PR TITLE
Increase coverage of arduino related code

### DIFF
--- a/pocs/sensors/arduino_io.py
+++ b/pocs/sensors/arduino_io.py
@@ -75,7 +75,7 @@ def detect_board_on_port(port, logger=None):
                 return data['name']
             logger.warning('Unable to find board name in reading: {}', reading)
             return None
-        except Exception as e:
+        except Exception as e:  # pragma: no cover
             logger.error('Exception while auto-detecting port {}: {}', port, e)
     finally:
         if serial_reader:


### PR DESCRIPTION
Add ability to shrink size of read chunks and size of read queue,
which will cause some chunks to be dropped, exercising the retry
logic.

Mark some code to be skipped in coverage calculations.

Partially addresses issue #653.