### PR TITLE
Don't overshoot the closed position on the first shutter.

### DIFF
--- a/pocs/dome/astrohaven.py
+++ b/pocs/dome/astrohaven.py
@@ -7,38 +7,35 @@ from pocs.dome import abstract_serial_dome
 
 
 class Protocol:
-    # yapf: disable
     # Status codes, produced when not responding to an input. They are oriented towards
     # reporting whether the two shutters are fully closed.
     BOTH_CLOSED = '0'  # Both A and B shutters are fully closed.
     A_IS_CLOSED = '1'  # Only shutter A is fully closed.
     B_IS_CLOSED = '2'  # Only shutter B is fully closed.
-    BOTH_OPEN   = '3'  # Really means both NOT fully closed.
+    BOTH_OPEN = '3'  # Really means both NOT fully closed.
 
     # Status codes produced by the dome when not responding to a movement command.
     STABLE_STATES = (BOTH_CLOSED, BOTH_OPEN, B_IS_CLOSED, A_IS_CLOSED)
 
     # Limit responses, when the limit has been reached on a direction of movement.
-    A_OPEN_LIMIT  = 'x'  # Response to asking for A to open, and being at open limit.
+    A_OPEN_LIMIT = 'x'  # Response to asking for A to open, and being at open limit.
     A_CLOSE_LIMIT = 'X'  # Response to asking for A to close, and being at close limit.
 
-    B_OPEN_LIMIT  = 'y'  # Response to asking for B to open, and being at open limit.
+    B_OPEN_LIMIT = 'y'  # Response to asking for B to open, and being at open limit.
     B_CLOSE_LIMIT = 'Y'  # Response to asking for B to close, and being at close limit.
 
     # Command codes, echoed while happening.
     CLOSE_A = 'A'
-    OPEN_A  = 'a'
+    OPEN_A = 'a'
 
     CLOSE_B = 'B'
-    OPEN_B  = 'b'
+    OPEN_B = 'b'
 
     # These codes are documented for an 18' dome, but appear
     # not to work with the 7' domes we have access to.
-    OPEN_BOTH =  'O'
+    OPEN_BOTH = 'O'
     CLOSE_BOTH = 'C'
-    RESET =      'R'
-
-    # yapf: enable
+    RESET = 'R'
 
     @classmethod
     def code_to_string(cls, code):

--- a/pocs/tests/test_astrohaven_dome.py
+++ b/pocs/tests/test_astrohaven_dome.py
@@ -19,7 +19,10 @@ def dome(config):
     dome_config.update({
         'brand': 'Astrohaven',
         'driver': 'astrohaven',
-        'port': 'astrohaven_simulator://',
+        'serial': {
+            'port': 'astrohaven_simulator://',
+            'baudrate': 9600,
+        }
     })
     del config['simulator']
     the_dome = pocs.dome.create_dome_from_config(config)


### PR DESCRIPTION
The feedback mechanism on the Astrohaven dome is rather limited:
it tells you whether a sensor on the lower shutter is tripped, but
nothing about the upper shutter. Since we were finding the dome
wasn't closing all the way reliably, overshooting seemed to
insure that the dome would close all the way. What we didn't
realize is that the variability in the straps and the sensor
could cause the overshoot to bend the lower shutter up and
over the pulley block on top of the fixed dome base, after
which we need to disassemble the dome to fix it. SIGH.

This was happening just for the first side to be closed (the
A side) as the other side couldn't close too far because it
would hit the top shutter of the first side. So, I've modified
the code so that it will stop immediately when it gets the
"closed" feedback from the first side, but then on the second
side will send one extra "close" command once the limit is
reached. Why? To avoid finding that the dome is almost closed,
but with a slight gap between the shutters.

Read SerialData params for a dome from a 'serial' dict.
As with AbstractSerialMount, this modifies AbstractSerialDome to
read the serial device configuration from an entry in the pocs*.yaml
file called 'serial' inside of the 'dome' entry.

Remove the default baudrate for the dome serial device from the
code and require that it be in the config.