### PR TITLE
Change the default storage type to PanFileDB.

### DIFF
--- a/conf_files/pocs.yaml
+++ b/conf_files/pocs.yaml
@@ -35,7 +35,7 @@ directories:
     mounts: POCS/resources/mounts
 db: 
     name: panoptes
-    type: mongo
+    type: file
 scheduler:
     type: dispatch
     fields_file: simple.yaml

--- a/conftest.py
+++ b/conftest.py
@@ -52,7 +52,7 @@ def pytest_addoption(parser):
     group.addoption(
         "--test-databases",
         nargs="+",
-        default=['mongo'],
+        default=['file'],
         help=("Test databases in the list. List items can include: " + db_names +
               ". Note that travis-ci will test all of them by default."))
 

--- a/pocs/tests/test_database.py
+++ b/pocs/tests/test_database.py
@@ -4,14 +4,6 @@ from pocs.utils.error import InvalidCollection
 from pocs.utils.logger import get_root_logger
 
 
-def test_insert_and_get_current(db):
-    rec = {'test': 'insert'}
-    db.insert_current('config', rec)
-
-    record = db.get_current('config')
-    assert record['data']['test'] == rec['test']
-
-
 def test_insert_and_no_permanent(db):
     rec = {'test': 'insert'}
     id0 = db.insert_current('config', rec, store_permanently=False)
@@ -21,6 +13,14 @@ def test_insert_and_no_permanent(db):
 
     record = db.find('config', id0)
     assert record is None
+
+
+def test_insert_and_get_current(db):
+    rec = {'test': 'insert'}
+    db.insert_current('config', rec)
+
+    record = db.get_current('config')
+    assert record['data']['test'] == rec['test']
 
 
 def test_clear_current(db):

--- a/pocs/utils/database.py
+++ b/pocs/utils/database.py
@@ -3,6 +3,7 @@ import os
 import pymongo
 import threading
 import weakref
+from contextlib import suppress
 from warnings import warn
 from uuid import uuid4
 from glob import glob
@@ -416,12 +417,15 @@ class PanFileDB(AbstractPanDB):
         except FileNotFoundError:
             return None
 
-    def clear_current(self, type):
-        current_f = os.path.join(self._storage_dir, 'current_{}.json'.format(type))
-        try:
+    def clear_current(self, record_type):
+        """Clears the current record of the given type.
+
+        Args:
+            record_type (str): The record type, e.g. 'weather', 'environment', etc.
+        """
+        current_f = self._get_file(record_type, permanent=False)
+        with suppress(FileNotFoundError):
             os.remove(current_f)
-        except FileNotFoundError:
-            pass
 
     def _get_file(self, collection, permanent=True):
         if permanent:

--- a/pocs/utils/database.py
+++ b/pocs/utils/database.py
@@ -390,16 +390,18 @@ class PanFileDB(AbstractPanDB):
 
     def find(self, collection, obj_id):
         collection_fn = self._get_file(collection)
-        with open(collection_fn, 'r') as f:
-            for line in f:
-                # Note: We can speed this up for the case where the obj_id doesn't
-                # contain any characters that json would need to escape: first
-                # check if the line contains the obj_id; if not skip. Else, parse
-                # as json, and then check for the _id match.
-                obj = json_util.loads(line)
-                if obj['_id'] == obj_id:
-                    return obj
-        return None
+        try:
+            with open(collection_fn, 'r') as f:
+                for line in f:
+                    # Note: We can speed this up for the case where the obj_id doesn't
+                    # contain any characters that json would need to escape: first
+                    # check if the line contains the obj_id; if not skip. Else, parse
+                    # as json, and then check for the _id match.
+                    obj = json_util.loads(line)
+                    if obj['_id'] == obj_id:
+                        return obj
+        except FileNotFoundError:
+            return None
 
     def clear_current(self, type):
         current_f = os.path.join(self._storage_dir, 'current_{}.json'.format(type))


### PR DESCRIPTION
This would change the default storage type to file db.

Closes #753 

Changes included:

* If looking for a record in a file type and there has never been a record written the file will not exist. This currently raises an exception but should just return None.
* Rearrange test order so that object insert without permanent store is tested first, which adds a little to the coverage in a more natural way.
