### PR TITLE
Keep CR2 files by default

### DIFF
--- a/pocs/camera/canon_gphoto2.py
+++ b/pocs/camera/canon_gphoto2.py
@@ -164,7 +164,7 @@ class Camera(AbstractGPhotoCamera):
         Converts the CR2 to a FITS file
         """
         self.logger.debug("Converting CR2 -> FITS: {}".format(file_path))
-        fits_path = cr2_utils.cr2_to_fits(file_path, headers=info, remove_cr2=True)
+        fits_path = cr2_utils.cr2_to_fits(file_path, headers=info, remove_cr2=False)
         # Replace the path name with the FITS file
         info['file_path'] = fits_path
         return fits_path


### PR DESCRIPTION
For now we want to keep the CR2 files and have them uploaded to the bucket. This will require some different management and perhaps a different bucket, but this is a good initial step to start saving the images.