### PR TITLE
Suppress the numpy DeprecationWarnings from astropy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,8 @@ python_files= test_*.py
 norecursedirs= scripts
 addopts= --doctest-modules
 doctest_optionflags= ELLIPSIS NORMALIZE_WHITESPACE ALLOW_UNICODE IGNORE_EXCEPTION_DETAIL
+filterwarnings =
+    ignore:elementwise == comparison failed:DeprecationWarning
 
 [metadata]
 author = PANOPTES Team


### PR DESCRIPTION
A recent change to numpy has resulted in lots of warnings from
astropy. It appears that an upcoming change to astropy will fix
the code so that we don't get the DeprecationWarnings, but until
then this change tells pytest to not clutter the output with
all of those warnings.

FWIW, I'd prefer a fix that still showed one copy of the warning,
but wasn't sure how to achieve that with modest effort.