### PR TITLE
Use DelaySigTerm to cleanly stop ArduinoIO

### DIFF
--- a/pocs/tests/test_arduino_io.py
+++ b/pocs/tests/test_arduino_io.py
@@ -373,18 +373,31 @@ def test_arduino_io_shutdown(serial_handlers, memory_db, msg_publisher, msg_subs
             # to shutdown cleanly; the alternative would be to kill the process.
             cmd_topic = board + ':commands'
             assert cmd_topic == aio._cmd_topic
+
+            # Direct manipulation of stop_running should work.
+            assert not aio.stop_running
+            aio.stop_running = True
+            assert aio.stop_running
+            aio.stop_running = False
+            assert not aio.stop_running
+
+            # And we should be able to send it the command over the command messaging system.
+            get_root_logger().debug('Sending shutdown command')
             cmd_publisher.send_message(cmd_topic, dict(command='shutdown'))
-            # _keep_running should still be true since we've not yet called handle_commands.
-            assert aio._keep_running
+            # stop_running should still be False since we've not yet called handle_commands.
+            assert not aio.stop_running
+
             # On a lightly loaded system, the send_message will work quickly, so that
             # the first call to handle_commands receives it, but it might take longer
             # sometimes.
             for _ in range(10):
-                aio.handle_commands()  # Currently the only setter of ArduinoIO._keep_running
-                if not aio._keep_running:
+                aio.handle_commands()
+                if aio.stop_running:
                     break
                 get_root_logger().debug('Shutdown not handled yet')
-            assert not aio._keep_running
+                get_root_logger().debug('ArduinoIO.stop_running == {!r}', aio.stop_running)
+
+            assert aio.stop_running
 
 
 def test_arduino_io_write_line(serial_handlers, memory_db, msg_publisher, msg_subscriber,
@@ -449,8 +462,8 @@ def test_arduino_io_write_line(serial_handlers, memory_db, msg_publisher, msg_su
         assert 'commands' not in msg_obj['data']
 
         # Shutdown in the expected style.
-        assert aio._keep_running
+        assert not aio.stop_running
         cmd_publisher.send_message(cmd_topic, dict(command='shutdown'))
         thread.join(timeout=10.0)
         assert not thread.is_alive()
-        assert not aio._keep_running
+        assert aio.stop_running

--- a/pocs/utils/logger.py
+++ b/pocs/utils/logger.py
@@ -20,7 +20,7 @@ class StrFormatLogRecord(logging.LogRecord):
 
     Even though you can select '{' as the style for the formatter class,
     you still can't use {} formatting for your message. The custom
-    `getMessage` tries legacy format and then tries new format.
+    `getMessage` tries new format, then falls back to legacy format.
 
     From: https://goo.gl/Cyt5NH
     """


### PR DESCRIPTION
Expose an ArduinoIO.stop_running property, use
from arduino_recorder.py CLI script to stop when
SIGTERM is received.

Added a callback arg to DelaySigTerm, allowing
arduino_recorder.py to be notified when
 SIGTERM is received.

FYI, the reason that I didn't use DelaySigTerm
directly in ArduinoIO.handle_reading is that it
doesn't work in threads other than main, and that
makes testing and uses of ArduinoIO other than
in arduino_recorder.py more difficult.
Nonetheless, it makes DelaySigTerm less applicable
than originally intended.

Fix minor comment error in logger.py.

Continues work on issue #420.