### PR TITLE
Improve coverage of ArduinoIO and simulator

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -269,6 +269,7 @@ def message_forwarder(messaging_ports):
         args.append(str(sub))
         args.append(str(pub))
 
+    get_root_logger().info('message_forwarder fixture starting: {}', args)
     proc = subprocess.Popen(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     # It takes a while for the forwarder to start, so allow for that.
     # TODO(jamessynge): Come up with a way to speed up these fixtures.

--- a/pocs/serial_handlers/protocol_arduinosimulator.py
+++ b/pocs/serial_handlers/protocol_arduinosimulator.py
@@ -2,7 +2,7 @@
 
 We use the pragma "no cover" in several places that happen to never be
 reached or that would only be reached if the code was called directly,
-i.e. in not in the way it is intended to be used.
+i.e. not in the way it is intended to be used.
 """
 
 import copy

--- a/pocs/tests/test_arduino_io.py
+++ b/pocs/tests/test_arduino_io.py
@@ -1,9 +1,12 @@
 # Test sensors.py ability to read from two sensor boards.
 
 import collections
+import contextlib
 import datetime
 import pytest
 import serial
+import threading
+import time
 
 from pocs.sensors import arduino_io
 import pocs.utils.error as error
@@ -76,27 +79,101 @@ def receive_message_with_timeout(subscriber, timeout_secs=1.0):
             return None, None
 
 
+@contextlib.contextmanager
+def open_serial_device(*args, **kwargs):
+    """Context manager that opens a serial device, disconnects at exit.
+
+    Ensures that an serial device is disconnected when exiting, which
+    in turn ensures that the Arduino simulator is shutdown.
+    """
+    ser = arduino_io.open_serial_device(*args, **kwargs)
+    try:
+        yield ser
+    finally:
+        ser.disconnect()
+
+
 # --------------------------------------------------------------------------------------------------
 # Basic tests of FakeArduinoSerialHandler.
 
 
 def test_create_camera_simulator(serial_handlers):
-    ser = rs232.SerialData(port='arduinosimulator://?board=camera', baudrate=9600)
-    assert ser.is_connected is True
-    ser.disconnect()
-    assert ser.is_connected is False
-    ser.connect()
-    assert ser.is_connected is True
-    # First read will typically get a fragment of a line, but then the next will
-    # get a full line.
-    s = ser.read()
-    assert s.endswith('\n')
-    s = ser.read()
-    assert s.startswith('{')
-    assert s.endswith('}\r\n')
-    assert 'camera_board' in s
-    ser.disconnect()
-    assert ser.is_connected is False
+    """Test SerialData, FakeArduinoSerialHandler and ArduinoSimulator."""
+    port='arduinosimulator://?board=camera'
+    ser = rs232.SerialData(port=port, baudrate=9600, timeout=2.0)
+    try:
+        assert ser.is_connected is True
+
+        # Some testing/coverage of the underlying handler and simulator...
+
+        ser.ser.open()  # Redundant, but covers a branch.
+
+        # There is nothing in the output buffer, so resetting it should
+        # have no effect.
+        assert ser.ser.out_waiting == 0
+        ser.ser.reset_output_buffer()
+        assert ser.ser.out_waiting == 0
+
+        # If we flush the input, we'll be able to find zero bytes waiting eventually.
+        was_empty = False
+        for n in range(10):
+            ser.reset_input_buffer()
+            if ser.ser.in_waiting == 0:
+                was_empty = True
+                break
+        assert was_empty
+
+        ser.disconnect()
+        assert ser.is_connected is False
+
+        # Various methods throw if the device isn't connected/open.
+        with pytest.raises(Exception):
+            ser.ser.in_waiting
+        with pytest.raises(Exception):
+            ser.ser.out_waiting
+        with pytest.raises(Exception):
+            ser.ser.read()
+        with pytest.raises(Exception):
+            ser.ser.flush()
+        with pytest.raises(Exception):
+            ser.ser.reset_output_buffer()
+
+        ser.connect()
+        assert ser.is_connected is True
+        # First read will typically get a fragment of a line, but then the next will
+        # get a full line.
+        s = ser.read()
+        assert s.endswith('\n')
+        s = ser.read()
+        assert s.startswith('{')
+        assert s.endswith('}\r\n')
+        assert 'camera_board' in s
+
+        # If we write a bunch of commands, eventually we can detect that the
+        # underlying serial device has pending output.
+        was_full = 0
+        for n in range(20):
+            ser.write('some bytes, again and again')
+            if ser.ser.out_waiting > 0:
+                was_full += 1
+                if was_full > 3:
+                    ser.ser.reset_output_buffer()
+                    break
+                ser.ser.flush()
+        assert was_full > 0
+
+        # Read until times out, at which point read will return
+        # whatever it has accumulated.
+        ser.ser.timeout = 0.1
+        total = 0
+        for n in range(20):
+            total += len(ser.read_bytes(size=None))
+        assert total > 0
+
+        ser.disconnect()
+        assert ser.is_connected is False
+    finally:
+        ser.disconnect()
 
 
 def test_create_default_simulator(serial_handlers):
@@ -122,14 +199,16 @@ def test_create_simulator_small_read_buffer(serial_handlers):
     ser = arduino_io.open_serial_device(
         'arduinosimulator://?board=telemetry&read_buffer_size=1&chunk_size=1')
     assert ser.is_connected is True
-    # Allow a lot of retries so that a busy machine still has a very good chance
-    # of succeeding in running this.
+    # Wait a bit so that the read buffer overflows.
+    time.sleep(4)
+    # Now start reading, which will certainly require some retries
+    # on very busy machines.
     retry_limit = 2000
     (ts, reading) = ser.get_and_parse_reading(retry_limit=retry_limit)
     assert isinstance(reading, dict)
     assert reading['name'] == 'telemetry_board'
     report_num = reading['report_num']
-    assert 1 <= report_num
+    assert 1 < report_num
     assert report_num <= retry_limit
     ser.disconnect()
     assert ser.is_connected is False
@@ -209,113 +288,169 @@ def test_auto_detect_arduino_devices(inject_get_serial_port_info, serial_handler
 def test_arduino_io_basic(serial_handlers, memory_db, msg_publisher, msg_subscriber, cmd_publisher,
                           cmd_subscriber):
     board = 'telemetry'
-    ser = arduino_io.open_serial_device('arduinosimulator://?board=' + board)
+    port = 'arduinosimulator://?board=' + board
     board = board + '_board'
-    aio = arduino_io.ArduinoIO(board, ser, memory_db, msg_publisher, cmd_subscriber)
+    with open_serial_device(port) as ser:
+        aio = arduino_io.ArduinoIO(board, ser, memory_db, msg_publisher, cmd_subscriber)
 
-    # Wait until we get the first reading.
-    stored_reading = read_and_return(aio, memory_db)
-    assert isinstance(stored_reading, dict)
-    assert sorted(stored_reading.keys()) == ['_id', 'data', 'date', 'type']
-    assert isinstance(stored_reading['_id'], str)
-    assert isinstance(stored_reading['date'], datetime.datetime)
-    assert stored_reading['type'] == board
+        # Wait until we get the first reading.
+        stored_reading = read_and_return(aio, memory_db)
+        assert isinstance(stored_reading, dict)
+        assert sorted(stored_reading.keys()) == ['_id', 'data', 'date', 'type']
+        assert isinstance(stored_reading['_id'], str)
+        assert isinstance(stored_reading['date'], datetime.datetime)
+        assert stored_reading['type'] == board
 
-    # Check that the reading was sent as a message. We need to allow some
-    # time for the message to pass through thee messaging system.
-    topic, msg_obj = receive_message_with_timeout(msg_subscriber)
-    assert topic == board
-    assert isinstance(msg_obj, dict)
-    assert len(msg_obj) == 3
-    assert isinstance(msg_obj.get('data'), dict)
-    assert isinstance(msg_obj.get('timestamp'), str)
-    assert msg_obj.get('name') == board
-    assert stored_reading['data']['data'] == msg_obj['data']
+        # Check that the reading was sent as a message. We need to allow some
+        # time for the message to pass through thee messaging system.
+        topic, msg_obj = receive_message_with_timeout(msg_subscriber)
+        assert topic == board
+        assert isinstance(msg_obj, dict)
+        assert len(msg_obj) == 3
+        assert isinstance(msg_obj.get('data'), dict)
+        assert isinstance(msg_obj.get('timestamp'), str)
+        assert msg_obj.get('name') == board
+        assert stored_reading['data']['data'] == msg_obj['data']
 
-    # Check that the reading was stored.
-    stored_reading = memory_db.get_current(board)
-    assert isinstance(stored_reading, dict)
-    assert sorted(stored_reading.keys()) == ['_id', 'data', 'date', 'type']
-    assert isinstance(stored_reading['_id'], str)
-    assert stored_reading['data']['data'] == msg_obj['data']
-    assert isinstance(stored_reading['date'], datetime.datetime)
-    assert stored_reading['type'] == board
+        # Check that the reading was stored.
+        stored_reading = memory_db.get_current(board)
+        assert isinstance(stored_reading, dict)
+        assert sorted(stored_reading.keys()) == ['_id', 'data', 'date', 'type']
+        assert isinstance(stored_reading['_id'], str)
+        assert stored_reading['data']['data'] == msg_obj['data']
+        assert isinstance(stored_reading['date'], datetime.datetime)
+        assert stored_reading['type'] == board
 
-    # There should be no new messages because we haven't called read_and_record again.
-    topic, msg_obj = receive_message_with_timeout(msg_subscriber, timeout_secs=0.2)
-    assert topic is None
-    assert msg_obj is None
+        # There should be no new messages because we haven't called read_and_record again.
+        topic, msg_obj = receive_message_with_timeout(msg_subscriber, timeout_secs=0.2)
+        assert topic is None
+        assert msg_obj is None
 
 
 def test_arduino_io_auto_connect_to_read(serial_handlers, memory_db, msg_publisher, msg_subscriber,
                                          cmd_publisher, cmd_subscriber):
     """Exercise ability to reconnect if disconnected."""
     board = 'camera'
-    ser = arduino_io.open_serial_device('arduinosimulator://?board=' + board)
+    port = 'arduinosimulator://?board=' + board
     board = board + '_board'
-    aio = arduino_io.ArduinoIO(board, ser, memory_db, msg_publisher, cmd_subscriber)
+    with open_serial_device(port) as ser:
+        aio = arduino_io.ArduinoIO(board, ser, memory_db, msg_publisher, cmd_subscriber)
 
-    read_and_return(aio, memory_db)
-    aio.reconnect()
-    read_and_return(aio, memory_db)
-    aio.disconnect()
-    read_and_return(aio, memory_db)
+        read_and_return(aio, memory_db)
+        aio.reconnect()
+        read_and_return(aio, memory_db)
+        aio.disconnect()
+        read_and_return(aio, memory_db)
 
 
 def test_arduino_io_board_name(serial_handlers, memory_db, msg_publisher, msg_subscriber,
                                cmd_publisher, cmd_subscriber):
     board = 'telemetry'
-    ser = arduino_io.open_serial_device('arduinosimulator://?board=' + board)
+    port = 'arduinosimulator://?board=' + board
     board = board + '_board'
-    aio = arduino_io.ArduinoIO(board, ser, memory_db, msg_publisher, cmd_subscriber)
+    with open_serial_device(port) as ser:
+        aio = arduino_io.ArduinoIO(board, ser, memory_db, msg_publisher, cmd_subscriber)
 
-    # Confirm that it checks the name of the board. If the reading contains
-    # a 'name', it must match the expected value.
-    aio.board = 'wrong'
-    with pytest.raises(error.ArduinoDataError):
-        read_and_return(aio, memory_db)
-    aio.board = board
+        # Confirm that it checks the name of the board. If the reading contains
+        # a 'name', it must match the expected value.
+        aio.board = 'wrong'
+        with pytest.raises(error.ArduinoDataError):
+            read_and_return(aio, memory_db)
+        aio.board = board
 
 
 def test_arduino_io_shutdown(serial_handlers, memory_db, msg_publisher, msg_subscriber,
                              cmd_publisher, cmd_subscriber):
     """Confirm request to shutdown is recorded."""
     board = 'telemetry'
-    ser = arduino_io.open_serial_device('arduinosimulator://?board=' + board)
+    port = 'arduinosimulator://?board=' + board
     board = board + '_board'
-    aio = arduino_io.ArduinoIO(board, ser, memory_db, msg_publisher, cmd_subscriber)
+    with open_serial_device(port) as ser:
+            aio = arduino_io.ArduinoIO(board, ser, memory_db, msg_publisher, cmd_subscriber)
 
-    # Ask it to stop working. Just records the request in a private variable,
-    # but if we'd been running it in a separate process this is how we'd get it
-    # to shutdown cleanly; the alternative would be to kill the process.
-    cmd_topic = board + ':commands'
-    assert cmd_topic == aio._cmd_topic
-    cmd_publisher.send_message(cmd_topic, dict(command='shutdown'))
-    # _keep_running should still be true since we've not yet called handle_commands.
-    assert aio._keep_running
-    aio.handle_commands()  # Currently the only setter of ArduinoIO._keep_running
-
-    # Shutdown is currently NOT being processed successfully. It appears to be a
-    # problem with the msg and cmd fixtures. I'll eventually uncomment this line when
-    # I've fixed the fixtures.
-    #    assert not aio._keep_running
+            # Ask it to stop working. Just records the request in a private variable,
+            # but if we'd been running it in a separate process this is how we'd get it
+            # to shutdown cleanly; the alternative would be to kill the process.
+            cmd_topic = board + ':commands'
+            assert cmd_topic == aio._cmd_topic
+            cmd_publisher.send_message(cmd_topic, dict(command='shutdown'))
+            # _keep_running should still be true since we've not yet called handle_commands.
+            assert aio._keep_running
+            # On a lightly loaded system, the send_message will work quickly, so that
+            # the first call to handle_commands receives it, but it might take longer
+            # sometimes.
+            for _ in range(10):
+                aio.handle_commands()  # Currently the only setter of ArduinoIO._keep_running
+                if not aio._keep_running:
+                    break
+                get_root_logger().debug('Shutdown not handled yet')
+            assert not aio._keep_running
 
 
 def test_arduino_io_write_line(serial_handlers, memory_db, msg_publisher, msg_subscriber,
                                cmd_publisher, cmd_subscriber):
     """Confirm request to shutdown is recorded."""
     board = 'telemetry'
-    ser = arduino_io.open_serial_device('arduinosimulator://?board=' + board)
+    port = 'arduinosimulator://?board=' + board
     board = board + '_board'
-    aio = arduino_io.ArduinoIO(board, ser, memory_db, msg_publisher, cmd_subscriber)
+    with open_serial_device(port) as ser:
+        aio = arduino_io.ArduinoIO(board, ser, memory_db, msg_publisher, cmd_subscriber)
 
-    # Send a command. For now, just a string to be sent.
-    # TODO(jamessynge): Add named based setting of relays.
-    # TODO(jamessynge): Add some validation of the effect of the command.
-    cmd_topic = board + ':commands'
-    assert cmd_topic == aio._cmd_topic
-    assert aio._keep_running
-    cmd_publisher.send_message(cmd_topic, dict(command='write_line', line='relay=on'))
-    aio.handle_commands()
-    assert aio._keep_running
-    # TODO(jamessynge): Come up with a way to validate the write_line is performed.
+        cmd_topic = board + ':commands'
+        assert cmd_topic == aio._cmd_topic
+
+        # Run ArduinoIO in a thread.
+        thread = threading.Thread(target=lambda: aio.run(), daemon=True)
+        thread.start()
+
+        # Wait until messages are received, with a time limit.
+        topic, msg_obj = msg_subscriber.receive_message(blocking=True, timeout_ms=20000)
+        assert topic
+        assert msg_obj
+        assert 'commands' not in msg_obj['data']
+
+        # Drain available messages.
+        for n in range(100):
+            topic, msg_obj = msg_subscriber.receive_message(blocking=False)
+            if not topic:
+                print(f'Drained at n=#{n}')
+                break
+
+        # Send a command. The simulator will echo it.
+        cmd_publisher.send_message(cmd_topic, dict(command='write_line', line='relay=on'))
+
+        # Look for a message with our command echoed.
+        for n in range(5):
+            topic, msg_obj = msg_subscriber.receive_message(blocking=True, timeout_ms=3000)
+            if 'commands' in msg_obj['data']:
+                break
+
+        assert 'commands' in msg_obj['data']
+        assert msg_obj['data']['commands'] == ['relay=on']
+
+        # Confirm that later messages don't have any commands.
+        topic, msg_obj = msg_subscriber.receive_message(blocking=True, timeout_ms=3000)
+        assert 'commands' not in msg_obj['data']
+
+        # Send another command. The simulator will echo it.
+        cmd_publisher.send_message(cmd_topic, dict(command='write_line', line='relay=off'))
+
+        # Look for a message with our command echoed.
+        for n in range(5):
+            topic, msg_obj = msg_subscriber.receive_message(blocking=True, timeout_ms=3000)
+            if 'commands' in msg_obj['data']:
+                break
+
+        assert 'commands' in msg_obj['data']
+        assert msg_obj['data']['commands'] == ['relay=off']
+
+        # Confirm that later messages don't have any commands.
+        topic, msg_obj = msg_subscriber.receive_message(blocking=True, timeout_ms=3000)
+        assert 'commands' not in msg_obj['data']
+
+        # Shutdown in the expected style.
+        assert aio._keep_running
+        cmd_publisher.send_message(cmd_topic, dict(command='shutdown'))
+        thread.join(timeout=10.0)
+        assert not thread.is_alive()
+        assert not aio._keep_running

--- a/pocs/tests/test_arduino_io.py
+++ b/pocs/tests/test_arduino_io.py
@@ -99,7 +99,7 @@ def open_serial_device(*args, **kwargs):
 
 def test_create_camera_simulator(serial_handlers):
     """Test SerialData, FakeArduinoSerialHandler and ArduinoSimulator."""
-    port='arduinosimulator://?board=camera'
+    port = 'arduinosimulator://?board=camera'
     ser = rs232.SerialData(port=port, baudrate=9600, timeout=2.0)
     try:
         assert ser.is_connected is True

--- a/pocs/tests/test_messaging.py
+++ b/pocs/tests/test_messaging.py
@@ -90,7 +90,6 @@ def test_storage_id(pub_and_sub, config, db):
 ################################################################################
 # Tests of the conftest.py messaging fixtures.
 
-
 def test_message_forwarder_exists(message_forwarder):
     assert isinstance(message_forwarder, dict)
     assert 'msg_ports' in message_forwarder
@@ -132,8 +131,6 @@ def assess_pub_sub(pub, sub):
     assert 'message' in msg_obj
     assert msg_obj['message'] == 'a string'
     assert 'timestamp' in msg_obj
-
-    # import pdb;pdb.set_trace()
 
 
 def test_msg_pub_sub(msg_publisher, msg_subscriber):

--- a/pocs/utils/messaging.py
+++ b/pocs/utils/messaging.py
@@ -228,6 +228,8 @@ class PanMessaging(object):
             flags = flags | zmq.NOBLOCK
         elif timeout_ms > 0:
             # Wait until a message is available or the timeout expires.
+            # TODO(jamessynge): Remove flags=..., confirm that works with
+            # the default flags value of zmq.POLLIN.
             self.socket.poll(timeout=timeout_ms, flags=(zmq.POLLIN | zmq.POLLOUT))
             # Don't block at this point, because we will have waited as long
             # as necessary.


### PR DESCRIPTION
ArduinoSimulator now adds commands it receives
to the next output message that it produces.
Send command bytes to the simulator one at a time,
again to better simulate the reality that the
Arduino communication is serial... and to improve
code coverage.
Add "# pragma: no cover" to various unreachable
lines in the Arduino simulator code.

Test that ArduinoIO listens for messages on the
command topic and forwards the contained line
to the Arduino.

Use the new timeout_ms param of PanMessaging.receive_message
in ArduinoIO.handle_commands.

Add some comments, TODOs, and clean up some
code style issues.