### PR TITLE
Raise exception if `gphoto2` not found on the system.

### DIFF
--- a/pocs/camera/__init__.py
+++ b/pocs/camera/__init__.py
@@ -25,6 +25,8 @@ def list_connected_cameras():
     """
 
     gphoto2 = shutil.which('gphoto2')
+    if not gphoto2:
+        raise error.NotFound('The gphoto2 command is missing, please install.')
     command = [gphoto2, '--auto-detect']
     result = subprocess.check_output(command)
     lines = result.decode('utf-8').split('\n')

--- a/pocs/camera/__init__.py
+++ b/pocs/camera/__init__.py
@@ -25,7 +25,7 @@ def list_connected_cameras():
     """
 
     gphoto2 = shutil.which('gphoto2')
-    if not gphoto2:
+    if not gphoto2:  # pragma: no cover
         raise error.NotFound('The gphoto2 command is missing, please install.')
     command = [gphoto2, '--auto-detect']
     result = subprocess.check_output(command)


### PR DESCRIPTION
Fixes #754 

New error (this is what we want to see):

```
pocs/tests/utils/test_utils.py::test_list_connected_cameras FAILED                                                                                                                     [ 66%]

========================================================================================== FAILURES ==========================================================================================
________________________________________________________________________________ test_list_connected_cameras _________________________________________________________________________________

    def test_list_connected_cameras():
>       ports = list_connected_cameras()

pocs/tests/utils/test_utils.py:71: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    def list_connected_cameras():
        """Detect connected cameras.
    
        Uses gphoto2 to try and detect which cameras are connected. Cameras should
        be known and placed in config but this is a useful utility.
    
        Returns:
            list: A list of the ports with detected cameras.
        """
    
        gphoto2 = shutil.which('gphoto2')
        if not gphoto2:
>           raise error.NotFound('The gphoto2 command is missing, please install.')
E           pocs.utils.error.NotFound: NotFound: The gphoto2 command is missing, please install.

pocs/camera/__init__.py:29: NotFound
------------------------------------------------------------------------------------- Captured log call --------------------------------------------------------------------------------------
error.py                    16 ERROR    NotFound: The gphoto2 command is missing, please install.
============================================================================ 1 failed, 27 passed in 5.92 seconds =============================================================================
(panoptes) ➜  POCS git:(check-for-gphoto2-754) ✗ 
```