### PR TITLE
Make all created Threads daemons

### DIFF
--- a/pocs/dome/protocol_astrohaven_simulator.py
+++ b/pocs/dome/protocol_astrohaven_simulator.py
@@ -357,7 +357,7 @@ class AstrohavenSerialSimulator(serial_handlers.NoOpSerial):
             _drain_queue(self.status_queue)
             self.stop.clear()
             self.plc_thread = threading.Thread(
-                name='Astrohaven PLC Simulator', target=lambda: self.plc.run())
+                name='Astrohaven PLC Simulator', target=lambda: self.plc.run(), daemon=True)
             self.plc_thread.start()
         elif self.plc_thread and not need_thread:
             self.stop.set()

--- a/pocs/serial_handlers/protocol_arduinosimulator.py
+++ b/pocs/serial_handlers/protocol_arduinosimulator.py
@@ -367,7 +367,7 @@ class FakeArduinoSerialHandler(serial_handlers.NoOpSerial):
             params = self._params_from_url(self.portstr)
             self._create_simulator(params)
             self.simulator_thread = threading.Thread(
-                name='Device Simulator', target=lambda: self.device_simulator.run())
+                name='Device Simulator', target=lambda: self.device_simulator.run(), daemon=True)
             self.simulator_thread.start()
         elif self.simulator_thread and not need_thread:
             self.stop.set()

--- a/pocs/tests/test_pocs.py
+++ b/pocs/tests/test_pocs.py
@@ -285,7 +285,7 @@ def test_run_wait_until_safe(observatory):
     pub = PanMessaging.create_publisher(6500)
     sub = PanMessaging.create_subscriber(6511)
 
-    pocs_thread = threading.Thread(target=start_pocs)
+    pocs_thread = threading.Thread(target=start_pocs, daemon=True)
     pocs_thread.start()
 
     try:
@@ -410,7 +410,7 @@ def test_run_power_down_interrupt(observatory):
         pocs.power_down()
         observatory.logger.info('start_pocs EXIT')
 
-    pocs_thread = threading.Thread(target=start_pocs)
+    pocs_thread = threading.Thread(target=start_pocs, daemon=True)
     pocs_thread.start()
 
     pub = PanMessaging.create_publisher(6500)


### PR DESCRIPTION
Some non-main threads weren't daemons, and were preventing pytest
from exiting when a test failed because the thread still existed.