### PR TITLE
Fix memory db clear

### DIFF
--- a/pocs/tests/test_database.py
+++ b/pocs/tests/test_database.py
@@ -23,9 +23,22 @@ def test_insert_and_no_permanent(db):
     assert record is None
 
 
+def test_clear_current(db):
+    rec = {'test': 'insert'}
+    db.insert_current('config', rec)
+
+    record = db.get_current('config')
+    assert record['data']['test'] == rec['test']
+
+    db.clear_current('config')
+
+    record = db.get_current('config')
+    assert record is None
+
+
 def test_simple_insert(db):
     rec = {'test': 'insert'}
-    id0 = db.insert('config', rec)
+    id0 = db.insert_current('config', rec)
 
     record = db.find('config', id0)
     assert record['data']['test'] == rec['test']

--- a/pocs/tests/test_database.py
+++ b/pocs/tests/test_database.py
@@ -38,7 +38,8 @@ def test_clear_current(db):
 
 def test_simple_insert(db):
     rec = {'test': 'insert'}
-    id0 = db.insert_current('config', rec)
+    # Use `insert` here, which returns an `ObjectId`
+    id0 = db.insert('config', rec)
 
     record = db.find('config', id0)
     assert record['data']['test'] == rec['test']

--- a/pocs/utils/database.py
+++ b/pocs/utils/database.py
@@ -297,6 +297,8 @@ class PanMongoDB(AbstractPanDB):
 
     def find(self, collection, obj_id):
         collection = getattr(self, collection)
+        if isinstance(obj_id, str):
+            obj_id = ObjectId(obj_id)
         return collection.find_one({'_id': ObjectId(obj_id)})
 
     def clear_current(self, type):

--- a/pocs/utils/database.py
+++ b/pocs/utils/database.py
@@ -300,7 +300,7 @@ class PanMongoDB(AbstractPanDB):
         collection = getattr(self, collection)
         if isinstance(obj_id, str):
             obj_id = ObjectId(obj_id)
-        return collection.find_one({'_id': ObjectId(obj_id)})
+        return collection.find_one({'_id': obj_id})
 
     def clear_current(self, type):
         self.current.delete_one({'type': type})

--- a/pocs/utils/database.py
+++ b/pocs/utils/database.py
@@ -6,6 +6,7 @@ import weakref
 from warnings import warn
 from uuid import uuid4
 from glob import glob
+from bson.objectid import ObjectId
 
 from pocs.utils import current_time
 from pocs.utils import serializers as json_util
@@ -296,7 +297,7 @@ class PanMongoDB(AbstractPanDB):
 
     def find(self, collection, obj_id):
         collection = getattr(self, collection)
-        return collection.find_one({'_id': obj_id})
+        return collection.find_one({'_id': ObjectId(obj_id)})
 
     def clear_current(self, type):
         self.current.delete_one({'type': type})

--- a/pocs/utils/database.py
+++ b/pocs/utils/database.py
@@ -497,10 +497,10 @@ class PanMemoryDB(AbstractPanDB):
             obj = json_util.loads(obj)
         return obj
 
-    def clear_current(self, type):
+    def clear_current(self, entry_type):
         try:
-            del self.current['type']
-        except KeyError:
+            del self.current[entry_type]
+        except KeyError as e:
             pass
 
     @classmethod


### PR DESCRIPTION
There is a bug for clearing the current entry in the Memory DB type. It's not clear if this was used anywhere but manifested itself as part of #710.

@jamessynge it's actually unclear to me where we are using the MemoryDB and if it's used for anything besides testing.

Edit: The actual fix is in 0fc200e0a9e3a38d0d3a4b778600bafe6d35b624 (merged as part of #710) as there were some circular failures going on with testing. This PR adds a test and other small cleanup.