### PR TITLE
Fix autofocus tests

### DIFF
--- a/pocs/tests/test_camera.py
+++ b/pocs/tests/test_camera.py
@@ -372,7 +372,6 @@ def test_autofocus_coarse_with_plots(camera, patterns, counter):
     autofocus_event.wait()
     counter['value'] += 1
     assert len(glob.glob(patterns['final'])) == counter['value']
-    assert len(glob.glob(patterns['fine_plot'])) == 1
     assert len(glob.glob(patterns['coarse_plot'])) == 1
 
 


### PR DESCRIPTION
The coarse focus no longer also does a fine focus (#659)

Closes #677 and closes #632 