### PR TITLE
Improve error handling in pocs/utils/images

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -324,26 +324,26 @@ def save_environ():
     os.environ = old_env
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def data_dir():
     return os.path.join(os.getenv('POCS'), 'pocs', 'tests', 'data')
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def unsolved_fits_file(data_dir):
     return os.path.join(data_dir, 'unsolved.fits')
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def solved_fits_file(data_dir):
     return os.path.join(data_dir, 'solved.fits.fz')
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def tiny_fits_file(data_dir):
     return os.path.join(data_dir, 'tiny.fits')
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def noheader_fits_file(data_dir):
     return os.path.join(data_dir, 'noheader.fits')

--- a/conftest.py
+++ b/conftest.py
@@ -6,6 +6,7 @@
 # In addition, there are fixtures defined here that are available to
 # all tests, not just those in pocs/tests.
 
+import copy
 import os
 import pytest
 import subprocess
@@ -314,3 +315,35 @@ def cmd_subscriber(message_forwarder):
     subscriber = PanMessaging.create_subscriber(port)
     yield subscriber
     subscriber.close()
+
+
+@pytest.fixture(scope='function')
+def save_environ():
+    old_env = copy.deepcopy(os.environ)
+    yield
+    os.environ = old_env
+
+
+@pytest.fixture
+def data_dir():
+    return os.path.join(os.getenv('POCS'), 'pocs', 'tests', 'data')
+
+
+@pytest.fixture
+def unsolved_fits_file(data_dir):
+    return os.path.join(data_dir, 'unsolved.fits')
+
+
+@pytest.fixture
+def solved_fits_file(data_dir):
+    return os.path.join(data_dir, 'solved.fits.fz')
+
+
+@pytest.fixture
+def tiny_fits_file(data_dir):
+    return os.path.join(data_dir, 'tiny.fits')
+
+
+@pytest.fixture
+def noheader_fits_file(data_dir):
+    return os.path.join(data_dir, 'noheader.fits')

--- a/pocs/tests/conftest.py
+++ b/pocs/tests/conftest.py
@@ -66,8 +66,3 @@ def config_with_simulated_dome(config):
         },
     })
     return config
-
-
-@pytest.fixture
-def data_dir():
-    return '{}/pocs/tests/data'.format(os.getenv('POCS'))

--- a/pocs/tests/test_images.py
+++ b/pocs/tests/test_images.py
@@ -1,5 +1,7 @@
 import os
 import pytest
+import shutil
+import tempfile
 
 from pocs.images import Image
 from pocs.images import OffsetError
@@ -8,6 +10,15 @@ from pocs.utils.error import Timeout
 
 from astropy import units as u
 from astropy.coordinates import SkyCoord
+
+
+def copy_file_to_dir(to_dir, file):
+    assert os.path.isfile(file)
+    result = os.path.join(to_dir, os.path.basename(file))
+    assert not os.path.exists(result)
+    shutil.copy(file, to_dir)
+    assert os.path.exists(result)
+    return result
 
 
 def test_fits_exists(unsolved_fits_file):
@@ -26,48 +37,48 @@ def test_fits_noheader(noheader_fits_file):
 
 
 def test_solve_timeout(tiny_fits_file):
-    im0 = Image(tiny_fits_file)
-
-    with pytest.raises(Timeout):
-        im0.solve_field(verbose=True, replace=False, radius=4, timeout=1)
-
-    try:
-        os.remove(tiny_fits_file.replace('.fits', '.axy'))
-    except Exception:
-        pass
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tiny_fits_file = copy_file_to_dir(tmpdir, tiny_fits_file)
+        im0 = Image(tiny_fits_file)
+        assert str(im0)
+        with pytest.raises(Timeout):
+            im0.solve_field(verbose=True, replace=False, radius=4, timeout=1)
 
 
 def test_fail_solve(tiny_fits_file):
-    im0 = Image(tiny_fits_file)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tiny_fits_file = copy_file_to_dir(tmpdir, tiny_fits_file)
+        im0 = Image(tiny_fits_file)
+        assert str(im0)
+        with pytest.raises(SolveError):
+            im0.solve_field(verbose=True, replace=False, radius=4)
 
-    with pytest.raises(SolveError):
+
+def test_solve_field_unsolved(unsolved_fits_file, solved_fits_file):
+    # We place the input images into a temp directory so that output images
+    # are also in the temp directory.
+    with tempfile.TemporaryDirectory() as tmpdir:
+        im0 = Image(copy_file_to_dir(tmpdir, unsolved_fits_file))
+
+        assert isinstance(im0, Image)
+        assert im0.wcs is None
+        assert im0.pointing is None
+
         im0.solve_field(verbose=True, replace=False, radius=4)
 
-    try:
-        os.remove(tiny_fits_file.replace('.fits', '.axy'))
-    except Exception:  # pragma: no cover
-        pass
+        assert im0.wcs is not None
+        assert im0.wcs_file is not None
+        assert isinstance(im0.pointing, SkyCoord)
+        assert im0.ra is not None
+        assert im0.dec is not None
+        assert im0.ha is not None
 
-
-def test_solve_field_unsolved(unsolved_fits_file):
-    im0 = Image(unsolved_fits_file)
-
-    assert isinstance(im0, Image)
-    assert im0.wcs is None
-    assert im0.pointing is None
-
-    im0.solve_field(verbose=True, replace=False, radius=4)
-
-    assert im0.wcs is not None
-    assert im0.wcs_file is not None
-    assert isinstance(im0.pointing, SkyCoord)
-    assert im0.ra is not None
-    assert im0.dec is not None
-    assert im0.ha is not None
-
-    # Remove extra files
-    os.remove(unsolved_fits_file.replace('.fits', '.solved'))
-    os.remove(unsolved_fits_file.replace('.fits', '.new'))
+        # Compare it to another file of known offset.
+        im1 = Image(copy_file_to_dir(tmpdir, solved_fits_file))
+        offset_info = im0.compute_offset(im1)
+        # print('offset_info:', offset_info)
+        expected_offset = [10.1 * u.arcsec, 5.29 * u.arcsec, 8.77 * u.arcsec]
+        assert u.allclose(offset_info, expected_offset, rtol=0.005)
 
 
 def test_solve_field_solved(solved_fits_file):
@@ -110,18 +121,6 @@ def test_pointing_error(solved_fits_file):
     assert (perr.delta_ra.to(u.degree).value - 1.647535444553057) < 1e-5
     assert (perr.delta_dec.to(u.degree).value - 1.560722632731533) < 1e-5
     assert (perr.magnitude.to(u.degree).value - 1.9445870862060288) < 1e-5
-
-
-def test_compute_offset_arcsec(solved_fits_file, unsolved_fits_file):
-    img0 = Image(solved_fits_file)
-    img1 = Image(solved_fits_file)
-
-    offset_info = img0.compute_offset(img1)
-    print('offset_info:', offset_info)
-
-    assert offset_info.delta_ra == 0
-    assert offset_info.delta_dec == 0
-    assert offset_info.magnitude == 0
 
 
 # def test_compute_offset_pixel(solved_fits_file, unsolved_fits_file):

--- a/pocs/tests/test_images.py
+++ b/pocs/tests/test_images.py
@@ -10,26 +10,6 @@ from astropy import units as u
 from astropy.coordinates import SkyCoord
 
 
-@pytest.fixture
-def unsolved_fits_file(data_dir):
-    return os.path.join(data_dir, 'unsolved.fits')
-
-
-@pytest.fixture
-def solved_fits_file(data_dir):
-    return os.path.join(data_dir, 'solved.fits.fz')
-
-
-@pytest.fixture
-def tiny_fits_file(data_dir):
-    return os.path.join(data_dir, 'tiny.fits')
-
-
-@pytest.fixture
-def noheader_fits_file(data_dir):
-    return os.path.join(data_dir, 'noheader.fits')
-
-
 def test_fits_exists(unsolved_fits_file):
     with pytest.raises(AssertionError):
         Image(unsolved_fits_file.replace('.fits', '.fit'))
@@ -132,14 +112,16 @@ def test_pointing_error(solved_fits_file):
     assert (perr.magnitude.to(u.degree).value - 1.9445870862060288) < 1e-5
 
 
-# def test_compute_offset_arcsec(solved_fits_file, unsolved_fits_file):
-#     img0 = Image(solved_fits_file)
-#     img1 = Image(unsolved_fits_file)
+def test_compute_offset_arcsec(solved_fits_file, unsolved_fits_file):
+    img0 = Image(solved_fits_file)
+    img1 = Image(solved_fits_file)
 
-#     offset_info = img0.compute_offset(img1)
+    offset_info = img0.compute_offset(img1)
+    print('offset_info:', offset_info)
 
-#     assert offset_info['offsetX'] - 3.9686712667745043 < 1e-5
-#     assert offset_info['offsetY'] - 17.585827075244445 < 1e-5
+    assert offset_info.delta_ra == 0
+    assert offset_info.delta_dec == 0
+    assert offset_info.magnitude == 0
 
 
 # def test_compute_offset_pixel(solved_fits_file, unsolved_fits_file):

--- a/pocs/tests/utils/test_image_utils.py
+++ b/pocs/tests/utils/test_image_utils.py
@@ -1,10 +1,28 @@
+import os
 import numpy as np
+import pytest
 import tempfile
 import shutil
 
 from glob import glob
 
 from pocs.utils import images as img_utils
+
+
+def test_make_images_dir(save_environ):
+    assert img_utils.make_images_dir()
+
+    # Invalid parent directory for 'images'.
+    os.environ['PANDIR'] = '/dev/null/'
+    with pytest.warns(UserWarning):
+        assert img_utils.make_images_dir() is None
+
+    # Valid parents for 'images' that need to be created.
+    with tempfile.TemporaryDirectory() as tmpdir:
+        parent = os.path.join(tmpdir, 'some', 'dirs')
+        imgdir = os.path.join(parent, 'images')
+        os.environ['PANDIR'] = parent
+        assert img_utils.make_images_dir() == imgdir
 
 
 def test_crop_data():
@@ -19,6 +37,49 @@ def test_crop_data():
 
     cropped03 = img_utils.crop_data(ones, verbose=True, box_width=6, center=(50, 50))
     assert cropped03.sum() == 36.
+
+
+def test_make_pretty_image(solved_fits_file, tiny_fits_file, save_environ):
+    # First make a dir and put the files in it
+    with tempfile.TemporaryDirectory() as tmpdir:
+        fz_file = os.path.join(tmpdir, os.path.basename(solved_fits_file))
+        fits_file = os.path.join(tmpdir, os.path.basename(tiny_fits_file))
+        # TODO Add a small CR2 file to our sample image files.
+
+        # Can't operate on non-existent files.
+        with pytest.warns(UserWarning):
+            assert not img_utils.make_pretty_image(fz_file)
+        with pytest.warns(UserWarning):
+            assert not img_utils.make_pretty_image(fits_file)
+
+        # Copy the files.
+        shutil.copy(solved_fits_file, tmpdir)
+        shutil.copy(tiny_fits_file, tmpdir)
+
+        # Not a valid file type (can't automatically handle fits.fz files).
+        with pytest.warns(UserWarning):
+            assert not img_utils.make_pretty_image(fz_file)
+
+        # Can handle the fits file, and creating the images dir for linking
+        # the latest image.
+        imgdir = os.path.join(tmpdir, 'images')
+        assert not os.path.isdir(imgdir)
+        os.environ['PANDIR'] = tmpdir
+
+        pretty = img_utils.make_pretty_image(fits_file, link_latest=True)
+        assert pretty
+        assert os.path.isfile(pretty)
+        assert os.path.isdir(imgdir)
+        latest = os.path.join(imgdir, 'latest.jpg')
+        assert os.path.isfile(latest)
+        os.remove(latest)
+        os.rmdir(imgdir)
+
+        # Try again, but without link_latest.
+        pretty = img_utils.make_pretty_image(fits_file)
+        assert pretty
+        assert os.path.isfile(pretty)
+        assert not os.path.isdir(imgdir)
 
 
 def test_clean_observation_dir(data_dir):

--- a/pocs/utils/images/__init__.py
+++ b/pocs/utils/images/__init__.py
@@ -25,6 +25,17 @@ palette.set_under('k', 1.0)
 palette.set_bad('g', 1.0)
 
 
+def make_images_dir():
+    images_dir = os.path.join(os.getenv('PANDIR'), 'images')
+    try:
+        os.makedirs(images_dir, exist_ok=True)
+        return images_dir
+    except Exception as e:
+        warn(f'Unable to create the images directory: {images_dir}')
+        warn(f'Exception during os.makedirs: {e}')
+        return None
+
+
 def crop_data(data, box_width=200, center=None, verbose=False):
     """ Return a cropped portion of the image
 
@@ -83,10 +94,10 @@ def make_pretty_image(fname, title=None, timeout=15, link_latest=False, **kwargs
     Returns:
         str -- Filename of image that was created.
     """
-    assert os.path.exists(fname),\
+    if not os.path.exists(fname):
         warn("File doesn't exist, can't make pretty: {}".format(fname))
-
-    if fname.endswith('.cr2'):
+        return None
+    elif fname.endswith('.cr2'):
         pretty_path = _make_pretty_from_cr2(fname, title=title, timeout=timeout, **kwargs)
     elif fname.endswith('.fits'):
         pretty_path = _make_pretty_from_fits(fname, title=title, **kwargs)
@@ -94,16 +105,17 @@ def make_pretty_image(fname, title=None, timeout=15, link_latest=False, **kwargs
         warn("File must be a Canon CR2 or FITS file.")
         return None
 
+    if not link_latest or not os.path.exists(pretty_path):
+        return pretty_path
+
     # Symlink latest.jpg to the image; first remove the symlink if it already exists.
-    if link_latest and os.path.exists(pretty_path):
-        latest_path = os.path.join(
-            os.getenv('PANDIR'),
-            'images',
-            'latest.jpg'
-        )
+    images_dir = make_images_dir()
+    if not images_dir:
+        warn(f"Can't link latest.jpg to {pretty_path}")
+    else:
+        latest_path = os.path.join(images_dir, 'latest.jpg')
         with suppress(FileNotFoundError):
             os.remove(latest_path)
-
         try:
             os.symlink(pretty_path, latest_path)
         except Exception as e:

--- a/pocs/utils/images/__init__.py
+++ b/pocs/utils/images/__init__.py
@@ -26,6 +26,7 @@ palette.set_bad('g', 1.0)
 
 
 def make_images_dir():
+    """Return the path of the PANDIR/images directory, creating it if necessary."""
     images_dir = os.path.join(os.getenv('PANDIR'), 'images')
     try:
         os.makedirs(images_dir, exist_ok=True)
@@ -202,7 +203,7 @@ def _make_pretty_from_fits(fname=None,
     return new_filename
 
 
-def _make_pretty_from_cr2(fname, title=None, timeout=15, **kwargs):  # pragma: no cover
+def _make_pretty_from_cr2(fname, title=None, timeout=15, **kwargs):
     verbose = kwargs.get('verbose', False)
 
     script_name = os.path.join(os.getenv('POCS'), 'scripts', 'cr2_to_jpg.sh')
@@ -215,15 +216,11 @@ def _make_pretty_from_cr2(fname, title=None, timeout=15, **kwargs):  # pragma: n
         print(cmd)
 
     try:
-        proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
         if verbose:
-            print(proc)
-    except OSError as e:
-        raise error.InvalidCommand("Can't send command to gphoto2. {!r} \t {}".format(e, cmd))
-    except ValueError as e:
-        raise error.InvalidCommand("Bad parameters to gphoto2. {!r} \t {}".format(e, cmd))
+            print(output)
     except Exception as e:
-        raise error.PanError("Timeout on plate solving: {!r}".format(e))
+        raise error.InvalidCommand("Error executing gphoto2: {!r}\nCommand: {}".format(e, cmd))
 
     return fname.replace('cr2', 'jpg')
 


### PR DESCRIPTION
Produce more explicit errors about why images can't be
linked in attempt to address an issue seen on travis.

Improve test coverage of images code.

Move fixtures for test images to POCS/conftest.py.