### PR TITLE
Changing the timelapse glob pattern.

### DIFF
--- a/pocs/utils/images/__init__.py
+++ b/pocs/utils/images/__init__.py
@@ -228,7 +228,7 @@ def _make_pretty_from_cr2(fname, title=None, timeout=15, **kwargs):
 def make_timelapse(
         directory,
         fn_out=None,
-        glob_pattern='201*T*.jpg',
+        glob_pattern='20[1-9][0-9]*T[0-9]*.jpg',
         overwrite=False,
         timeout=60,
         verbose=False,
@@ -242,9 +242,9 @@ def make_timelapse(
         fn_out (str, optional): Full path to output file name, if not provided,
             defaults to `directory` basename.
         glob_pattern (str, optional): A glob file pattern of images to include,
-            default '201*T*.jpg', which corresponds to the observation images but
-            excludes any pointing images. The pattern should be relative to the
-            local directory.
+            default '20[1-9][0-9]*T[0-9]*.jpg', which corresponds to the observation
+            images but excludes any pointing images. The pattern should be relative
+            to the local directory.
         overwrite (bool, optional): Overwrite timelapse if exists, default False.
         timeout (int): Timeout for making movie, default 60 seconds.
         verbose (bool, optional): Show output, default False.
@@ -256,7 +256,6 @@ def make_timelapse(
     Raises:
         error.InvalidSystemCommand: Raised if ffmpeg command is not found.
         FileExistsError: Raised if fn_out already exists and overwrite=False.
-
     """
     if fn_out is None:
         head, tail = os.path.split(directory)

--- a/pocs/utils/images/__init__.py
+++ b/pocs/utils/images/__init__.py
@@ -228,7 +228,7 @@ def _make_pretty_from_cr2(fname, title=None, timeout=15, **kwargs):
 def make_timelapse(
         directory,
         fn_out=None,
-        file_type='jpg',
+        glob_pattern='201*T*.jpg',
         overwrite=False,
         timeout=60,
         verbose=False,
@@ -241,7 +241,10 @@ def make_timelapse(
         directory (str): Directory containing image files
         fn_out (str, optional): Full path to output file name, if not provided,
             defaults to `directory` basename.
-        file_type (str, optional): Type of file to search for, default 'jpg'.
+        glob_pattern (str, optional): A glob file pattern of images to include,
+            default '201*T*.jpg', which corresponds to the observation images but
+            excludes any pointing images. The pattern should be relative to the
+            local directory.
         overwrite (bool, optional): Overwrite timelapse if exists, default False.
         timeout (int): Timeout for making movie, default 60 seconds.
         verbose (bool, optional): Show output, default False.
@@ -253,6 +256,7 @@ def make_timelapse(
     Raises:
         error.InvalidSystemCommand: Raised if ffmpeg command is not found.
         FileExistsError: Raised if fn_out already exists and overwrite=False.
+
     """
     if fn_out is None:
         head, tail = os.path.split(directory)
@@ -274,7 +278,7 @@ def make_timelapse(
     if ffmpeg is None:
         raise error.InvalidSystemCommand("ffmpeg not found, can't make timelapse")
 
-    inputs_glob = os.path.join(directory, '*.{}'.format(file_type))
+    inputs_glob = os.path.join(directory, glob_pattern)
 
     try:
         ffmpeg_cmd = [


### PR DESCRIPTION
Instead of just specifying the file type allow a full glob to be passed. By default only include things that match a timestamp, which excludes the pointing images. Closes #740