### PR TITLE
Add install-apt-packages.sh

### DIFF
--- a/scripts/install/README.md
+++ b/scripts/install/README.md
@@ -1,0 +1,114 @@
+# PANOPTES Software Installation Tools
+
+## Installation Procedure
+
+__MUCH WORK IS NEEDED HERE__
+
+### Initial Setup of Bare Computer
+
+#### Install Ubuntu 18.04 Desktop
+#### Create Primary Account
+
+When prompted to create the primary account during the install of Ubuntu,
+create an account with your name (e.g. james)...
+
+### Install Linux Packages (Software) Needed to Install PANOPTES
+
+```
+sudo apt-get update
+sudo apt-get install --yes git
+```
+
+### Install Linux Packages (Software) Needed by PANOPTES
+
+*This is where we need a single script that we can fetch from github
+rather than use git clone.*
+
+#### Create Secondary (PANOPTES) Account
+
+Create an account for user `panoptes` with all the privileges of the
+primary user, especially plugdev (needed for access to serial ports).
+
+> If using docker, then also add the user to the docker group.
+> If you don't know what that means, then skip adding to the docker group.
+
+## Script Descriptions
+
+### default-env-vars.sh
+
+Sets the PANOPTES related environment variables to their default values.
+Once you've run install-dependencies.sh you won't need this script anymore.
+
+### run-apt-cacher-ng-in-docker.sh
+
+This is a tool primarily for developers and testers of the PANOPTES
+software. It helps speed up the install-apt-packages.sh in the case
+that you need to run that command many times, as when testing changes
+to the install scripts. In particular, it starts a docker container
+running a caching proxy that listens on port 3142 for requests for
+apt packages. If it hasn't seen a request for that package before,
+it pass the request on to the "real" package repository, stores the
+fetched package in a directory and returns the package to the caller
+(e.g. to `apt-get`).
+
+Requires that `docker` be installed. Learn more on the
+(docker site)[https://docs.docker.com/install/linux/docker-ce/ubuntu/].
+
+### configure-apt-cache.sh
+
+If you've run run-apt-cacher-ng-in-docker.sh, then you can either
+tell apt-get where to find the caching proxy each time or you can
+run this script which permanently records the fact that you have
+a caching proxy running on port 3142.
+
+```
+   $ $POCS/scripts/install/configure-apt-cache.sh 3142
+```
+
+### install-apt-packages.sh
+
+Installs the required Linux open source software onto the machines.
+The user that executes this must be a member of the sudo group
+(i.e. allowed to run commands as `root`).
+If you're running the caching proxy (see above), and have NOT
+run configure-apt-cache.sh, then you'll want to tell this script
+where to find the proxy:
+
+```
+   $ APT_PROXY_PORT=3142 $POCS/scripts/install/install-apt-packages.sh
+```
+
+### install-dependencies.sh
+
+Installs the open source software that the PANOPTES software depends upon,
+including running install-apt-packages.sh.
+Writes a script ($PANDIR/set-panoptes-env.sh) that sets up your shell with
+the correct environment variables for running the PANOPTES software, and
+adds a call to that script into your shell's initialization script.
+
+### install-helper-functions.sh
+
+This isn't intended to be executed directly; instead it provides a bunch of
+functions that are used by several of the scripts described above.
+
+## Resource (List) Descriptions
+
+These files list packages to be installed, and are read by the scripts
+described above.
+
+### apt-packages-list.txt
+
+List of Linux packages to be installed; these are "native" packages (i.e.
+compiled software). Installing such packages requires `root` privileges
+in order to execute `apt-get install` (used by `install-apt-packages.sh`
+and `install-dependencies.sh`).
+
+### conda-packages-list.txt
+
+List of packages in the Anaconda format, many of which are implemented in
+Python, but not all. These do not require `root` privileges to install.
+
+### $POCS/requirements.txt
+
+List of packages in the Wheel format, installed using the `pip` tool.
+These do not require `root` privileges to install.

--- a/scripts/install/configure-apt-cache.sh
+++ b/scripts/install/configure-apt-cache.sh
@@ -4,7 +4,7 @@
 # if one has been setup. Pass in the port as the first (and only) argument
 # to this script, else set the APT_PROXY_PORT environment variable to the
 # port number. Records the URL of the proxy "permanently" in
-# /etc/apt/apt.conf.d/01proxy; root root access is required to write to
+# /etc/apt/apt.conf.d/01proxy; root access is required to write to
 # that file.
 #
 # Using this script is appropriate if it isn't practical to pass the

--- a/scripts/install/configure-apt-cache.sh
+++ b/scripts/install/configure-apt-cache.sh
@@ -1,52 +1,45 @@
 #!/bin/bash -e
 
-# Tell apt where to find the cache for packages, if one has been setup.
-# We look for the APT_PROXY_PORT environment variable to be set to the port
-# number, else for the first argument to be set to the port number.
-
-# Requires root access in order to write to /etc/apt/apt.conf.d/01proxy
-
-# TODO(james): Determine if we can replace this change of the config file
-# with a --option flag on apt-get, ala:
+# Tell apt where to find the local (on-host) caching proxy for APT packages,
+# if one has been setup. Pass in the port as the first (and only) argument
+# to this script, else set the APT_PROXY_PORT environment variable to the
+# port number. Records the URL of the proxy "permanently" in
+# /etc/apt/apt.conf.d/01proxy; root root access is required to write to
+# that file.
+#
+# Using this script is appropriate if it isn't practical to pass the
+# URL of the proxy on the apt-get command line, such as this way:
 #
 #   apt-get -o "Acquire::HTTP::Proxy=${APT_PROXY_URL}" install ...
 #
-# This would avoid the need for sudo outside of docker build, and would
-# avoid docker build permanently recording the proxy in docker image.
-
+# The script install-apt-packages.sh uses this latter approach.
+#
 # To learn more, see:
 # https://github.com/sameersbn/docker-apt-cacher-ng
 # https://gist.github.com/dergachev/8441335
 # https://chandrusoft.wordpress.com/2012/09/30/disable-proxy-when-using-apt-get/
 
-APT_PROXY_PORT="${APT_PROXY_PORT:-${1}}"
-if [ -z "${APT_PROXY_PORT}" ] ; then
-  echo "No apt cache proxy declared via APT_PROXY_PORT or script argument."
-  exit 0
-fi
-echo "APT_PROXY_PORT: ${APT_PROXY_PORT}"
+THIS_DIR="$(dirname "$(readlink -f "${0}")")"
+# shellcheck source=/var/panoptes/POCS/scripts/install/install-helper-functions.sh
+source "${THIS_DIR}/install-helper-functions.sh"
 
-# Need to figure out our IP address. We'll try multiple techniques.
-HOST_IP=$(awk '/^[a-z]+[0-9]+\t00000000/ { printf("%d.%d.%d.%d\n", "0x" substr($3, 7, 2), "0x" substr($3, 5, 2), "0x" substr($3, 3, 2), "0x" substr($3, 1, 2)) }' < /proc/net/route)
-if [ -z "${HOST_IP}" -a -x /sbin/ip ] ; then
-  HOST_IP=$(/sbin/ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
-fi
-if [ -z "${HOST_IP}" ] ; then
-  echo "Unable to determine host IP address!"
+# shellcheck disable=SC2086
+APT_PROXY_URL="$(get_apt_proxy_url ${1})"
+if [ -z "${APT_PROXY_URL}" ] ; then
+  echo "Unable to find operating APT proxy!" 1>&2
   exit 1
 fi
 
-APT_PROXY_URL="http://${HOST_IP}:${APT_PROXY_PORT}"
 APT_PROXY_FILE=/etc/apt/apt.conf.d/01proxy
 
-if [ 0 == $(id -u) ]; then
+if [ 0 == "$(id -u)" ]; then
   # Running as root already.
   cat >> "${APT_PROXY_FILE}" <<EOL
 Acquire::HTTP::Proxy "${APT_PROXY_URL}";
 Acquire::HTTPS::Proxy "false";
 EOL
 else
-  echo "Running sudo to write to ${APT_PROXY_FILE}; you may be prompted for"
+  echo "Running sudo to append to ${APT_PROXY_FILE}; you may be prompted for"
   echo "your password..."
   (set -x ; cat <<EOL | sudo tee --append "${APT_PROXY_FILE}" > /dev/null
 Acquire::HTTP::Proxy "${APT_PROXY_URL}";
@@ -55,6 +48,10 @@ EOL
 )
 fi
 
+echo
+echo "Appended to ${APT_PROXY_FILE}"
+echo_bar
 cat /etc/apt/apt.conf.d/01proxy
+echo_bar
 echo
 echo "Using apt proxy at: ${APT_PROXY_URL}"

--- a/scripts/install/install-apt-packages.sh
+++ b/scripts/install/install-apt-packages.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -ex
+
+# Installs APT packages (e.g. debian/ubuntu packages installed for all users).
+# Requires being logged in as root or the ability to successfully execute sudo.
+
+THIS_DIR="$(dirname "$(readlink -f "${0}")")"
+# shellcheck source=/var/panoptes/POCS/scripts/install/install-helper-functions.sh
+source "${THIS_DIR}/install-helper-functions.sh"
+
+# Suppress prompting for input during package processing, unless DEBIAN_FRONTEND
+# is already set. The tzdata 
+if [ -z "${DEBIAN_FRONTEND}" ] ; then
+  export DEBIAN_FRONTEND=noninteractive
+fi
+
+# Generate the basic apt-get install command, minus the list of packages.
+declare -a apt_get_install=(apt-get install --no-install-recommends --yes)
+# shellcheck disable=SC2119
+apt_proxy_url="$(get_apt_proxy_url)"
+if [ -n "${apt_proxy_url}" ] ; then
+  apt_get_install+=(-o "Acquire::HTTP::Proxy=${apt_proxy_url}")
+fi
+
+# Install all of the packages specified in the files in the args.
+function install_apt_packages() {
+  echo
+  echo_running_sudo "apt-get update"
+  echo
+  my_sudo apt-get update
+
+  for APT_PKGS_FILE in "$@"
+  do
+    # Remove all the comments from the package list and install the packages whose
+    # names are left.
+    APT_PKGS="$(cut '-d#' -f1 "${APT_PKGS_FILE}" | sort | uniq)"
+    echo
+    echo_running_sudo "apt-get install for the files in ${APT_PKGS_FILE}"
+    echo
+    # shellcheck disable=SC2086
+    my_sudo "${apt_get_install[@]}" ${APT_PKGS}
+  done
+}
+
+cd "${THIS_DIR}"
+
+if [ $# -eq 0 ] ; then
+  install_apt_packages apt-packages-list.txt
+else  
+  install_apt_packages "$@"
+fi

--- a/scripts/install/install-apt-packages.sh
+++ b/scripts/install/install-apt-packages.sh
@@ -8,12 +8,15 @@ THIS_DIR="$(dirname "$(readlink -f "${0}")")"
 source "${THIS_DIR}/install-helper-functions.sh"
 
 # Suppress prompting for input during package processing, unless DEBIAN_FRONTEND
-# is already set. The tzdata 
+# is already set. The tzdata package prompts the user to pick a timezone,
+# annoying when you're trying to automate things and don't care which time
+# zone is selected (the default is UTC).
 if [ -z "${DEBIAN_FRONTEND}" ] ; then
   export DEBIAN_FRONTEND=noninteractive
 fi
 
 # Generate the basic apt-get install command, minus the list of packages.
+# We store into a shell array, i.e. an array of strings.
 declare -a apt_get_install=(apt-get install --no-install-recommends --yes)
 # shellcheck disable=SC2119
 apt_proxy_url="$(get_apt_proxy_url)"
@@ -36,6 +39,11 @@ function install_apt_packages() {
     echo
     echo_running_sudo "apt-get install for the files in ${APT_PKGS_FILE}"
     echo
+    # A note on syntax: ${array_variable} expands to just the first element
+    # of the array. ${array_variable[@]} expands to all of the elements.
+    # Putting quotes around that has the affect of expanding the array as
+    # one quoted string PER element in the array, and thus spaces in
+    # a single element (e.g. "a b") doesn't result in multiple 'words'.
     # shellcheck disable=SC2086
     my_sudo "${apt_get_install[@]}" ${APT_PKGS}
   done

--- a/scripts/install/install-dependencies.sh
+++ b/scripts/install/install-dependencies.sh
@@ -6,6 +6,9 @@
 THIS_DIR="$(dirname "$(readlink -f "${0}")")"
 THIS_PROGRAM="$(basename "${0}")"
 
+# shellcheck source=/var/panoptes/POCS/scripts/install/install-helper-functions.sh
+source "${THIS_DIR}/install-helper-functions.sh"
+
 # We try to figure out where things are so that minimal work is required
 # by the user.
 VARS_ARE_OK=1
@@ -87,7 +90,6 @@ fi
 # Python 3.6 works around a problem building astroscrappy in 3.7.
 PYTHON_VERSION="3.6"
 ASTROMETRY_VERSION="0.76"
-INSTALL_PREFIX="/usr/local"
 ASTROMETRY_DIR="${PANDIR}/astrometry"
 CONDA_INSTALL_DIR="${PANDIR}/miniconda"
 CONDA_SH="${CONDA_INSTALL_DIR}/etc/profile.d/conda.sh"
@@ -196,39 +198,7 @@ while test ${#} -gt 0; do
 done
 
 #-------------------------------------------------------------------------------
-# Get the type of the first arg, i.e. shell function, executable, etc.
-# For more info: https://ss64.com/bash/type.html
-#            or: https://bash.cyberciti.biz/guide/Type_command
-function safe_type() {
-  type -t "${1}" || /bin/true
-}
-
-# Get the disk location of the first arg.
-function safe_which() {
-  type -p "${1}" || /bin/true
-}
-
-#-------------------------------------------------------------------------------
-# Logging support (nascent; I want to add more control and a log file).
-
-# Print a separator bar of # characters.
-function echo_bar() {
-  local terminal_width
-  if [ -n "${TERM}" -a -t 0 ] ; then
-    if [[ -n "$(which resize)" ]] ; then
-      terminal_width="$(resize 2>/dev/null | grep COLUMNS= | cut -d= -f2)"
-    elif [[ -n "$(which stty)" ]] ; then
-      terminal_width="$(stty size 2>/dev/null | cut '-d ' -f2)"
-    fi
-  fi
-  printf "%${terminal_width:-80}s\n" | tr ' ' '#'
-}
-
-#-------------------------------------------------------------------------------
 # Misc helper functions.
-
-# Does the first arg start with the second arg?
-function beginswith() { case "${1}" in "${2}"*) true;; *) false;; esac; }
 
 # Backup the file whose path is the first arg, and print the path of the
 # backup file. If the file doesn't exist, no path is output.
@@ -374,21 +344,6 @@ function extract_version_from_pkg_config() {
   fi
 }
 
-# Install all of the packages specified in the apt-packages-list file.
-function install_apt_packages() {
-  echo
-  echo "Running sudo apt-get update, you may be prompted for your password."
-  echo
-  (set -x ; sudo apt-get update)
-  # Remove all the comments from the package list and install the packages whose
-  # names are left.
-  APT_PKGS="$(cut '-d#' -f1 "${THIS_DIR}/apt-packages-list.txt" | sort | uniq)"
-  echo
-  echo "Running sudo apt-get install, you may be prompted for your password."
-  echo
-  (set -x ; sudo apt-get install --yes ${APT_PKGS})
-}
-
 function install_mongodb() {
   # This is based on https://www.howtoforge.com/tutorial/install-mongodb-on-ubuntu/
   # Note this function does not configure mongodb itself, i.e. no users or
@@ -471,43 +426,6 @@ function conda_is_present() {
   return 0  # Probably
 }
 
-function is_panoptes_env_activated() {
-  if ! conda_is_present ; then
-    return 1  # No
-  fi
-  # Do we have a conda executable? If not, then no environment has
-  # been activated so far.
-  if [[ -z "${CONDA_EXE}" || ! -x "${CONDA_EXE}" ]] ; then
-    return 1  # No
-  fi
-  # Does it work?
-  local -r conda_info="$("${CONDA_EXE}" info 2>/dev/null || /bin/true)"
-  if [[ -z "${conda_info}" ]] ; then
-    return 1  # No
-  fi
-  # Is the panoptes-env activated?
-  if ! (echo "${conda_info}" | grep -q -E 'active environment.*:.*panoptes-env$') ; then
-    return 1  # No
-  fi
-  # Does the env have a valid location?
-  local -r env_location="$(echo "${conda_info}" | \
-                           (grep -E 'active env location :' || /bin/true) | \
-                           cut -d: -f2 | xargs)"
-  if [[ -z "${env_location}" ]] ; then
-    return 1  # No
-  fi
-  if [[ ! -d "${env_location}" ]] ; then
-    return 1  # No
-  fi
-  # Is python in that location?
-  local -r python_location="$(safe_which python)"
-  if ! beginswith "${python_location}" "${env_location}" ; then
-    return 1  # No
-  fi
-  # Looks good.
-  return 0
-}
-
 # Get the location of the panoptes environment.
 function get_panoptes_env_location() {
   if ! conda_is_present ; then
@@ -563,6 +481,7 @@ function install_conda() {
   # Where CONDA_INSTALL_DIR is where Anaconda or miniconda was installed.
   # We do the first step here. Later we'll activate the PANOPTES environment.
 
+  # shellcheck disable=SC1090
   . "${CONDA_SH}"
 }
 
@@ -575,6 +494,7 @@ function add_conda_channels() {
   # package. And by default the most recently added repository is treated
   # as the highest priority repository. Here we use prepend to be clear
   # that we want astropy to be highest priority.
+  # shellcheck disable=SC1090
   . "${CONDA_SH}"
   if (conda config --show channels | grep -F -q astropy) ; then
     conda config --remove channels astropy
@@ -592,6 +512,7 @@ function add_conda_channels() {
 function prepare_panoptes_conda_env() {
   # Use the base Anaconda environment until we're ready to
   # work with the PANOPTES environment.
+  # shellcheck disable=SC1090
   . "${CONDA_SH}"
   conda activate base
 
@@ -634,6 +555,7 @@ function prepare_panoptes_conda_env() {
 function maybe_install_conda() {
   # Just in case conda isn't setup, but exists...
   if [[ -z "$(safe_type conda)" && -f "${CONDA_SH}" ]] ; then
+    # shellcheck disable=SC1090
     . "${CONDA_SH}"
   fi
   if [[ -z "$(safe_type conda)" ]] ; then
@@ -806,20 +728,13 @@ fi
 # Install packages using the APT package manager. Works on Debian based systems
 # such as Ubuntu.
 if [[ "${DO_APT_GET}" -eq 1 ]] ; then
-  install_apt_packages
+  "${THIS_DIR}/install-apt-packages.sh"
 fi
 
 # Install Mongodb, a document database. Used by POCS for storing observation
 # metadata and the environment readings from which weather plots are generated.
 if [[ "${DO_MONGODB}" -eq 1 ]] ; then
   maybe_install_mongodb
-fi
-
-# Before installing conda, figure out if the calling shell had the correct
-# environment setup.
-had_activated_panoptes_env=0
-if is_panoptes_env_activated ; then
-  had_activated_panoptes_env=1
 fi
 
 # Install Conda, a Python package manager from Anaconda, Inc. Supports both
@@ -830,6 +745,7 @@ if [[ "${DO_CONDA}" -eq 1 ]] ; then
 fi
 
 if [[ -f "${CONDA_SH}" ]] ; then
+  # shellcheck disable=SC1090
   . "${CONDA_SH}"
 else
   echo_bar

--- a/scripts/install/install-helper-functions.sh
+++ b/scripts/install/install-helper-functions.sh
@@ -78,7 +78,7 @@ function proc_net_route_addr() {
   printf "%d.%d.%d.%d\n" "${a}" "${b}" "${c}" "${d}"
 }
 
-# Print the first IP on the route to 8.8.8.8, i.e. to Google's public DNS server?
+# Print the first IP on the route to 8.8.8.8, i.e. to Google's public DNS server.
 # Will be one of this hosts IP addresses or nothing if 'ip' is not installed.
 function route_dns_addr() {
   if [ -x /sbin/ip ] ; then

--- a/scripts/install/install-helper-functions.sh
+++ b/scripts/install/install-helper-functions.sh
@@ -1,0 +1,148 @@
+#!/bin/bash 
+# This file is to be sourced into another to add helper functions, rather than
+# executed directly.
+
+#-------------------------------------------------------------------------------
+# Logging support (nascent; I want to add more control and a log file).
+
+# Print a separator bar of # characters.
+function echo_bar() {
+  local terminal_width
+  if [ -n "${TERM}" ] && [ -t 0 ] ; then
+    if [[ -n "$(which resize)" ]] ; then
+      terminal_width="$(resize 2>/dev/null | grep COLUMNS= | cut -d= -f2)"
+    elif [[ -n "$(which stty)" ]] ; then
+      terminal_width="$(stty size 2>/dev/null | cut '-d ' -f2)"
+    fi
+  fi
+  printf "%${terminal_width:-80}s\n" | tr ' ' '#'
+}
+
+function echo_running_sudo() {
+  if [ "$(id -u -n)" == "root" ] ; then
+    echo "Running $1"
+  else
+    echo "Running sudo $1; you may be prompted for your password."
+  fi
+}
+
+#-------------------------------------------------------------------------------
+# Misc helper functions.
+
+# Execute the args (a command) as root, either using sudo or directly if already
+# running as root.
+function my_sudo() {
+  if [ "$(id -u -n)" == "root" ] ; then
+    "$@"
+  else
+    (set -x ; sudo "$@")
+  fi
+}
+
+# Get the type of the first arg, i.e. shell function, executable, etc.
+# For more info: https://ss64.com/bash/type.html
+#            or: https://bash.cyberciti.biz/guide/Type_command
+function safe_type() {
+  type -t "${1}" || /bin/true
+}
+
+# Print the disk location of the first arg.
+function safe_which() {
+  type -p "${1}" || /bin/true
+}
+
+# Does the first arg start with the second arg?
+function beginswith() { case "${1}" in "${2}"*) true;; *) false;; esac; }
+
+#-------------------------------------------------------------------------------
+# Helpers for finding the APT caching proxy.
+
+# 
+function proc_net_route_addr() {
+  if [ ! -e /proc/net/route ] ; then
+    return
+  fi
+  # This can be done with awk, but that is then much harder to debug.
+  # /proc/net/route has contents like this:
+  #    Iface Destination Gateway  Flags RefCnt Use Metric Mask     MTU Window IRTT                                                       
+  #    eth0  00000000    010011AC 0003  0      0   0      00000000 0   0      0                                                                               
+  # We're looking to find a line like the second one, with zero for the destination
+  # and the Gateway is the 32-bit hex value for the IPv4 address of the docker host,
+  # where the last two characters represent the leading (high) bits of the address.
+  local -r -a words=( $(grep -E -i '^[a-z][a-z0-9]+\s00000000\s[0-9a-f][0-9a-f][0-9a-f][0-9a-f]' /proc/net/route ) )
+  local -r gateway="${words[2]}"
+  local -r a="0x${gateway:6:2}"
+  local -r b="0x${gateway:4:2}"
+  local -r c="0x${gateway:2:2}"
+  local -r d="0x${gateway:0:2}"
+  printf "%d.%d.%d.%d\n" "${a}" "${b}" "${c}" "${d}"
+}
+
+# Print the first IP on the route to 8.8.8.8, i.e. to Google's public DNS server?
+# Will be one of this hosts IP addresses or nothing if 'ip' is not installed.
+function route_dns_addr() {
+  if [ -x /sbin/ip ] ; then
+    # What is the route to 8.8.8.8, i.e. to Google's public DNS server?
+    /sbin/ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}'
+  fi
+}
+
+# Checks whether $1 (a URL) is for a server that will respond.
+# Returns status code:
+#    1 if the URL ($1) is invalid
+#    $2 if no tool available to check the validity
+#    0 otherwise
+function check_is_url() {
+  local -r url="${1}"
+  local -r default_status="${2}"
+
+  # curl supports head requests, exactly what we want.
+  if [ -x "$(safe_which curl)" ] ; then
+    local -r response_head="$(curl --silent --fail-early --head --max-time 3 "${url}" || /bin/true)"
+    if beginswith "${response_head}" "HTTP/" ; then
+      return 0
+    fi
+    echo "curl unable to fetch headers for ${url}" 1>&2
+    return 1
+  fi
+
+  if [ -x "$(safe_which wget)" ] ; then
+    (set +e ; wget --quiet --spider --tries 1 "${url}")
+    case $? in
+      0|6|8)  # No error, auth failure or HTTP error.
+        return 0
+        ;;
+      *)
+        echo "wget unable to fetch headers for ${url}" 1>&2
+        return 1
+    esac
+  fi
+
+  return "${default_status}"
+}
+
+# Print the URL for the APT caching proxy. Looks for the port to use as
+# the first arg (if any are provided), else the APT_PROXY_PORT environment
+# variable; if neither is set, then no URL is printed.
+# If curl is available, it is used to test whether the URL is valid, but if
+# not then the URL is assumed valid.
+function get_apt_proxy_url() {
+  local -r apt_proxy_port="${1:-${APT_PROXY_PORT}}"
+  if [ -z "${apt_proxy_port}" ] ; then
+    echo "No apt cache proxy declared via APT_PROXY_PORT or script argument." 1>&2
+    return
+  fi
+  echo "APT_PROXY_PORT: ${apt_proxy_port}" 1>&2
+
+  # See if we can connect to a webserver at our address and the apt proxy port.
+  for apt_proxy_host in "$(route_dns_addr)" "$(proc_net_route_addr)" "localhost" ; do
+    if [ -z "${apt_proxy_host}" ] ; then
+      continue
+    fi
+    local apt_proxy_url="http://${apt_proxy_host}:${apt_proxy_port}"
+    if check_is_url "${apt_proxy_url}" 0 ; then
+      echo "${apt_proxy_url}"
+      return
+    fi
+  done
+}


### PR DESCRIPTION
scripts/install/install-apt-packages.sh will work in docker build,
docker run or on the debian/ubuntu host. Will use an APT caching
proxy if one is provided via command line or environment variable.
Will use sudo if not running as root, else just execute the apt
commands directly.

Add scripts/install/install-helper-functions.sh with functions
from install-dependencies.sh and new functions to support using
an APT caching proxy.

Use install-helper-functions.sh from configure-apt-cache.sh
and install-dependencies.sh.

Use install-apt-packages.sh from install-dependencies.sh.

Removed some dead code from install-dependencies.

Tidied up install shell scripts following much of the advice
from shellcheck, but also disabled some shellcheck complaints.