### PR TITLE
Replace command collect_status with status in pocs_shell

### DIFF
--- a/bin/pocs_shell
+++ b/bin/pocs_shell
@@ -217,6 +217,7 @@ Hardware names: {}   (or all for all hardware)'''.format(
         if self.msg_subscriber is None:
             self.do_start_messaging()
         status = self.pocs.status()
+        print()
         pprint(status)
         print()
 

--- a/bin/pocs_shell
+++ b/bin/pocs_shell
@@ -156,12 +156,12 @@ class PocsShell(Cmd):
             simulator = []
 
         try:
-            cameras = create_cameras_from_config()
+            cameras = create_cameras_from_config(simulator=simulator)
             observatory = Observatory(simulator=simulator, cameras=cameras)
             self.pocs = POCS(observatory, messaging=True)
             self.pocs.initialize()
-        except error.PanError:
-            pass
+        except error.PanError as e:
+            print_warning('Problem setting up POCS: {}'.format(e))
 
     def help_setup_pocs(self):
         print('''Setup and initialize a POCS instance.
@@ -209,32 +209,16 @@ Hardware names: {}   (or all for all hardware)'''.format(
         else:
             print_warning('Please run `setup_pocs` before trying to run')
 
-    def do_collect_status(self, *arg):
-        """Just records the `status` for pocs.
-
-        This would mostly be used when you want to record information from
-        POCS but might be driving the system manually
-
-        """
-        if self.pocs is not None:
-            if self.msg_subscriber is None:
-                self.do_start_messaging()
-
-            print_info("Recording POCS status - Press Ctrl-c to interrupt")
-
-            _keep_going = True
-            while _keep_going:
-                try:
-                    status = self.pocs.status()
-                    pprint(status)
-                    print_info('*' * 80)
-                    self.pocs.db.insert_current('system', status, store_permanently=False)
-                    time.sleep(2)
-                except KeyboardInterrupt:
-                    print_warning('Stopping collection')
-                    _keep_going = False
-        else:
+    def do_status(self, *arg):
+        """Print the `status` for pocs."""
+        if self.pocs is None:
             print_warning('Please run `setup_pocs` before trying to run')
+            return
+        if self.msg_subscriber is None:
+            self.do_start_messaging()
+        status = self.pocs.status()
+        pprint(status)
+        print()
 
     def do_pocs_command(self, cmd):
         """Send a command to POCS instance.
@@ -640,7 +624,8 @@ class DriftShell(Cmd):
         try:
             self.pocs = POCS(simulator=simulator)
             self.pocs.initialize()
-        except error.PanError:
+        except error.PanError as e:
+
             pass
 
     def do_drift_test(self, *arg):

--- a/pocs/camera/__init__.py
+++ b/pocs/camera/__init__.py
@@ -65,8 +65,6 @@ def create_cameras_from_config(config=None, logger=None, **kwargs):
     if not logger:
         logger = logger_module.get_root_logger()
 
-    logger.info(f'kwargs: {kwargs!r}')
-
     if not config:
         config = load_config(**kwargs)
 
@@ -83,7 +81,7 @@ def create_cameras_from_config(config=None, logger=None, **kwargs):
     logger.debug("Camera config: {}".format(camera_info))
 
     simulator_names = hardware.get_simulator_names(config=config, kwargs=kwargs)
-    logger.info(f'simulator_names = {", ".join(simulator_names)}')
+    logger.debug(f'simulator_names = {", ".join(simulator_names)}')
     a_simulator = 'camera' in simulator_names
     auto_detect = camera_info.get('auto_detect', False)
 

--- a/pocs/camera/__init__.py
+++ b/pocs/camera/__init__.py
@@ -3,6 +3,7 @@ import re
 import shutil
 import subprocess
 
+from pocs import hardware
 from pocs.utils import error
 from pocs.utils import load_module
 from pocs.utils.config import load_config
@@ -64,6 +65,8 @@ def create_cameras_from_config(config=None, logger=None, **kwargs):
     if not logger:
         logger = logger_module.get_root_logger()
 
+    logger.info(f'kwargs: {kwargs!r}')
+
     if not config:
         config = load_config(**kwargs)
 
@@ -79,7 +82,9 @@ def create_cameras_from_config(config=None, logger=None, **kwargs):
 
     logger.debug("Camera config: {}".format(camera_info))
 
-    a_simulator = 'camera' in kwargs_or_config('simulator', default=list())
+    simulator_names = hardware.get_simulator_names(config=config, kwargs=kwargs)
+    logger.info(f'simulator_names = {", ".join(simulator_names)}')
+    a_simulator = 'camera' in simulator_names
     auto_detect = camera_info.get('auto_detect', False)
 
     ports = list()
@@ -94,7 +99,7 @@ def create_cameras_from_config(config=None, logger=None, **kwargs):
 
         if len(ports) == 0:
             raise error.PanError(
-                msg="No cameras detected. Use --simulator=camera for simulator.")
+                msg="No cameras detected. For testing, use camera simulator.")
         else:
             logger.debug("Detected Ports: {}".format(ports))
 

--- a/pocs/core.py
+++ b/pocs/core.py
@@ -511,7 +511,7 @@ class POCS(PanStateMachine, PanBase):
                 now = current_time()
 
             if timer.expired():
-                raise error.Timeout("Timemout waiting for {} event".format(event_type))
+                raise error.Timeout("Timedout waiting for {} event".format(event_type))
 
             # Sleep for a little bit.
             time.sleep(sleep_delay)

--- a/pocs/hardware.py
+++ b/pocs/hardware.py
@@ -23,7 +23,7 @@ def get_simulator_names(simulator=None, kwargs=None, config=None):
     of type 'X'; that is up to the code working with the config to create drivers for real or
     simulated hardware.
 
-    This funciton is intended to be called from PanBase or similar, which receives kwargs that
+    This function is intended to be called from PanBase or similar, which receives kwargs that
     may include simulator, config or both. For example:
            get_simulator_names(config=self.config, kwargs=kwargs)
     Or:

--- a/pocs/utils/config.py
+++ b/pocs/utils/config.py
@@ -42,7 +42,7 @@ def load_config(config_files=None, simulator=None, parse=True, ignore_local=Fals
             used as a simulator.
         parse (bool, optional): If the config file should attempt to create
             objects such as dates, astropy units, etc.
-        ignore_local (bool, optional): If local files should be ignore, see
+        ignore_local (bool, optional): If local files should be ignored, see
             Notes for details.
 
     Returns:


### PR DESCRIPTION
New command prints status once, then returns control to the user.

Fix initialization of cameras to honor simulator specified to
setup_pocs command.

Fix a couple of typos.