### PR TITLE
Fix broken travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ install:
   - cd $PANDIR
 
   # Install astrometry.net
-  - wget http://astrometry.net/downloads/astrometry.net-0.72.tar.gz
+  - wget https://github.com/dstndstn/astrometry.net/releases/download/0.72/astrometry.net-0.72.tar.gz
   - tar zxvf astrometry.net-0.72.tar.gz
   - cd astrometry.net-0.72 && make && make py && make install INSTALL_DIR=$PANDIR/astrometry
   - echo 'add_path $PANDIR/astrometry/data' | sudo tee --append $PANDIR/astrometry/etc/astrometry.cfg

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ gcloud
 google-cloud-storage
 matplotlib >= 2.0.0,<3.0.0
 mocket
-numpy >= 1.12.1,<1.15.3
+numpy >= 1.12.1, !=1.15.3
 pycodestyle == 2.3.1
 pymongo >= 3.2.2
 pyserial >= 3.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ gcloud
 google-cloud-storage
 matplotlib >= 2.0.0,<3.0.0
 mocket
-numpy >= 1.12.1
+numpy >= 1.12.1, !1.15.3
 pycodestyle == 2.3.1
 pymongo >= 3.2.2
 pyserial >= 3.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ gcloud
 google-cloud-storage
 matplotlib >= 2.0.0,<3.0.0
 mocket
-numpy >= 1.12.1, !1.15.3
+numpy >= 1.12.1,<1.15.3
 pycodestyle == 2.3.1
 pymongo >= 3.2.2
 pyserial >= 3.1.1


### PR DESCRIPTION
There is ongoing work in #711,  #712 and #713 to update some of the travis install for astrometry-net, but in light of the fact that [astrometry.net website will be down](https://github.com/dstndstn/astrometry.net/issues/139#issuecomment-433922607) for an unknown amount of time, this PR simply switches the URL to the github release page, which will unblock #709 and #710.

Edit: Also fixes numpy version to [fix IERS import](https://github.com/astropy/astroplan/issues/375#issuecomment-433592126).