### PR TITLE
pocs_shell options parsing

### DIFF
--- a/bin/pocs_shell
+++ b/bin/pocs_shell
@@ -20,7 +20,7 @@ from pocs.camera import create_cameras_from_config
 from pocs.scheduler.field import Field
 from pocs.scheduler.observation import Observation
 from pocs.utils import current_time
-from pocs.utils import parse_string_to_params
+from pocs.utils import string_to_params
 from pocs.utils import error
 from pocs.utils import images as img_utils
 from pocs.utils.images import fits as fits_utils
@@ -146,7 +146,7 @@ class PocsShell(Cmd):
 
     def do_setup_pocs(self, *arg):
         """Setup and initialize a POCS instance."""
-        args, kwargs = parse_string_to_params(*arg)
+        args, kwargs = string_to_params(*arg)
 
         simulator = kwargs.get('simulator', list())
         if isinstance(simulator, str):
@@ -623,7 +623,7 @@ class DriftShell(Cmd):
 
     def do_setup_pocs(self, *arg):
         """Setup and initialize a POCS instance."""
-        args, kwargs = parse_string_to_params(*arg)
+        args, kwargs = string_to_params(*arg)
         simulator = kwargs.get('simulator', [])
         print_info("Simulator: {}".format(simulator))
 
@@ -638,7 +638,7 @@ class DriftShell(Cmd):
         if self.ready is False:
             return
 
-        args, kwargs = parse_string_to_params(*arg)
+        args, kwargs = string_to_params(*arg)
 
         try:
             direction = kwargs['direction']
@@ -680,7 +680,7 @@ class DriftShell(Cmd):
         if not self.ready:
             return
 
-        args, kwargs = parse_string_to_params(*arg)
+        args, kwargs = string_to_params(*arg)
 
         num_pics = int(kwargs.get('num_pics', self.num_pics))
         exp_time = float(kwargs.get('exp_time', self.exp_time))

--- a/bin/pocs_shell
+++ b/bin/pocs_shell
@@ -147,7 +147,11 @@ class PocsShell(Cmd):
 
     def do_setup_pocs(self, *arg):
         """Setup and initialize a POCS instance."""
-        simulator = listify(arg[0].split())
+        args, kwargs = parse_options(*arg)
+
+        simulator = kwargs.get('simulator', list())
+        if isinstance(simulator, str):
+            simulator = [simulator]
 
         # TODO(wtgee) Incorporate real power readings
         if 'power' not in simulator:
@@ -156,9 +160,6 @@ class PocsShell(Cmd):
         if 'POCSTIME' in os.environ:
             print_warning("Clearing POCSTIME variable")
             del os.environ['POCSTIME']
-
-        if simulator is None:
-            simulator = []
 
         try:
             cameras = create_cameras_from_config(simulator=simulator)
@@ -864,6 +865,38 @@ def print_error(msg):
 
 
 def parse_options(opts):
+    """Parses the options passed by the user when using the shell.
+
+    A user of the `peas_shell` can supply positional and keyword arguments to the
+    command being called, however the native structured of the `Cmd` module does
+    not parse these options but instead passes this as a single string. This utility
+    method does some simple parsing of that string and returns a list of positoinal
+    parameters and a dictonary of keyword arguments.  A keyword argument is considered
+    anything that contains an equal sign (e.g. `exptime=30`).
+
+    A list of items can be passed by specifying the keyword argument multiple times.
+
+    Note:
+        This function will attempt to parse keyword values as floats if possible.
+        If a string is required inclue a single quote around the value, e.g.
+        `param='42'` will keep the value as the string `'42'`.
+
+    Example:
+
+    .. code-block::
+
+        # Note that this is a mostly fabricated example.
+        PEAS > setup_pocs simulator=night simulator=mount num_retries=3 unit_id='001'
+
+    Args:
+        opts (str): A single string containing everything beyond the actual
+            command that is called.
+
+    Returns:
+        tuple(list, dict): Returns a list of positional parameters and a dictonary
+            of keyword arguments. These correspond to the *args and **kwargs that
+            a typical funciton would receive.
+    """
     args = []
     kwargs = {}
 

--- a/bin/pocs_shell
+++ b/bin/pocs_shell
@@ -4,7 +4,6 @@ import readline
 import time
 import zmq
 
-from contextlib import suppress
 from cmd import Cmd
 from subprocess import TimeoutExpired
 from pprint import pprint
@@ -21,12 +20,12 @@ from pocs.camera import create_cameras_from_config
 from pocs.scheduler.field import Field
 from pocs.scheduler.observation import Observation
 from pocs.utils import current_time
+from pocs.utils import parse_string_to_params
 from pocs.utils import error
 from pocs.utils import images as img_utils
 from pocs.utils.images import fits as fits_utils
 from pocs.utils.images import cr2 as cr2_utils
 from pocs.utils.images import polar_alignment as polar_alignment_utils
-from pocs.utils import listify
 from pocs.utils.database import PanDB
 from pocs.utils.messaging import PanMessaging
 
@@ -147,7 +146,7 @@ class PocsShell(Cmd):
 
     def do_setup_pocs(self, *arg):
         """Setup and initialize a POCS instance."""
-        args, kwargs = parse_options(*arg)
+        args, kwargs = parse_string_to_params(*arg)
 
         simulator = kwargs.get('simulator', list())
         if isinstance(simulator, str):
@@ -624,7 +623,7 @@ class DriftShell(Cmd):
 
     def do_setup_pocs(self, *arg):
         """Setup and initialize a POCS instance."""
-        args, kwargs = parse_options(*arg)
+        args, kwargs = parse_string_to_params(*arg)
         simulator = kwargs.get('simulator', [])
         print_info("Simulator: {}".format(simulator))
 
@@ -639,7 +638,7 @@ class DriftShell(Cmd):
         if self.ready is False:
             return
 
-        args, kwargs = parse_options(*arg)
+        args, kwargs = parse_string_to_params(*arg)
 
         try:
             direction = kwargs['direction']
@@ -681,7 +680,7 @@ class DriftShell(Cmd):
         if not self.ready:
             return
 
-        args, kwargs = parse_options(*arg)
+        args, kwargs = parse_string_to_params(*arg)
 
         num_pics = int(kwargs.get('num_pics', self.num_pics))
         exp_time = float(kwargs.get('exp_time', self.exp_time))
@@ -862,62 +861,6 @@ def print_warning(msg):
 
 def print_error(msg):
     console.color_print(msg, 'red')
-
-
-def parse_options(opts):
-    """Parses the options passed by the user when using the shell.
-
-    A user of the `peas_shell` can supply positional and keyword arguments to the
-    command being called, however the native structured of the `Cmd` module does
-    not parse these options but instead passes this as a single string. This utility
-    method does some simple parsing of that string and returns a list of positoinal
-    parameters and a dictonary of keyword arguments.  A keyword argument is considered
-    anything that contains an equal sign (e.g. `exptime=30`).
-
-    A list of items can be passed by specifying the keyword argument multiple times.
-
-    Note:
-        This function will attempt to parse keyword values as floats if possible.
-        If a string is required inclue a single quote around the value, e.g.
-        `param='42'` will keep the value as the string `'42'`.
-
-    Example:
-
-    .. code-block::
-
-        # Note that this is a mostly fabricated example.
-        PEAS > setup_pocs simulator=night simulator=mount num_retries=3 unit_id='001'
-
-    Args:
-        opts (str): A single string containing everything beyond the actual
-            command that is called.
-
-    Returns:
-        tuple(list, dict): Returns a list of positional parameters and a dictonary
-            of keyword arguments. These correspond to the *args and **kwargs that
-            a typical funciton would receive.
-    """
-    args = []
-    kwargs = {}
-
-    for opt in opts.split(' '):
-        if '=' not in opt:
-            args.append(opt)
-        else:
-            name, value = opt.split('=')
-            name = name.replace('--', '')
-
-            # Make it a number if possible.
-            with suppress(ValueError):
-                value = float(value)
-
-            if name in kwargs:
-                kwargs[name] = listify(kwargs[name])
-                kwargs[name].append(value)
-            else:
-                kwargs[name] = value
-
-    return args, kwargs
 
 
 if __name__ == '__main__':

--- a/bin/pocs_shell
+++ b/bin/pocs_shell
@@ -4,6 +4,7 @@ import readline
 import time
 import zmq
 
+from contextlib import suppress
 from cmd import Cmd
 from subprocess import TimeoutExpired
 from pprint import pprint
@@ -872,6 +873,11 @@ def parse_options(opts):
         else:
             name, value = opt.split('=')
             name = name.replace('--', '')
+
+            # Make it a number if possible.
+            with suppress(ValueError):
+                value = float(value)
+
             if name in kwargs:
                 kwargs[name] = listify(kwargs[name])
                 kwargs[name].append(value)

--- a/pocs/utils/__init__.py
+++ b/pocs/utils/__init__.py
@@ -218,7 +218,7 @@ def get_free_space(dir=None):
     return free_space
 
 
-def parse_string_to_params(opts):
+def string_to_params(opts):
     """Parses a single string into parameters that can be passed to a function.
 
     A user of the `peas_shell` can supply positional and keyword arguments to the
@@ -235,12 +235,17 @@ def parse_string_to_params(opts):
         If a string is required inclue a single quote around the value, e.g.
         `param='42'` will keep the value as the string `'42'`.
 
-    Example:
 
-    .. code-block::
-
-        # Note that this is a mostly fabricated example.
-        PEAS > setup_pocs simulator=night simulator=mount num_retries=3 unit_id='001'
+    >>> from pocs.utils import string_to_params
+    >>> args, kwargs = string_to_params("parg1 parg2 key1=a_str key2=2 key2='2' key3=03")
+    >>> args
+    (['parg1', 'parg2']
+    >>> kwargs
+    {'key1': 'a_str', 'key2': [2.0, "'2'"], 'key3': 3.0})
+    >>> isinstance(kwargs['key2'][0], float)
+    True
+    >>> isinstance(kwargs['key2'][1], str)
+    True
 
     Args:
         opts (str): A single string containing everything beyond the actual

--- a/pocs/utils/__init__.py
+++ b/pocs/utils/__init__.py
@@ -3,7 +3,6 @@ import os
 import shutil
 import signal
 import time
-import shlex
 
 from astropy import units as u
 from astropy.coordinates import AltAz
@@ -242,12 +241,14 @@ def string_to_params(opts):
     >>> from pocs.utils import string_to_params
     >>> args, kwargs = string_to_params("parg1 parg2 key1=a_str key2=2 key2='2' key3=03")
     >>> args
-    (['parg1', 'parg2']
+    ['parg1', 'parg2']
     >>> kwargs
-    {'key1': 'a_str', 'key2': [2.0, "2"], 'key3': 3.0})
+    {'key1': 'a_str', 'key2': [2.0, '2'], 'key3': 3.0}
     >>> isinstance(kwargs['key2'][0], float)
     True
     >>> isinstance(kwargs['key2'][1], str)
+    True
+    >>> kwargs['key2'][1] == '2'
     True
     >>> args, kwargs = string_to_params('--key1=val1 --key1-2=val1-2')
     >>> kwargs
@@ -265,7 +266,7 @@ def string_to_params(opts):
     args = []
     kwargs = {}
 
-    for opt in shlex.split(opts):
+    for opt in opts.split(' '):
         if '=' not in opt:
             args.append(opt)
         else:
@@ -273,13 +274,13 @@ def string_to_params(opts):
             if name.startswith('--') and len(name) > 2:
                 name = name[2:]
 
-            # if "'" in value:
-            #     # Remove the explict single quotes.
-            #     value.replace("'", "")
-            # else:
-            # Make it a number if possible.
-            with contextlib.suppress(ValueError):
-                value = float(value)
+            if "'" in value:
+                # Remove the explict single quotes.
+                value = value.replace("'", "")
+            else:
+                # Make it a number if possible.
+                with contextlib.suppress(ValueError):
+                    value = float(value)
 
             if name in kwargs:
                 kwargs[name] = listify(kwargs[name])


### PR DESCRIPTION
Convert any kwarg options to a number if possible.

This is used in #736 to pass options to the (new) `do_take_flat_fields` call, e.g.:

```
POCS > take_flat_fields target_adu_percentage=0.2 max_num_exposures=5
```