### PR TITLE
New horizon checks

### DIFF
--- a/conf_files/pocs.yaml
+++ b/conf_files/pocs.yaml
@@ -19,8 +19,10 @@ location:
     longitude: -155.58 # Degrees
     elevation: 3400.0 # Meters
     utc_offset: -10.00 # Hours
-    horizon: 30 # Degrees
-    twilight_horizon: -18 # Degrees
+    horizon: 30 # Degrees - Targets above this limit
+    flat_horizon: -6 # Degrees - Flats between this and focus horizon
+    focus_horizon: -12 # Degrees - Dark enough to focus on stars
+    observe_horizon: -18 # Degrees - Sun below this limit to observe
     timezone: US/Hawaii
     gmt_offset: -600 # Offset in minutes from GMT during
                      # standard time (not daylight saving)

--- a/conf_files/pocs.yaml
+++ b/conf_files/pocs.yaml
@@ -19,13 +19,13 @@ location:
     longitude: -155.58 # Degrees
     elevation: 3400.0 # Meters
     utc_offset: -10.00 # Hours
-    horizon: 30 # Degrees - Targets above this limit
-    flat_horizon: -6 # Degrees - Flats when sun between this and focus horizon
-    focus_horizon: -12 # Degrees - Dark enough to focus on stars
-    observe_horizon: -18 # Degrees - Sun below this limit to observe
+    horizon: 30 # Degrees; targets must be above this to be considered valid.
+    flat_horizon: -6 # Degrees - Flats when sun between this and focus horizon.
+    focus_horizon: -12 # Degrees - Dark enough to focus on stars.
+    observe_horizon: -18 # Degrees - Sun below this limit to observe.
     timezone: US/Hawaii
-    gmt_offset: -600 # Offset in minutes from GMT during
-                     # standard time (not daylight saving)
+    gmt_offset: -600 # Offset in minutes from GMT during.
+                     # standard time (not daylight saving).
 directories:
     base: /var/panoptes
     images: images

--- a/conf_files/pocs.yaml
+++ b/conf_files/pocs.yaml
@@ -20,7 +20,7 @@ location:
     elevation: 3400.0 # Meters
     utc_offset: -10.00 # Hours
     horizon: 30 # Degrees - Targets above this limit
-    flat_horizon: -6 # Degrees - Flats between this and focus horizon
+    flat_horizon: -6 # Degrees - Flats when sun between this and focus horizon
     focus_horizon: -12 # Degrees - Dark enough to focus on stars
     observe_horizon: -18 # Degrees - Sun below this limit to observe
     timezone: US/Hawaii

--- a/pocs/core.py
+++ b/pocs/core.py
@@ -327,15 +327,15 @@ class POCS(PanStateMachine, PanBase):
 
         return safe
 
-    def is_dark(self, horizon='flat'):
+    def is_dark(self, horizon='observe'):
         """Is it dark
 
         Checks whether it is dark at the location provided. This checks for the config
         entry `location.flat_horizon` by default.
 
         Args:
-            horizon (str, optional): Which horizon to use, 'flat' (default),
-                'focus', or 'observe'.
+            horizon (str, optional): Which horizon to use, 'flat''focus', or
+                'observe' (default).
 
         Returns:
             bool: Is sun below horizon at location

--- a/pocs/observatory.py
+++ b/pocs/observatory.py
@@ -143,6 +143,7 @@ class Observatory(PanBase):
 # Device Getters/Setters
 ##########################################################################
 
+
     def add_camera(self, cam_name, camera):
         """Add camera to list of cameras as cam_name.
 
@@ -644,8 +645,9 @@ class Observatory(PanBase):
             pressure = config_site.get('pressure', 0.680) * u.bar
             elevation = config_site.get('elevation', 0 * u.meter)
             horizon = config_site.get('horizon', 30 * u.degree)
-            twilight_horizon = config_site.get(
-                'twilight_horizon', -18 * u.degree)
+            flat_horizon = config_site.get('flat_horizon', 0 * u.degree)
+            focus_horizon = config_site.get('focus_horizon', 0 * u.degree)
+            observe_horizon = config_site.get('observe_horizon', -18 * u.degree)
 
             self.location = {
                 'name': name,
@@ -656,7 +658,9 @@ class Observatory(PanBase):
                 'utc_offset': utc_offset,
                 'pressure': pressure,
                 'horizon': horizon,
-                'twilight_horizon': twilight_horizon,
+                'flat_horizon': flat_horizon,
+                'focus_horizon': focus_horizon,
+                'observe_horizon': observe_horizon,
             }
             self.logger.debug("Location: {}".format(self.location))
 

--- a/pocs/observatory.py
+++ b/pocs/observatory.py
@@ -68,7 +68,7 @@ class Observatory(PanBase):
         self.logger.info('\t Observatory initialized')
 
 ##########################################################################
-# Property methods
+# Helper methods
 ##########################################################################
 
     def is_dark(self, horizon='observe', at_time=None):
@@ -96,7 +96,7 @@ class Observatory(PanBase):
         return is_dark
 
 ##########################################################################
-# Helper methods
+# Properties
 ##########################################################################
 
     @property

--- a/pocs/observatory.py
+++ b/pocs/observatory.py
@@ -645,8 +645,8 @@ class Observatory(PanBase):
             pressure = config_site.get('pressure', 0.680) * u.bar
             elevation = config_site.get('elevation', 0 * u.meter)
             horizon = config_site.get('horizon', 30 * u.degree)
-            flat_horizon = config_site.get('flat_horizon', 0 * u.degree)
-            focus_horizon = config_site.get('focus_horizon', 0 * u.degree)
+            flat_horizon = config_site.get('flat_horizon', -6 * u.degree)
+            focus_horizon = config_site.get('focus_horizon', -12 * u.degree)
             observe_horizon = config_site.get('observe_horizon', -18 * u.degree)
 
             self.location = {

--- a/pocs/observatory.py
+++ b/pocs/observatory.py
@@ -145,7 +145,6 @@ class Observatory(PanBase):
 # Device Getters/Setters
 ##########################################################################
 
-
     def add_camera(self, cam_name, camera):
         """Add camera to list of cameras as cam_name.
 

--- a/pocs/observatory.py
+++ b/pocs/observatory.py
@@ -68,7 +68,7 @@ class Observatory(PanBase):
         self.logger.info('\t Observatory initialized')
 
 ##########################################################################
-# Helper methods
+# Property methods
 ##########################################################################
 
     def is_dark(self, horizon='observe', at_time=None):

--- a/pocs/observatory.py
+++ b/pocs/observatory.py
@@ -93,6 +93,8 @@ class Observatory(PanBase):
             sun_pos = self.observer.altaz(at_time, target=get_sun(at_time)).alt
             self.logger.debug(f"Sun {sun_pos:.02f} > {horizon_deg} [{horizon}]")
 
+        return is_dark
+
 ##########################################################################
 # Helper methods
 ##########################################################################

--- a/pocs/tests/conftest.py
+++ b/pocs/tests/conftest.py
@@ -5,7 +5,6 @@
 # of this project.
 
 import copy
-import os
 import pytest
 
 import pocs.base

--- a/pocs/tests/test_observatory.py
+++ b/pocs/tests/test_observatory.py
@@ -156,10 +156,21 @@ def test_default_config(observatory):
 
 def test_is_dark(observatory):
     os.environ['POCSTIME'] = '2016-08-13 10:00:00'
-    assert observatory.is_dark is True
+    assert observatory.is_dark() is True
 
     os.environ['POCSTIME'] = '2016-08-13 22:00:00'
-    assert observatory.is_dark is False
+    assert observatory.is_dark() is False
+    assert observatory.is_dark() is False
+    assert observatory.is_dark(at_time=Time('2016-08-13 10:00:00')) is True
+    os.environ['POCSTIME'] = '2016-09-09 04:00:00'
+    assert observatory.is_dark(horizon='flat') is False
+    os.environ['POCSTIME'] = '2016-09-09 05:00:00'
+    assert observatory.is_dark(horizon='flat') is True
+    assert observatory.is_dark(horizon='observe') is False
+    assert observatory.is_dark(horizon='invalid-defaults-to-observe') is False
+    os.environ['POCSTIME'] = '2016-09-09 09:00:00'
+    assert observatory.is_dark(horizon='observe') is True
+    assert observatory.is_dark(horizon='invalid-defaults-to-observe') is True
 
 
 def test_standard_headers(observatory):

--- a/pocs/utils/config.py
+++ b/pocs/utils/config.py
@@ -1,5 +1,6 @@
 import os
 import yaml
+from contextlib import suppress
 
 from astropy import units as u
 from pocs import hardware
@@ -120,8 +121,15 @@ def _parse_config(config):
     if 'location' in config:
         loc = config['location']
 
-        for angle in ['latitude', 'longitude', 'horizon', 'twilight_horizon']:
-            if angle in loc:
+        for angle in [
+            'latitude',
+            'longitude',
+            'horizon',
+            'flat_horizon',
+            'focus_horizon',
+            'observe_horizon'
+        ]:
+            with suppress(KeyError):
                 loc[angle] = loc[angle] * u.degree
 
         loc['elevation'] = loc.get('elevation', 0) * u.meter


### PR DESCRIPTION
This makes available three different horizons that correspond to the civil, nautical, and astronomical twilight. In fact, it begs the question of whether we should just name them that anyway, which would follow astroplan.

This has been extracted from #541 and merely adds the horizons and configures the `is_dark` methods to use them. There should be no change of behavior for a unit from this PR.

Following this PR would be code that incorporates these changes into the various "waiting" events, which will also be extracted from #541 (and improved upon).