### PR TITLE
Support max_nexp

### DIFF
--- a/pocs/scheduler/observation.py
+++ b/pocs/scheduler/observation.py
@@ -10,7 +10,7 @@ class Observation(PanBase):
 
     @u.quantity_input(exp_time=u.second)
     def __init__(self, field, exp_time=120 * u.second, min_nexp=60, max_nexp=None,
-                 exp_set_size=10, priority=100, **kwargs):
+                 exp_set_size=1, priority=100, **kwargs):
         """An observation of a given `~pocs.scheduler.field.Field`.
 
         An observation consists of a minimum number of exposures (`min_nexp`) that
@@ -35,9 +35,9 @@ class Observation(PanBase):
             max_nexp (int, optional): The maxiumum number of exposures to take,
                 default `None`, which will dwell on the field as long as possible.
                 See also the note in the docstring.
-            exp_set_size (int, optional): Number of exposures taken per set, default 10.
+            exp_set_size (int, optional): Number of exposures taken per set, default 1,
+                which will match any block size.
             priority (int, optional): The priority of the target, default 100.
-            **kwargs: Description
         """
         PanBase.__init__(self)
 
@@ -233,7 +233,7 @@ class Observation(PanBase):
 ##################################################################################################
 
     def __str__(self):
-        str_repr = "{}: {} exposures in blocks of {}, min/max {}/{}, priority {:.0f}".format(
+        str_repr = "{}: {} exposures in blocks of {}, min/max={}/{}, priority={:.0f}".format(
             self.field.name,
             self.exp_time,
             self.exp_set_size,

--- a/pocs/state/states/default/analyzing.py
+++ b/pocs/state/states/default/analyzing.py
@@ -15,6 +15,10 @@ def on_enter(event_data):
             pocs.say("Forcing a move to the scheduler")
             pocs.next_state = 'scheduling'
 
+        # Check for maximum number of exposures
+        if observation.current_exp_num == observation.max_nexp:
+            pocs.logger.info('Maximum number of exposures reached, rescheduling')
+
         # Check for minimum number of exposures
         if observation.current_exp_num >= observation.min_nexp:
             # Check if we have completed an exposure block

--- a/pocs/tests/test_dispatch_scheduler.py
+++ b/pocs/tests/test_dispatch_scheduler.py
@@ -69,6 +69,7 @@ def field_list():
         name: Wasp 33
         position: 02h26m51.0582s +37d33m01.733s
         priority: 100
+        exp_set_size: 10
     -
         name: M42
         position: 05h35m17.2992s -05d23m27.996s

--- a/pocs/tests/test_observation.py
+++ b/pocs/tests/test_observation.py
@@ -54,7 +54,7 @@ def test_bad_min_set_combo(field):
     with pytest.raises(AssertionError):
         Observation(field, exp_set_size=7)
     with pytest.raises(AssertionError):
-        Observation(field, min_nexp=57)
+        Observation(field, min_nexp=57, exp_set_size=10)
 
 
 def test_small_sets(field):
@@ -84,19 +84,18 @@ def test_min_max_nexp(field):
     assert obs.max_nexp == 10
 
 
-def test_default_min_duration(field):
+def test_default_durations(field):
     obs = Observation(field)
+    # Each set lasts (default one exp at 120s):
+    assert obs.set_duration == 120 * u.second
+
+    # Total with default minimum lasts:
     assert obs.minimum_duration == 7200 * u.second
-
-
-def test_default_set_duration(field):
-    obs = Observation(field)
-    assert obs.set_duration == 1200 * u.second
 
 
 def test_print(field):
     obs = Observation(field, exp_time=17.5 * u.second, min_nexp=27, exp_set_size=9)
-    str_repr = "Test Observation: 17.5 s exposures in blocks of 9, min/max 27/None, priority 100"
+    str_repr = "Test Observation: 17.5 s exposures in blocks of 9, min/max=27/None, priority=100"
     assert str(obs) == str_repr
 
 

--- a/pocs/tests/test_observation.py
+++ b/pocs/tests/test_observation.py
@@ -68,6 +68,22 @@ def test_good_min_set_combo(field):
     assert isinstance(obs, Observation)
 
 
+def test_min_max_nexp(field):
+    # Test with neither
+    obs = Observation(field)
+    assert obs.min_nexp == 60
+    assert obs.max_nexp is None
+
+    # Test with min_nexp == max_nexp
+    obs = Observation(field, min_nexp=10, max_nexp=10)
+    assert obs.min_nexp == obs.max_nexp
+
+    # Test with min_nexp > max_nexp
+    obs = Observation(field, max_nexp=10)
+    assert obs.min_nexp == 10
+    assert obs.max_nexp == 10
+
+
 def test_default_min_duration(field):
     obs = Observation(field)
     assert obs.minimum_duration == 7200 * u.second
@@ -80,7 +96,8 @@ def test_default_set_duration(field):
 
 def test_print(field):
     obs = Observation(field, exp_time=17.5 * u.second, min_nexp=27, exp_set_size=9)
-    assert str(obs) == "Test Observation: 17.5 s exposures in blocks of 9, minimum 27, priority 100"
+    str_repr = "Test Observation: 17.5 s exposures in blocks of 9, min/max 27/None, priority 100"
+    assert str(obs) == str_repr
 
 
 def test_seq_time(field):

--- a/pocs/tests/test_pocs.py
+++ b/pocs/tests/test_pocs.py
@@ -269,8 +269,7 @@ def test_run_wait_until_safe(observatory, cmd_publisher, msg_subscriber):
                                                     'position': '20h06m15.4536s +44d27m24.75s',
                                                     'priority': '100',
                                                     'exp_time': 2,
-                                                    'min_nexp': 2,
-                                                    'exp_set_size': 2,
+                                                    'max_nexp': 2,
                                                     })
 
         pocs.initialize()
@@ -407,8 +406,7 @@ def test_run_complete(pocs):
                                                         'position': '20h06m15.4536s +44d27m24.75s',
                                                         'priority': '100',
                                                         'exp_time': 2,
-                                                        'min_nexp': 2,
-                                                        'exp_set_size': 2,
+                                                        'max_nexp': 2,
                                                 })
 
     pocs.initialize()
@@ -431,8 +429,7 @@ def test_run_power_down_interrupt(observatory, cmd_publisher, msg_subscriber):
                                                     'position': '20h06m15.4536s +44d27m24.75s',
                                                     'priority': '100',
                                                     'exp_time': 2,
-                                                    'min_nexp': 2,
-                                                    'exp_set_size': 2,
+                                                    'max_nexp': 2,
                                                     })
         pocs.logger.info('Starting observatory run')
         pocs.run()

--- a/resources/targets/simulator.yaml
+++ b/resources/targets/simulator.yaml
@@ -3,5 +3,4 @@
     position: 02h26m51.0582s +37d33m01.733s
     priority: 100
     exp_time: 2
-    min_nexp: 2
-    exp_set_size: 2
+    max_nexp: 2


### PR DESCRIPTION
Add the ability to limit the maximum number of exposures taken during an observation. Note that this does not prevent the Observation from being rescheduled.

**Behavior Change** This changes the default `exp_set_size=1` so that essentially any combination of exposures is allowed by default.

Closes #749.