### PR TITLE
Fixing a missing pointing image

### DIFF
--- a/pocs/camera/canon_gphoto2.py
+++ b/pocs/camera/canon_gphoto2.py
@@ -101,7 +101,10 @@ class Camera(AbstractGPhotoCamera):
 
         # Add most recent exposure to list
         if self.is_primary:
-            observation.exposure_list[image_id] = file_path.replace('.cr2', '.fits')
+            if 'POINTING' in headers:
+                observation.pointing_images[image_id] = file_path.replace('.cr2', '.fits')
+            else:
+                observation.exposure_list[image_id] = file_path.replace('.cr2', '.fits')
 
         # Process the image after a set amount of time
         wait_time = exp_time + self.readout_time

--- a/pocs/state/states/default/pointing.py
+++ b/pocs/state/states/default/pointing.py
@@ -40,7 +40,7 @@ def on_enter(event_data):
             # Start the exposure
             camera_event = primary_camera.take_observation(
                 observation,
-                fits_headers,
+                headers=fits_headers,
                 exp_time=exptime,
                 filename='pointing{:02d}'.format(img_num)
             )


### PR DESCRIPTION
There is some inconsistency in the `take_observation` methods between the regular `camera.py` and the `canon_gphoto2.py`, not to mention some duplication of code. The duplication caused me to miss this update the other day, which is breaking the pointing state.

Note that the bug was inside a `gphoto2` specific file which means the camera simulator did not reveal the error. There isn't a good way to test without real hardware.