### PR TITLE
Fixing up the serial doctest.

### DIFF
--- a/pocs/utils/rs232.py
+++ b/pocs/utils/rs232.py
@@ -54,8 +54,6 @@ class SerialData(object):
 
         # Register our serial simulators
         >>> serial.protocol_handler_packages.append('pocs.tests.serial_handlers')
-
-        # Create a fake device
         >>> from pocs.tests.serial_handlers.protocol_buffers import SetRBufferValue as WriteFakeDevice
         >>> from pocs.tests.serial_handlers.protocol_buffers import GetWBufferValue as ReadFakeDevice
         >>> from pocs.tests.serial_handlers.protocol_buffers import ResetBuffers
@@ -65,6 +63,9 @@ class SerialData(object):
 
         # Connect to our fake buffered device
         >>> device_listener = SerialData(port='buffers://')
+
+        # Note: A manual reset is currently required because implementation is not complete.
+        # See https://github.com/panoptes/POCS/issues/758 for details.
         >>> ResetBuffers()
         >>> device_listener.is_connected
         True

--- a/pocs/utils/rs232.py
+++ b/pocs/utils/rs232.py
@@ -51,33 +51,38 @@ class SerialData(object):
     .. doctest::
 
         >>> import serial
+
         # Register our serial simulators
         >>> serial.protocol_handler_packages.append('pocs.tests.serial_handlers')
+
         # Create a fake device
         >>> from pocs.tests.serial_handlers.protocol_buffers import SetRBufferValue as WriteFakeDevice
-        >>> from pocs.tests.serial_handlers.protocol_buffers import GetWBuffer as ReadFakeDevice
+        >>> from pocs.tests.serial_handlers.protocol_buffers import GetWBufferValue as ReadFakeDevice
+        >>> from pocs.tests.serial_handlers.protocol_buffers import ResetBuffers
 
         # Import our serial utils
         >>> from pocs.utils.rs232 import SerialData
 
         # Connect to our fake buffered device
         >>> device_listener = SerialData(port='buffers://')
+        >>> ResetBuffers()
         >>> device_listener.is_connected
         True
 
-        >>> device.port
-        buffers://
+        >>> device_listener.port
+        'buffers://'
 
         # Device sends event
         >>> WriteFakeDevice(b'emit event')
 
         # Listen for event
         >>> device_listener.read()
-        emit event
+        'emit event'
 
-        >>> device_listener.write(b'ack event')
+        >>> device_listener.write('ack event')
+        9
         >>> ReadFakeDevice()
-        ack event
+        b'ack event'
     """
 
     def __init__(self,


### PR DESCRIPTION
I've made this separate from a more generic PR to clean up the doctests because some of this behavior confuses me so I want it to be discussed with @jamessynge.

I can't get this example to work without calling `ResetBuffers`, which seems a little odd to me. Perhaps it should be called automatically somewhere?

Also, the `device_listener.write()` will fail if given a byte-string as the underlying rs232 is calling an `encode` automatically. Could switch [`rs232.SerialData.write`](https://github.com/panoptes/POCS/blob/develop/pocs/utils/rs232.py#L211) to detect string type and skip, which would probably make it more generic.

That might make this test a little more consistent as it currently writes a normal string but returns (via `ReadFakeDevice`) a byte-string.