### PR TITLE
Add DelaySigTerm to pocs/utils.

### DIFF
--- a/pocs/tests/utils/test_utils.py
+++ b/pocs/tests/utils/test_utils.py
@@ -130,8 +130,9 @@ def test_delay_of_sigterm_with_nosignal():
 def test_delay_of_sigterm_with_handled_signal():
     """Confirm that another type of signal can be handled.
 
-    In this test we'll send SIGCHLD, which should call the
-    handler the test installs immediately.
+    In this test we'll send SIGCHLD, which should immediately call the
+    signal_handler the test installs, demonstrating that only SIGTERM
+    is affected by this DelaySigTerm.
     """
     test_signal = signal.SIGCHLD
 
@@ -208,6 +209,9 @@ def test_delay_of_sigterm_with_raised_exception():
             # Send the test signal. It should immediately
             # call our handler.
             os.kill(os.getpid(), test_signal)
+            # Should not reach this point because signal_handler() should
+            # be called because we called:
+            #     signal.signal(other-handler, signal_handler)
             after_signal = True
             assert False, "Should not get here!"
     except UserWarning:

--- a/pocs/tests/utils/test_utils.py
+++ b/pocs/tests/utils/test_utils.py
@@ -1,11 +1,12 @@
 import os
 import pytest
-
+import signal
 import time
 from datetime import datetime as dt
 from astropy import units as u
 
 from pocs.utils import current_time
+from pocs.utils import DelaySigTerm
 from pocs.utils import listify
 from pocs.utils import load_module
 from pocs.utils import CountdownTimer
@@ -115,3 +116,149 @@ def test_countdown_timer():
     assert counter == pytest.approx(1)
     assert timer.time_left() == 0
     assert timer.expired() is True
+
+
+def test_delay_of_sigterm_with_nosignal():
+    orig_sigterm_handler = signal.getsignal(signal.SIGTERM)
+
+    with DelaySigTerm():
+        assert signal.getsignal(signal.SIGTERM) != orig_sigterm_handler
+
+    assert signal.getsignal(signal.SIGTERM) == orig_sigterm_handler
+
+
+def test_delay_of_sigterm_with_handled_signal():
+    """Confirm that another type of signal can be handled.
+
+    In this test we'll send SIGCHLD, which should call the
+    handler the test installs immediately.
+    """
+    test_signal = signal.SIGCHLD
+
+    # Booleans to keep track of how far we've gotten.
+    before_signal = False
+    after_signal = False
+    signal_handled = False
+    after_with = False
+
+    def signal_handler(signum, frame):
+        assert before_signal
+
+        nonlocal signal_handled
+        assert not signal_handled
+        signal_handled = True
+
+        assert not after_signal
+
+    old_test_signal_handler = signal.getsignal(test_signal)
+    orig_sigterm_handler = signal.getsignal(signal.SIGTERM)
+    try:
+        # Install our handler.
+        signal.signal(test_signal, signal_handler)
+
+        with DelaySigTerm():
+            assert signal.getsignal(signal.SIGTERM) != orig_sigterm_handler
+            before_signal = True
+            # Send the test signal. It should immediately
+            # call our handler.
+            os.kill(os.getpid(), test_signal)
+            assert signal_handled
+            after_signal = True
+
+        after_with = True
+        assert signal.getsignal(signal.SIGTERM) == orig_sigterm_handler
+    finally:
+        assert before_signal
+        assert signal_handled
+        assert after_signal
+        assert after_with
+        assert signal.getsignal(signal.SIGTERM) == orig_sigterm_handler
+        signal.signal(test_signal, old_test_signal_handler)
+
+
+def test_delay_of_sigterm_with_raised_exception():
+    """Confirm that raising an exception inside the handler is OK."""
+    test_signal = signal.SIGCHLD
+
+    # Booleans to keep track of how far we've gotten.
+    before_signal = False
+    after_signal = False
+    signal_handled = False
+    exception_caught = False
+
+    def signal_handler(signum, frame):
+        assert before_signal
+
+        nonlocal signal_handled
+        assert not signal_handled
+        signal_handled = True
+
+        assert not after_signal
+        raise UserWarning()
+
+    old_test_signal_handler = signal.getsignal(test_signal)
+    orig_sigterm_handler = signal.getsignal(signal.SIGTERM)
+    try:
+        # Install our handler.
+        signal.signal(test_signal, signal_handler)
+
+        with DelaySigTerm():
+            assert signal.getsignal(signal.SIGTERM) != orig_sigterm_handler
+            before_signal = True
+            # Send the test signal. It should immediately
+            # call our handler.
+            os.kill(os.getpid(), test_signal)
+            after_signal = True
+            assert False, "Should not get here!"
+    except UserWarning:
+        assert before_signal
+        assert signal_handled
+        assert not after_signal
+        assert not exception_caught
+        assert signal.getsignal(signal.SIGTERM) == orig_sigterm_handler
+        exception_caught = True
+    finally:
+        # Restore old handler before asserts.
+        signal.signal(test_signal, old_test_signal_handler)
+
+        assert before_signal
+        assert signal_handled
+        assert not after_signal
+        assert exception_caught
+        assert signal.getsignal(signal.SIGTERM) == orig_sigterm_handler
+
+
+def test_delay_of_sigterm_with_sigterm():
+    """Confirm that SIGTERM is in fact delayed."""
+
+    # Booleans to keep track of how far we've gotten.
+    before_signal = False
+    after_signal = False
+    signal_handled = False
+
+    def signal_handler(signum, frame):
+        assert before_signal
+        assert after_signal
+
+        nonlocal signal_handled
+        assert not signal_handled
+        signal_handled = True
+
+    orig_sigterm_handler = signal.getsignal(signal.SIGTERM)
+    try:
+        # Install our handler.
+        signal.signal(signal.SIGTERM, signal_handler)
+
+        with DelaySigTerm():
+            before_signal = True
+            # Send SIGTERM. It should not call the handler yet.
+            os.kill(os.getpid(), signal.SIGTERM)
+            assert not signal_handled
+            after_signal = True
+
+        assert signal.getsignal(signal.SIGTERM) == signal_handler
+        assert before_signal
+        assert after_signal
+        assert signal_handled
+    finally:
+        signal.signal(signal.SIGTERM, orig_sigterm_handler)

--- a/pocs/utils/__init__.py
+++ b/pocs/utils/__init__.py
@@ -281,7 +281,6 @@ class DelaySigTerm(contextlib.ContextDecorator):
 
         with DelaySigTerm():
             db.WriteCurrentRecord(record)
-
     """
     # TODO(jamessynge): Consider generalizing as DelaySignal(signum).
     def __enter__(self):

--- a/pocs/utils/__init__.py
+++ b/pocs/utils/__init__.py
@@ -1,5 +1,8 @@
+import contextlib
 import os
 import shutil
+import signal
+import subprocess
 import time
 
 from astropy import units as u
@@ -267,3 +270,35 @@ def altaz_to_radec(alt=35, az=90, location=None, obstime=None, verbose=False):
 
     altaz = AltAz(obstime=obstime, location=location, alt=alt * u.deg, az=az * u.deg)
     return SkyCoord(altaz.transform_to(ICRS))
+
+
+class DelaySigTerm(contextlib.ContextDecorator):
+    """Supports delaying SIGTERM during a critical section.
+
+    This allows one to avoid having SIGTERM interrupt a
+    critical block of code, such as saving to a database.
+    For example:
+
+        with DelaySigTerm():
+            db.WriteCurrentRecord(record)
+
+    """
+    # TODO(jamessynge): Consider generalizing as DelaySignal(signum).
+    def __enter__(self):
+        self.caught = False
+        self.old_handler = signal.getsignal(signal.SIGTERM)
+
+        def handler(signum, frame):
+            self.caught = True
+
+        signal.signal(signal.SIGTERM, handler)
+        return self
+
+    def __exit__(self, *exc):
+        signal.signal(signal.SIGTERM, self.old_handler)
+        if self.caught:
+            # Send SIGTERM to this process.
+            os.kill(os.getpid(), signal.SIGTERM)
+            # Suppress any exception caught while the context was running.
+            return True
+        return False


### PR DESCRIPTION
Used to prevent SIGTERM from interrupting a "critical section",
which in this case is any block of code run as follows:

```
with DelaySigTerm():
    code-to-protect-from-sigterm
```

This is a part of addressing issue #420.