### PR TITLE
Add support for filter wheels

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -14,4 +14,5 @@ ignore:
   - "pocs/mount/ioptron.py"
   - "pocs/focuser/birger.py"
   - "pocs/focuser/focuslynx.py"
+  - "pocs/filterwheel/sbig.py"
   - "peas/weather.py"

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -412,9 +412,9 @@ class AbstractCamera(PanBase):
         header.set('CAM-MOD', self.model, 'Camera model')
 
         if self.focuser:
-            header = self.focuser._fits_header(header)
+            header = self.focuser._add_fits_keywords(header)
         if self.filterwheel:
-            header = self.filterwheel._fits_header(header)
+            header = self.filterwheel._add_fits_keywords(header)
 
         return header
 

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -522,8 +522,8 @@ class AbstractCamera(PanBase):
             else:
                 # Should have been passed either a instance of base_class or dict with subcomponent
                 # configuration. Got something else...
-                self.logger.error(
-                    "Expected either a {} instance or dict, got {}".format(class_name, focuser))
+                self.logger.error("Expected either a {} instance or dict, got {}".format(
+                    class_name, subcomponent))
                 setattr(self, name, None)
         else:
             setattr(self, name, None)

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -61,14 +61,14 @@ class AbstractCamera(PanBase):
         self._file_extension = kwargs.get('file_extension', 'fits')
         self._current_observation = None
 
-        self._create_submodule(subcomponent=focuser,
-                               name='focuser',
-                               class_name='Focuser',
-                               base_class=AbstractFocuser)
-        self._create_submodule(subcomponent=filter_wheel,
-                               name='filterwheel',
-                               class_name='FilterWheel',
-                               base_class=AbstractFilterWheel)
+        self._create_subcomponent(subcomponent=focuser,
+                                  name='focuser',
+                                  class_name='Focuser',
+                                  base_class=AbstractFocuser)
+        self._create_subcomponent(subcomponent=filterwheel,
+                                  name='filterwheel',
+                                  class_name='FilterWheel',
+                                  base_class=AbstractFilterWheel)
 
         self.logger.debug('Camera created: {}'.format(name))
 

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -62,11 +62,11 @@ class AbstractCamera(PanBase):
         self._current_observation = None
 
         self._create_subcomponent(subcomponent=focuser,
-                                  name='focuser',
+                                  sub_name='focuser',
                                   class_name='Focuser',
                                   base_class=AbstractFocuser)
         self._create_subcomponent(subcomponent=filterwheel,
-                                  name='filterwheel',
+                                  sub_name='filterwheel',
                                   class_name='FilterWheel',
                                   base_class=AbstractFilterWheel)
 
@@ -512,7 +512,7 @@ class AbstractCamera(PanBase):
                 subcomponent, e.g. `pocs.focuser`
             class_name (str): name of the subcomponent class, e.g. 'Focuser'
             base_class (class): the base class for the subcomponent, e.g.
-                `pocs.focuser.AbtractFocuser1, used to check whether subcomponent is an instance.
+                `pocs.focuser.AbtractFocuser`, used to check whether subcomponent is an instance.
         """
         if subcomponent:
             if isinstance(subcomponent, base_class):

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -70,7 +70,7 @@ class AbstractCamera(PanBase):
                                   class_name='FilterWheel',
                                   base_class=AbstractFilterWheel)
 
-        self.logger.debug('Camera created: {}'.format(name))
+        self.logger.debug('Camera created: {}'.format(self))
 
 ##################################################################################################
 # Properties
@@ -535,8 +535,12 @@ class AbstractCamera(PanBase):
 
         s = "{} ({}) on {}".format(name, self.uid, self.port)
 
-        if hasattr(self, 'focuser') and self.focuser is not None:
+        if self.focuser:
             s += ' with {}'.format(self.focuser.name)
+            if self.filterwheel:
+                s += ' & {}'.format(self.filterwheel.name)
+        elif self.filterwheel:
+            s += ' with {}'.format(self.filterwheel.name)
 
         return s
 

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -53,7 +53,7 @@ class AbstractCamera(PanBase):
         self.is_primary = primary
         self.properties = None
 
-        self.filter_type = kwargs.get('filter_type', 'RGGB')
+        self._filter_type = kwargs.get('filter_type', 'RGGB')
 
         self._connected = False
         self._serial_number = kwargs.get('serial_number', 'XXXXXX')
@@ -158,6 +158,14 @@ class AbstractCamera(PanBase):
         not for those that don't (e.g. DSLRs).
         """
         raise NotImplementedError
+
+    @property
+    def filter_type(self):
+        """ Image sensor filter type (e.g. 'RGGB') or name of the current filter (e.g. 'g2_3') """
+        if self.filterwheel:
+            return self.filterwheel.current_filter
+        else:
+            return self._filter_type
 
 ##################################################################################################
 # Methods
@@ -402,6 +410,11 @@ class AbstractCamera(PanBase):
         header.set('CAM-ID', self.uid, 'Camera serial number')
         header.set('CAM-NAME', self.name, 'Camera name')
         header.set('CAM-MOD', self.model, 'Camera model')
+
+        if self.focuser:
+            header = self.focuser._fits_header(header)
+        if self.filterwheel:
+            header = self.filterwheel._fits_header(header)
 
         return header
 

--- a/pocs/camera/fli.py
+++ b/pocs/camera/fli.py
@@ -305,9 +305,6 @@ class Camera(AbstractCamera):
         header.set('XPIXSZ', self._info['pixel width'].value, 'Microns')
         header.set('YPIXSZ', self._info['pixel height'].value, 'Microns')
 
-        if self.focuser:
-            header = self.focuser._fits_header(header)
-
         return header
 
     def _get_camera_info(self):

--- a/pocs/camera/sbig.py
+++ b/pocs/camera/sbig.py
@@ -29,9 +29,9 @@ class Camera(AbstractCamera):
         super().__init__(name, *args, **kwargs)
         self.connect()
         if filter_type is not None:
-            # connect() will set this based on camera info, but that doesn't know about filters
-            # upstream of the CCD.
-            self.filter_type = filter_type
+            # connect() will have set this based on camera info, but that doesn't know about filters
+            # upstream of the CCD. Can be set manually here, or handled by a filterwheel attribute.
+            self._filter_type = filter_type
         if self.is_connected:
             # Set and enable cooling, if a set point has been given.
             if set_point is not None:
@@ -133,11 +133,11 @@ class Camera(AbstractCamera):
 
         if self._info['colour']:
             if self._info['Truesense']:
-                self.filter_type = 'CRGB'
+                self._filter_type = 'CRGB'
             else:
-                self.filter_type = 'RGGB'
+                self._filter_type = 'RGGB'
         else:
-            self.filter_type = 'M'
+            self._filter_type = 'M'
 
     def take_exposure(self,
                       seconds=1.0 * u.second,
@@ -192,8 +192,5 @@ class Camera(AbstractCamera):
                    'Microns')
         header.set('EGAIN', self._info['readout modes'][readout_mode]['gain'].value,
                    'Electrons/ADU')
-
-        if self.focuser:
-            header = self.focuser._fits_header(header)
 
         return header

--- a/pocs/camera/sbigudrv.py
+++ b/pocs/camera/sbigudrv.py
@@ -318,6 +318,18 @@ class SBIGDriver(PanBase):
 
         return readout_thread
 
+    def cfw_init(self, handle):
+        """
+        Initialise colour filter wheel
+
+        Sends the initialise command to the colour filter wheel attached to the camera
+        specified with handle. This will generally not be required because all SBIG filter
+        wheels initialise themselves on power up.
+        """
+        with self._command_lock:
+            self._set_handle(handle)
+            self._send_command('CC_CFW', cfw_init_params, cfw_init_results)
+
 # Private methods
 
     def _readout(self, handle, centiseconds, filename, readout_mode_code,
@@ -596,6 +608,14 @@ class SBIGDriver(PanBase):
         # there are likely to be situations where other return codes don't
         # necessarily indicate a fatal error.
         if error != 'CE_NO_ERROR':
+            if error = 'CE_CFW_ERROR':
+                cfw_error_code = results.cfwError
+                try:
+                    error = "CFW {}".format(CFWError(cfw_error_code).name)
+                except ValueError:
+                    raise RunTImeError("SBIG Driver return unknown CFW error code '{}'".format(
+                        cfw_error_code))
+
             raise RuntimeError("SBIG Driver returned error '{}'!".format(error))
 
         return error

--- a/pocs/camera/sbigudrv.py
+++ b/pocs/camera/sbigudrv.py
@@ -636,7 +636,10 @@ command_codes = {'CC_NULL': 0,
                  'CC_CUSTOMER_OPTIONS': 55,
                  'CC_DEBUG_LOG': 56,
                  'CC_QUERY_USB2': 57,
-                 'CC_QUERY_ETHERNET2': 58}
+                 'CC_QUERY_ETHERNET2': 58,
+                 'CC_GET_AO_MODEL': 59,
+                 'CC_QUERY_USB3': 60,
+                 'CC_QUERY_COMMAND_STATUS2': 61}
 
 # Reversed dictionary, just in case you ever need to look up a command given a
 # command code.
@@ -685,7 +688,9 @@ errors = {0: 'CE_NO_ERROR',
           38: 'CE_DIFF_GUIDER_ERROR',
           39: 'CE_RIPPLE_CORRECTION_ERROR',
           40: 'CE_EZUSB_RESET',
-          41: 'CE_NEXT_ERROR'}
+          41: 'CE_INCOMPATIBLE_FIRMWARE',
+          42: 'CE_INVALID_HANDLE',
+          43: 'CE_NEXT_ERROR'}
 
 # Reverse dictionary, just in case you ever need to look up an error code given
 # an error name

--- a/pocs/camera/sbigudrv.py
+++ b/pocs/camera/sbigudrv.py
@@ -499,7 +499,7 @@ class SBIGDriver(PanBase):
         try:
             query = self.cfw_query(handle, model)
             while query['status'] == 'BUSY':
-                if timer.expired:
+                if timer.expired():
                     msg = "Timeout waiting for filter wheel on {} move to {} to complete".format(
                         self._ccd_info[handle]['serial number'], position)
                     raise error.Timeout(msg)
@@ -553,8 +553,8 @@ class SBIGDriver(PanBase):
         Returns:
             CFWResults: ctypes Structure containing results of the command
         """
-        cfw_params = CFWParams(CFWSelect[model], *args)
-        cfw_results = CFWResuls()
+        cfw_params = CFWParams(CFWModelSelect[model], *args)
+        cfw_results = CFWResults()
         with self._command_lock:
             self._set_handle(handle)
             self._send_command('CC_CFW', cfw_params, cfw_results)

--- a/pocs/camera/sbigudrv.py
+++ b/pocs/camera/sbigudrv.py
@@ -314,8 +314,7 @@ class SBIGDriver(PanBase):
                         header, exposure_event)
         readout_thread = threading.Timer(interval=wait,
                                          function=self._readout,
-                                         args=readout_args,
-                                         daemon=True)
+                                         args=readout_args)
         readout_thread.start()
 
         return readout_thread

--- a/pocs/camera/sbigudrv.py
+++ b/pocs/camera/sbigudrv.py
@@ -490,20 +490,24 @@ class SBIGDriver(PanBase):
 
     def _disable_vdd_optimized(self, handle):
         """
-        There are many driver control parameters, almost all of which we would not want to change from their default
-        values. The one exception is DCP_VDD_OPTIMIZED. From the SBIG manual:
+        There are many driver control parameters, almost all of which we would not want to change
+        from their default values. The one exception is DCP_VDD_OPTIMIZED. From the SBIG manual:
 
-            The DCP_VDD_OPTIMIZED parameter defaults to TRUE which lowers the CCD’s Vdd (which reduces amplifier glow)
-            only for images 3 seconds and longer. This was done to increase the image throughput for short exposures as
-            raising and lowering Vdd takes 100s of milliseconds. The lowering and subsequent raising of Vdd delays the
-            image readout slightly which causes short exposures to have a different bias structure than long exposures.
-            Setting this parameter to FALSE stops the short exposure optimization from occurring.
+            The DCP_VDD_OPTIMIZED parameter defaults to TRUE which lowers the CCD’s Vdd (which
+            reduces amplifier glow) only for images 3 seconds and longer. This was done to increase
+            the image throughput for short exposures as raising and lowering Vdd takes 100s of
+            milliseconds. The lowering and subsequent raising of Vdd delays the image readout
+            slightly which causes short exposures to have a different bias structure than long
+            exposures. Setting this parameter to FALSE stops the short exposure optimization from
+            occurring.
 
-        The default behaviour will improve image throughput for exposure times of 3 seconds or less but at the penalty
-        of altering the bias structure between short and long exposures. This could cause systematic errors in bias
-        frames, dark current measurements, etc. It's probably not worth it.
+        The default behaviour will improve image throughput for exposure times of 3 seconds or less
+        but at the penalty of altering the bias structure between short and long exposures. This
+        could cause systematic errors in bias frames, dark current measurements, etc. It's probably
+        not worth it.
         """
-        set_driver_control_params = SetDriverControlParams(driver_control_codes['DCP_VDD_OPTIMIZED'], 0)
+        set_driver_control_params = SetDriverControlParams(
+            driver_control_codes['DCP_VDD_OPTIMIZED'], 0)
         self.logger.debug('Disabling DCP_VDD_OPTIMIZE on {}'.format(handle))
         with self._command_lock:
             self._set_handle(handle)
@@ -775,7 +779,23 @@ device_types = {0: "DEV_NONE",
                 0x7F06: "DEV_USB5",
                 0x7F07: "DEV_USB6",
                 0x7F08: "DEV_USB7",
-                0x7F09: "DEV_USB8"}
+                0x7F09: "DEV_USB8",
+                0x7F0A: "DEV_USB9",
+                0x7F0B: "DEV_USB10",
+                0x7F0C: "DEV_USB11",
+                0x7F0D: "DEV_USB12",
+                0x7F0E: "DEV_USB13",
+                0x7F0F: "DEV_USB14",
+                0x7F10: "DEV_USB15",
+                0x7F11: "DEV_USB16",
+                0x7F12: "DEV_USB17",
+                0x7F13: "DEV_USB18",
+                0x7F14: "DEV_USB19",
+                0x7F15: "DEV_USB20",
+                0x7F16: "DEV_USB21",
+                0x7F19: "DEV_USB22",
+                0x7F1A: "DEV_USB23",
+                0x7F1B: "DEV_USB24"}
 
 # Reverse dictionary
 device_type_codes = {device: code for code, device in device_types.items()}
@@ -1053,6 +1073,9 @@ driver_control_params = {i: param for i, param in enumerate(('DCP_USB_FIFO_ENABL
                                                              'DCP_COLUMN_REPAIR_ENABLE',
                                                              'DCP_WARM_PIXEL_REPAIR_ENABLE',
                                                              'DCP_WARM_PIXEL_REPAIR_COUNT',
+                                                             'DCP_TDI_MODE_DRIFT_RATE',
+                                                             'DCP_OVERRIDE_AD_GAIN',
+                                                             'DCP_ENABLE_AUTO_OFFSET',
                                                              'DCP_LAST'))}
 
 driver_control_codes = {param: code for code, param in driver_control_params.items()}

--- a/pocs/filterwheel/__init__.py
+++ b/pocs/filterwheel/__init__.py
@@ -1,0 +1,1 @@
+from pocs.filterwheel.filterwheel import AbstractFilterWheel  # pragma: no flakes

--- a/pocs/filterwheel/filterwheel.py
+++ b/pocs/filterwheel/filterwheel.py
@@ -1,4 +1,5 @@
 from pocs.base import PanBase
+from pocs.utils import listify
 
 
 class AbstractFilterWheel(PanBase):
@@ -8,7 +9,7 @@ class AbstractFilterWheel(PanBase):
     Args:
         name (str, optional): name of the filter wheel
         model (str, optional): model of the filter wheel
-        camera (pocs.camera.Camera, optional): camera that this filter wheel is associated with.
+        camera (pocs.camera.*.Camera, optional): camera that this filter wheel is associated with.
         filter_names (list of str): names of the filters installed at each filter wheel position
     """
     def __init__(self,
@@ -21,9 +22,13 @@ class AbstractFilterWheel(PanBase):
 
         self._model = model
         self._name = name
-        self.camera = camera
-        self._filter_names = filter_names
-
+        self._camera = camera
+        self._filter_names = listify(filter_names)
+        if not self._filter_names:
+            # Empty list
+            msg = "Must provide list of filter names"
+            self.logger.error(msg)
+            raise ValueError(msg)
         self._n_positions = len(filter_names)
         self._connected = False
         self._serial_number = 'XXXXXX'
@@ -169,4 +174,7 @@ class AbstractFilterWheel(PanBase):
         return header
 
     def __str__(self):
-        return "{} ({})".format(self.name, self.uid)
+        if self.camera:
+            return "{} ({}) on {}".format(self.name, self.uid, self.camera.uid)
+        else:
+            return "{} ({})".format(self.name, self.uid)

--- a/pocs/filterwheel/filterwheel.py
+++ b/pocs/filterwheel/filterwheel.py
@@ -112,6 +112,10 @@ class AbstractFilterWheel(PanBase):
 # Methods
 ##################################################################################################
 
+    def connect(self):
+        """ Connect to filter wheel """
+        raise NotImplementError
+
     def move_to(self, position, blocking=False):
         """
         Move the filter wheel to the given position.

--- a/pocs/filterwheel/filterwheel.py
+++ b/pocs/filterwheel/filterwheel.py
@@ -166,7 +166,6 @@ class AbstractFilterWheel(PanBase):
         header.set('FW-MOD', self.model, 'Filter wheel model')
         header.set('FW-ID', self.uid, 'Filter wheel serial number')
         header.set('FW-POS', self.position, 'Filter wheel position')
-        header.set('FILTER', self.current_filter, 'Filter name')
         return header
 
     def __str__(self):

--- a/pocs/filterwheel/filterwheel.py
+++ b/pocs/filterwheel/filterwheel.py
@@ -1,5 +1,6 @@
 from pocs.base import PanBase
 
+
 class AbstractFilterWheel(PanBase):
     """
     Base class for all filter wheels
@@ -24,9 +25,29 @@ class AbstractFilterWheel(PanBase):
         self._connected = False
         self._serial_number = 'XXXXXX'
 
+        self.logger.debug('Filter wheel created: {} on {}'.format(self.name, self.port))
+
+##################################################################################################
+# Properties
+##################################################################################################
+
+
+@property
+def uid(self):
+    """ A serial number of the filter wheel """
+    return self._serial_number
+
+
+@property
+def is_connected(self):
+    """ Is the filterwheel available """
+    return self._connected
+
+
 ##################################################################################################
 # Methods
 ##################################################################################################
+
 
 def go_to(self, position):
     """
@@ -40,7 +61,7 @@ def _fits_header(self, header):
     header.set('FW-MOD', self.model, 'Filter wheel model')
     header.set('FW-ID', self.uid, 'Filter wheel serial number')
     header.set('FW-POS', self.position, 'Filter wheel position')
-    header.set('FILTER', self.filter_names[self.position], 'Filter name')
+    header.set('FILTER', self.filter_name, 'Filter name')
     return header
 
 

--- a/pocs/filterwheel/filterwheel.py
+++ b/pocs/filterwheel/filterwheel.py
@@ -6,64 +6,114 @@ class AbstractFilterWheel(PanBase):
     Base class for all filter wheels
 
     Args:
-        name (str, optional): name of the focuser
-        model (str, optional): model of the focuser
+        name (str, optional): name of the filter wheel
+        model (str, optional): model of the filter wheel
         camera (pocs.camera.Camera, optional): camera that this filter wheel is associated with.
         filter_names (list of str): names of the filters installed at each filter wheel position
     """
     def __init__(self,
-                 name='Generic Filterwheel',
+                 name='Generic Filter Wheel',
                  model='simulator',
                  camera=None,
                  filter_names=None,
                  *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.model = model
-        self.name = name
+        self._model = model
+        self._name = name
+        self._camera = camera
+        self._filter_names = filter_names
 
+        self._n_positions = len(filter_names)
         self._connected = False
         self._serial_number = 'XXXXXX'
 
-        self.logger.debug('Filter wheel created: {} on {}'.format(self.name, self.port))
+        self.logger.debug('Filter wheel created: {}'.format(self))
 
 ##################################################################################################
 # Properties
 ##################################################################################################
 
+    @property
+    def model(self):
+        """ Model of the filter wheel """
+        return self._model
 
-@property
-def uid(self):
-    """ A serial number of the filter wheel """
-    return self._serial_number
+    @property
+    def name(self):
+        """ Name of the filter wheel """
+        return self._name
 
+    @property
+    def uid(self):
+        """ A serial number of the filter wheel """
+        return self._serial_number
 
-@property
-def is_connected(self):
-    """ Is the filterwheel available """
-    return self._connected
+    @property
+    def is_connected(self):
+        """ Is the filterwheel available """
+        return self._connected
 
+    @property
+    def camera(self):
+        """
+        Reference to the Camera object that the Focuser is assigned to, if any. A Focuser
+        should only ever be assigned to one or zero Cameras!
+        """
+        return self._camera
+
+    @camera.setter
+    def camera(self, camera):
+        if self._camera:
+            self.logger.warning("{} assigned to {}, skipping attempted assignment to {}!",
+                                self, self.camera, camera)
+        else:
+            self._camera = camera
+
+    @property
+    def filter_names(self):
+        """ List of the names of the filters installed in the filter wheel """
+        return self._filter_names
+
+    @property
+    def n_positions(self):
+        """ Number of positions in the filter wheel """
+        return self._n_positions
 
 ##################################################################################################
 # Methods
 ##################################################################################################
 
+    def move_to(self, position, blocking=False):
+        """
+        Move the filter wheel to the given position.
 
-def go_to(self, position):
-    """
+        The position can be expressed either as an integer, or as (part of) one of the names from
+        the filter_names list. To allow filter names of the form '<filter band>_<serial number>'
+        to be selected by band only position can be a substring from the start of one
+        of the names in the filter_names list, provided that this produces only one match.
 
-    """
-    raise NotImplementedError
+        Args:
+            position (int or str): position to move to.
+            blocking (bool, optional): If False (default) return immediately, if True block until
+                the filter wheel move has been completed.
 
+        Returns:
+            threading.Event: Event that will be set to signal when the move has completed
+        """
+        raise NotImplementedError
 
-def _fits_header(self, header):
-    header.set('FW-NAME', self.name, 'Filter wheel name')
-    header.set('FW-MOD', self.model, 'Filter wheel model')
-    header.set('FW-ID', self.uid, 'Filter wheel serial number')
-    header.set('FW-POS', self.position, 'Filter wheel position')
-    header.set('FILTER', self.filter_name, 'Filter name')
-    return header
+##################################################################################################
+# Private methods
+##################################################################################################
 
+    def _fits_header(self, header):
+        header.set('FW-NAME', self.name, 'Filter wheel name')
+        header.set('FW-MOD', self.model, 'Filter wheel model')
+        header.set('FW-ID', self.uid, 'Filter wheel serial number')
+        header.set('FW-POS', self.position, 'Filter wheel position')
+        header.set('FILTER', self.filter_name, 'Filter name')
+        return header
 
-def __str__(self):
-    return "{} ({}) on {}".format(self.name, self.uid, self.port)
+    def __str__(self):
+        return "{} ({})".format(self.name, self.uid)

--- a/pocs/filterwheel/filterwheel.py
+++ b/pocs/filterwheel/filterwheel.py
@@ -98,7 +98,7 @@ class AbstractFilterWheel(PanBase):
     def current_filter(self):
         """ Name of the filter in the current position """
         try:
-            filter_name = self.filter_names[self.position + 1]  # 1 based numbering
+            filter_name = self.filter_names[self.position - 1]  # 1 based numbering
         except (IndexError, TypeError):
             # Some filter wheels sometimes cannot return their current position
             filter_name = "UNKNOWN"
@@ -150,7 +150,7 @@ class AbstractFilterWheel(PanBase):
         int_position = None
         if isinstance(position, str):
             # Got a string, so search for a match in the filter names list
-            for i, filter_name in enumerate(filter_names):
+            for i, filter_name in enumerate(self.filter_names):
                 if filter_name.startswith(position):
                     int_position = i + 1  # 1 based numbering for filter wheel positions
 

--- a/pocs/filterwheel/filterwheel.py
+++ b/pocs/filterwheel/filterwheel.py
@@ -1,4 +1,3 @@
-from pocs.camera import AbstractCamera
 from pocs.base import PanBase
 
 
@@ -65,10 +64,6 @@ class AbstractFilterWheel(PanBase):
 
     @camera.setter
     def camera(self, camera):
-        if not isinstance(camera, AbstractCamera):
-            msg = "Camera must be an instance of pocs.camera.AbstractCamera, got {}".format(camera)
-            self.logger.error(msg)
-            raise ValueError(msg)
         if self._camera:
             self.logger.warning("{} assigned to {}, skipping attempted assignment to {}!",
                                 self, self.camera, camera)
@@ -99,7 +94,7 @@ class AbstractFilterWheel(PanBase):
         """ Name of the filter in the current position """
         try:
             filter_name = self.filter_names[self.position + 1]  # 1 based numbering
-        except IndexError, TypeError:
+        except (IndexError, TypeError):
             # Some filter wheels sometimes cannot return their current position
             filter_name = "UNKNOWN"
         return filter_name
@@ -171,7 +166,7 @@ class AbstractFilterWheel(PanBase):
         header.set('FW-MOD', self.model, 'Filter wheel model')
         header.set('FW-ID', self.uid, 'Filter wheel serial number')
         header.set('FW-POS', self.position, 'Filter wheel position')
-        header.set('FILTER', self.filter_name, 'Filter name')
+        header.set('FILTER', self.current_filter, 'Filter name')
         return header
 
     def __str__(self):

--- a/pocs/filterwheel/filterwheel.py
+++ b/pocs/filterwheel/filterwheel.py
@@ -85,6 +85,29 @@ class AbstractFilterWheel(PanBase):
         """ Number of positions in the filter wheel """
         return self._n_positions
 
+    @property
+    def position(self):
+        """ Current integer position of the filter wheel """
+        raise NotImplementedError
+
+    @position.setter
+    def position(self, position):
+        self.move_to(position, blocking=True)
+
+    @property
+    def current_filter(self):
+        """ Name of the filter in the current position """
+        try:
+            filter_name = self.filter_names[self.position + 1]  # 1 based numbering
+        except IndexError, TypeError:
+            # Some filter wheels sometimes cannot return their current position
+            filter_name = "UNKNOWN"
+        return filter_name
+
+    @current_filter.setter
+    def current_filter(self, filter_name):
+        self.move_to(filter_name, blocking=True)
+
 ##################################################################################################
 # Methods
 ##################################################################################################

--- a/pocs/filterwheel/filterwheel.py
+++ b/pocs/filterwheel/filterwheel.py
@@ -1,0 +1,48 @@
+from pocs.base import PanBase
+
+class AbstractFilterWheel(PanBase):
+    """
+    Base class for all filter wheels
+
+    Args:
+        name (str, optional): name of the focuser
+        model (str, optional): model of the focuser
+        camera (pocs.camera.Camera, optional): camera that this filter wheel is associated with.
+        filter_names (list of str): names of the filters installed at each filter wheel position
+    """
+    def __init__(self,
+                 name='Generic Filterwheel',
+                 model='simulator',
+                 camera=None,
+                 filter_names=None,
+                 *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.model = model
+        self.name = name
+
+        self._connected = False
+        self._serial_number = 'XXXXXX'
+
+##################################################################################################
+# Methods
+##################################################################################################
+
+def go_to(self, position):
+    """
+
+    """
+    raise NotImplementedError
+
+
+def _fits_header(self, header):
+    header.set('FW-NAME', self.name, 'Filter wheel name')
+    header.set('FW-MOD', self.model, 'Filter wheel model')
+    header.set('FW-ID', self.uid, 'Filter wheel serial number')
+    header.set('FW-POS', self.position, 'Filter wheel position')
+    header.set('FILTER', self.filter_names[self.position], 'Filter name')
+    return header
+
+
+def __str__(self):
+    return "{} ({}) on {}".format(self.name, self.uid, self.port)

--- a/pocs/filterwheel/filterwheel.py
+++ b/pocs/filterwheel/filterwheel.py
@@ -146,6 +146,17 @@ class AbstractFilterWheel(PanBase):
 
         Returns:
             threading.Event: Event that will be set to signal when the move has completed
+
+        Examples:
+            Substring matching is useful when the filter names contain both the type of filter
+            and a serial number, e.g. the following selects a g band filter without having to
+            know its full name.
+
+            >>> fw = FilterWheel(filter_names=['u_12', 'g_04', 'r_09', 'i_20', 'z_07'])
+            >>> fw_event = fw.move_to('g')
+            >>> fw_event.wait()
+            >>> fw.current_filter
+            'g_04'
         """
         assert self.is_connected, self.logger.error("Filter wheel must be connected to move")
         position = self._parse_position(position)
@@ -210,7 +221,7 @@ class AbstractFilterWheel(PanBase):
 
         return int_position
 
-    def _fits_header(self, header):
+    def _add_fits_keywords(self, header):
         header.set('FW-NAME', self.name, 'Filter wheel name')
         header.set('FW-MOD', self.model, 'Filter wheel model')
         header.set('FW-ID', self.uid, 'Filter wheel serial number')

--- a/pocs/filterwheel/sbig.py
+++ b/pocs/filterwheel/sbig.py
@@ -50,7 +50,7 @@ class FilterWheel(AbstractFilterWheel):
         """ Firmware version of the filter wheel """
         return self._firmware_version
 
-    @property
+    @AbstractFilterWheel.position.getter
     def position(self):
         """ Current integer position of the filter wheel """
         status = self._SBIGDriver.cfw_query(self._handle)
@@ -68,6 +68,7 @@ class FilterWheel(AbstractFilterWheel):
         self._handle = self.camera._handle
 
         info = self._SBIGDriver.cfw_get_info(self._handle)
+        self._model = info['model']
         self._firmware_version = info['firmware_version']
         self._n_positions = info['n_positions']
         if len(filter_names) != self.n_positions:

--- a/pocs/filterwheel/sbig.py
+++ b/pocs/filterwheel/sbig.py
@@ -82,7 +82,7 @@ class FilterWheel(AbstractFilterWheel):
         self._n_positions = info['n_positions']
         if len(self.filter_names) != self.n_positions:
             msg = "Number of names in filter_names ({}) doesn't".format(len(self.filter_names)) + \
-                "match number of positions in filter wheel ({})".format(self.n_positions)
+                " match number of positions in filter wheel ({})".format(self.n_positions)
             self.logger.error(msg)
             raise ValueError(msg)
 

--- a/pocs/filterwheel/sbig.py
+++ b/pocs/filterwheel/sbig.py
@@ -1,0 +1,8 @@
+from pocs.filterwheel import AbstractFilterWheel
+
+class FilterWheel(AbstractFilterWheel):
+    """
+
+    """
+    def __init__():
+        pass

--- a/pocs/filterwheel/sbig.py
+++ b/pocs/filterwheel/sbig.py
@@ -1,3 +1,8 @@
+from threading import Event
+
+from astropy import units as u
+
+from pocs.camera import AbstractCamera
 from pocs.filterwheel import AbstractFilterWheel
 
 
@@ -5,5 +10,90 @@ class FilterWheel(AbstractFilterWheel):
     """
 
     """
-    def __init__():
-        pass
+    def __init__(self,
+                 name='SBIG Filter Wheel',
+                 model='sbig',
+                 camera=None,
+                 filter_names=None,
+                 serial_number=None,
+                 *args, **kwargs):
+        super().__init__(name=name,
+                         model=model,
+                         camera=camera,
+                         filter_names=filter_name,
+                         *args, **kwargs)
+
+        if camera is None:
+            msg = "Camera must be provided for SBIG filter wheels"
+            self.logger.error(msg)
+            raise ValueError(msg)
+        if not isinstance(camera, AbstractCamera):
+            msg = "Camera must be an instance of pocs.camera.AbstractCamera, got {}".format(camera)
+            self.logger.error(msg)
+            raise ValueError(msg)
+        self._SBIGDriver = self.camera._SBIGDriver
+        self._handle = self.camera._handle
+
+        info = self._SBIGDriver.cfw_get_info(self._handle)
+        self._firmware_version = info['firmware_version']
+        self._n_positions = info['n_positions']
+        if len(filter_names) != self.n_positions:
+            msg = "Number of names in filter_names ({}) doesn't match".format(len(filter_names)) + \
+                "number of positions in filter wheel ({})".format(self.n_positions)
+            self.logger.error(msg)
+            raise ValueError(msg)
+
+##################################################################################################
+# Properties
+##################################################################################################
+
+    @property
+    def firmware_version(self):
+        """ Firmware version of the filter wheel """
+        return self._firmware_version
+
+##################################################################################################
+# Methods
+##################################################################################################
+
+    def go_to(self, position, blocking=False, timeout=10 * u.second):
+        """
+        Move the filter wheel to the given position.
+
+        The position can be expressed either as an integer, or as (part of) one of the names from
+        the filter_names list. To allow filter names of the form '<filter band>_<serial number>'
+        to be selected by band only position can be a substring from the start of one
+        of the names in the filter_names list, provided that this produces only one match.
+
+        Args:
+            position (int or str): position to move to.
+            blocking (bool, optional): If False (default) return immediately, if True block until
+                the filter wheel move has been completed.
+            timeout (u.Quantity, optional): maximum time to wait for the move to complete. Should be
+                a Quantity with time units. If a numeric type without units is given seconds will be
+                assumed. Default is 10 seconds.
+
+        Returns:
+            threading.Event: Event that will be set to signal when the move has completed
+        """
+        move_event = Event()
+        self._SBIGDriver.cfw_goto(handle=self._handle,
+                                  position=position,
+                                  cfw_event=move_event,
+                                  timeout=timeout)
+        if blocking:
+            move_event.wait()
+
+        return move_event
+
+##################################################################################################
+# Private methods
+##################################################################################################
+
+    def _fits_header(self, header):
+        header = super()._fits_header(header)
+        header.set('FW-FW', self.firmware_version, 'Filter wheel firmware version')
+        return header
+
+    def __str__(self):
+        return "{} ({}) on {}".format(self.name, self.model, self.camera.uid)

--- a/pocs/filterwheel/sbig.py
+++ b/pocs/filterwheel/sbig.py
@@ -107,7 +107,7 @@ class FilterWheel(AbstractFilterWheel):
                                   cfw_event=move_event,
                                   timeout=self._timeout)
 
-    def _fits_header(self, header):
-        header = super()._fits_header(header)
+    def _add_fits_keywords(self, header):
+        header = super()._add_fits_keywords(header)
         header.set('FW-FW', self.firmware_version, 'Filter wheel firmware version')
         return header

--- a/pocs/filterwheel/sbig.py
+++ b/pocs/filterwheel/sbig.py
@@ -1,5 +1,6 @@
 from pocs.filterwheel import AbstractFilterWheel
 
+
 class FilterWheel(AbstractFilterWheel):
     """
 

--- a/pocs/filterwheel/sbig.py
+++ b/pocs/filterwheel/sbig.py
@@ -1,4 +1,4 @@
-from threading import Event
+import threading
 import math
 
 from astropy import units as u
@@ -97,7 +97,7 @@ class FilterWheel(AbstractFilterWheel):
         """
         assert self.is_connected, self.logger.error("Filter wheel must be connected to move")
         position = self._parse_position(position)
-        move_event = Event()
+        move_event = threading.Event()
         self._SBIGDriver.cfw_goto(handle=self._handle,
                                   position=position,
                                   cfw_event=move_event,

--- a/pocs/filterwheel/sbig.py
+++ b/pocs/filterwheel/sbig.py
@@ -1,4 +1,5 @@
 from threading import Event
+import math
 
 from astropy import units as u
 
@@ -61,6 +62,14 @@ class FilterWheel(AbstractFilterWheel):
     def firmware_version(self):
         """ Firmware version of the filter wheel """
         return self._firmware_version
+
+    @property
+    def position(self):
+        """ Current integer position of the filter wheel """
+        status = self._SBIGDriver.cfw_query(self._handle)
+        if math.isnan(status['position']):
+            self.logger.warning("Filter wheel position unknown, returning NaN")
+        return status['position']
 
 ##################################################################################################
 # Methods

--- a/pocs/filterwheel/sbig.py
+++ b/pocs/filterwheel/sbig.py
@@ -39,20 +39,7 @@ class FilterWheel(AbstractFilterWheel):
                          filter_names=filter_names,
                          *args, **kwargs)
         self._serial_number = serial_number
-        self._SBIGDriver = self.camera._SBIGDriver
-        self._handle = self.camera._handle
-
-        info = self._SBIGDriver.cfw_get_info(self._handle)
-        self._firmware_version = info['firmware_version']
-        self._n_positions = info['n_positions']
-        if len(filter_names) != self.n_positions:
-            msg = "Number of names in filter_names ({}) doesn't match".format(len(filter_names)) + \
-                "number of positions in filter wheel ({})".format(self.n_positions)
-            self.logger.error(msg)
-            raise ValueError(msg)
-
-        self.logger.info("Filter wheel {} initialised".format(self))
-        self._connected = True
+        self.connect()
 
 ##################################################################################################
 # Properties
@@ -74,6 +61,23 @@ class FilterWheel(AbstractFilterWheel):
 ##################################################################################################
 # Methods
 ##################################################################################################
+
+    def connect(self):
+        """ Connect to filter wheel """
+        self._SBIGDriver = self.camera._SBIGDriver
+        self._handle = self.camera._handle
+
+        info = self._SBIGDriver.cfw_get_info(self._handle)
+        self._firmware_version = info['firmware_version']
+        self._n_positions = info['n_positions']
+        if len(filter_names) != self.n_positions:
+            msg = "Number of names in filter_names ({}) doesn't match".format(len(filter_names)) + \
+                "number of positions in filter wheel ({})".format(self.n_positions)
+            self.logger.error(msg)
+            raise ValueError(msg)
+
+        self.logger.info("Filter wheel {} initialised".format(self))
+        self._connected = True
 
     def move_to(self, position, blocking=False, timeout=10 * u.second):
         """

--- a/pocs/filterwheel/sbig.py
+++ b/pocs/filterwheel/sbig.py
@@ -36,7 +36,7 @@ class FilterWheel(AbstractFilterWheel):
         super().__init__(name=name,
                          model=model,
                          camera=camera,
-                         filter_names=filter_name,
+                         filter_names=filter_names,
                          *args, **kwargs)
         self._serial_number = serial_number
         self._SBIGDriver = self.camera._SBIGDriver
@@ -115,6 +115,3 @@ class FilterWheel(AbstractFilterWheel):
         header = super()._fits_header(header)
         header.set('FW-FW', self.firmware_version, 'Filter wheel firmware version')
         return header
-
-    def __str__(self):
-        return "{} ({}) on {}".format(self.name, self.uid, self.camera.uid)

--- a/pocs/filterwheel/simulator.py
+++ b/pocs/filterwheel/simulator.py
@@ -1,0 +1,8 @@
+from pocs.filterwheel import AbstractFilterWheel
+
+class FilterWheel(PanBase):
+    """
+
+    """
+    def __init__():
+        pass

--- a/pocs/filterwheel/simulator.py
+++ b/pocs/filterwheel/simulator.py
@@ -1,7 +1,7 @@
 from pocs.filterwheel import AbstractFilterWheel
 
 
-class FilterWheel(PanBase):
+class FilterWheel(AbstractFilterWheel):
     """
 
     """

--- a/pocs/filterwheel/simulator.py
+++ b/pocs/filterwheel/simulator.py
@@ -38,7 +38,7 @@ class FilterWheel(AbstractFilterWheel):
                          filter_names=filter_names,
                          *args, **kwargs)
         if isinstance(move_time, u.Quantity):
-            self._move_time = move_time.to(u.seconds).value
+            self._move_time = move_time.to(u.second).value
         else:
             self._move_time = move_time
         self._move_birectional = bool(move_bidirectional)
@@ -49,7 +49,7 @@ class FilterWheel(AbstractFilterWheel):
 # Properties
 ##################################################################################################
 
-    @property
+    @AbstractFilterWheel.position.getter
     def position(self):
         """ Current integer position of the filter wheel """
         if math.isnan(self._position):
@@ -109,8 +109,7 @@ class FilterWheel(AbstractFilterWheel):
 
         move = threading.Timer(interval=move_duration,
                                function=self._complete_move,
-                               args=(position, move_event),
-                               daemon=True)
+                               args=(position, move_event))
         self._moving = True
         self._position = float('nan')
         move.start()
@@ -118,8 +117,7 @@ class FilterWheel(AbstractFilterWheel):
         if move_duration > timeout:
             timeout_timer = threading.Timer(interval=timeout,
                                             function=self._timeout_move,
-                                            args(move_event),
-                                            daemon=True)
+                                            args=(move_event))
             timeout_timer.start()
 
         if blocking:

--- a/pocs/filterwheel/simulator.py
+++ b/pocs/filterwheel/simulator.py
@@ -1,5 +1,6 @@
 from pocs.filterwheel import AbstractFilterWheel
 
+
 class FilterWheel(PanBase):
     """
 

--- a/pocs/filterwheel/simulator.py
+++ b/pocs/filterwheel/simulator.py
@@ -1,3 +1,11 @@
+import math
+import time
+import random
+import threading
+
+from astropy import units as u
+
+from pocs.utils import error
 from pocs.filterwheel import AbstractFilterWheel
 
 
@@ -10,24 +18,125 @@ class FilterWheel(AbstractFilterWheel):
         model (str, optional): model of the filter wheel
         camera (pocs.camera.*.Camera, optional): camera that this filter wheel is associated with.
         filter_names (list of str): names of the filters installed at each filter wheel position
+        move_time (astropy.units.Quantity, optional): time to move the filter wheel by one position,
+            optional, default 1 second.
+        move_bidirectional (bool, optional): if True will simulate filter wheel which can rotate in
+            either direction, if False (default) will similate a filter wheel that only moves in
+            one direction.
     """
     def __init__(self,
-                 name='Simulated filter wheel',
+                 name='Simulated Filter Wheel',
                  model='simulator',
                  camera=None,
                  filter_names=None,
+                 move_time=1 * u.second,
+                 move_bidirectional=False,
                  *args, **kwargs):
-
         super().__init__(name=name,
                          model=model,
                          camera=camera,
                          filter_names=filter_names,
                          *args, **kwargs)
+        if isinstance(move_time, u.Quantity):
+            self._move_time = move_time.to(u.seconds).value
+        else:
+            self._move_time = move_time
+        self._move_birectional = bool(move_bidirectional)
+        self.connect()
+        self.logger.info("Filter wheel {} initialised".format(self))
+
+##################################################################################################
+# Properties
+##################################################################################################
 
     @property
     def position(self):
-        """ """
-        pass
+        """ Current integer position of the filter wheel """
+        if math.isnan(self._position):
+            self.logger.warning("Filter wheel position unknown, returning NaN")
+        return self._position
 
-    def move_to(self, position):
-        pass
+##################################################################################################
+# Methods
+##################################################################################################
+
+    def connect(self):
+        """ Connect to the filter wheel """
+        self._serial_number = 'SF{:04d}'.format(random.randint(0, 9999))
+        self._position = 1
+        self._moving = False
+        self._connected = True
+
+    def move_to(self, position, blocking=False, timeout=10 * u.second):
+        """
+        Move the filter wheel to the given position.
+
+        The position can be expressed either as an integer, or as (part of) one of the names from
+        the filter_names list. To allow filter names of the form '<filter band>_<serial number>'
+        to be selected by band only position can be a substring from the start of one
+        of the names in the filter_names list, provided that this produces only one match.
+
+        Args:
+            position (int or str): position to move to.
+            blocking (bool, optional): If False (default) return immediately, if True block until
+                the filter wheel move has been completed.
+            timeout (u.Quantity, optional): maximum time to wait for the move to complete. Should be
+                a Quantity with time units. If a numeric type without units is given seconds will be
+                assumed. Default is 10 seconds.
+
+        Returns:
+            threading.Event: Event that will be set to signal when the move has completed
+        """
+        assert self.is_connected, self.logger.error("Filter wheel must be connected to move")
+        position = self._parse_position(position)
+        if isinstance(timeout, u.Quantity):
+                timeout = timeout.to(u.second).value
+
+        move_event = threading.Event()
+        if self._moving:
+            move_event.set()
+            msg = "Attempt to move filter wheel when already moving"
+            self.logger.error(msg)
+            raise RuntimeError(msg)
+
+        move_distance = position - self.position
+        if move_distance < 0:
+            if not self._move_birectional:
+                move_distance += self._n_positions
+            else:
+                move_distance = -move_distance
+        move_duration = move_distance * self._move_time
+
+        move = threading.Timer(interval=move_duration,
+                               function=self._complete_move,
+                               args=(position, move_event),
+                               daemon=True)
+        self._moving = True
+        self._position = float('nan')
+        move.start()
+
+        if move_duration > timeout:
+            timeout_timer = threading.Timer(interval=timeout,
+                                            function=self._timeout_move,
+                                            args(move_event),
+                                            daemon=True)
+            timeout_timer.start()
+
+        if blocking:
+            move_event.wait()
+
+        return move_event
+
+##################################################################################################
+# Private methods
+##################################################################################################
+
+    def _complete_move(self, position, move_event):
+        self._position = position
+        self._moving = False
+        move_event.set()
+
+    def _timeout_move(self, move_event):
+        move_event.set()
+        msg = "Timeout waiting for filter wheel move to complete"
+        raise error.Timeout(msg)

--- a/pocs/filterwheel/simulator.py
+++ b/pocs/filterwheel/simulator.py
@@ -3,7 +3,31 @@ from pocs.filterwheel import AbstractFilterWheel
 
 class FilterWheel(AbstractFilterWheel):
     """
+    Class for simulated filter wheels.
 
+    Args:
+        name (str, optional): name of the filter wheel
+        model (str, optional): model of the filter wheel
+        camera (pocs.camera.*.Camera, optional): camera that this filter wheel is associated with.
+        filter_names (list of str): names of the filters installed at each filter wheel position
     """
-    def __init__():
+    def __init__(self,
+                 name='Simulated filter wheel',
+                 model='simulator',
+                 camera=None,
+                 filter_names=None,
+                 *args, **kwargs):
+
+        super().__init__(name=name,
+                         model=model,
+                         camera=camera,
+                         filter_names=filter_names,
+                         *args, **kwargs)
+
+    @property
+    def position(self):
+        """ """
+        pass
+
+    def move_to(self, position):
         pass

--- a/pocs/filterwheel/simulator.py
+++ b/pocs/filterwheel/simulator.py
@@ -88,19 +88,20 @@ class FilterWheel(AbstractFilterWheel):
             raise RuntimeError(msg)
 
         move_distance = position - self.position
-        if move_distance < 0:
-            if not self._move_birectional:
-                move_distance += self._n_positions
-            else:
-                move_distance = -move_distance
+        if self._move_birectional:
+            # Filter wheel can move either direction, just need magnitude of the move.
+            move_distance = abs(move_distance)
+        else:
+            # Filter wheel can only move one way, will have to go the long way around for -ve moves
+            move_distance = move_distance % self._n_positions
         move_duration = move_distance * self._move_time
 
         move = threading.Timer(interval=move_duration,
                                function=self._complete_move,
                                args=(position, move_event))
-        move.start()
         self._position = float('nan')
         self._moving = True
+        move.start()
 
         if move_duration > self._timeout:
             timeout_timer = threading.Timer(interval=self._timeout,

--- a/pocs/focuser/birger.py
+++ b/pocs/focuser/birger.py
@@ -470,8 +470,8 @@ class Focuser(AbstractFocuser):
             self.logger.debug("Moved {} encoder units to far stop".format(r[:-2]))
             return int(r[:-2])
 
-    def _fits_header(self, header):
-        header = super()._fits_header(header)
+    def _add_fits_keywords(self, header):
+        header = super()._add_fits_keywords(header)
         header.set('FOC-HW', self.hardware_version, 'Focuser hardware version')
         header.set('FOC-FW', self.firmware_version, 'Focuser firmware version')
         header.set('LENSINFO', self.lens_info, 'Attached lens')

--- a/pocs/focuser/birger.py
+++ b/pocs/focuser/birger.py
@@ -265,7 +265,8 @@ class Focuser(AbstractFocuser):
         """
         response = self._send_command('fa{:d}'.format(int(position)), response_length=1)
         if response[0][:4] != 'DONE':
-            self.logger.error("{} got response '{}', expected 'DONENNNNN,N'!".format(self, response[0].rstrip()))
+            self.logger.error("{} got response '{}', expected 'DONENNNNN,N'!".format(
+                self, response[0].rstrip()))
         else:
             r = response[0][4:].rstrip()
             self.logger.debug("Moved to {} encoder units".format(r[:-2]))
@@ -288,7 +289,8 @@ class Focuser(AbstractFocuser):
         """
         response = self._send_command('mf{:d}'.format(increment), response_length=1)
         if response[0][:4] != 'DONE':
-            self.logger.error("{} got response '{}', expected 'DONENNNNN,N'!".format(self, response[0].rstrip()))
+            self.logger.error("{} got response '{}', expected 'DONENNNNN,N'!".format(
+                self, response[0].rstrip()))
         else:
             r = response[0][4:].rstrip()
             self.logger.debug("Moved by {} encoder units".format(r[:-2]))
@@ -312,7 +314,8 @@ class Focuser(AbstractFocuser):
                 be used if the number of lines expected is not known (e.g. 'ds' command).
 
         Returns:
-            list: possibly empty list containing the '\r' terminated lines of the response from the adaptor.
+            list: possibly empty list containing the '\r' terminated lines of the response from the
+            adaptor.
         """
         if not self.is_connected:
             self.logger.critical("Attempt to send command to {} when not connected!".format(self))
@@ -329,7 +332,8 @@ class Focuser(AbstractFocuser):
 
         # In verbose mode adaptor will first echo the command
         echo = self._serial_io.readline().rstrip()
-        assert echo == command, self.logger.warning("echo != command: {} != {}".format(echo, command))
+        assert echo == command, self.logger.warning("echo != command: {} != {}".format(
+            echo, command))
 
         # Adaptor should then send 'OK', even if there was an error.
         ok = self._serial_io.readline().rstrip()
@@ -362,9 +366,11 @@ class Focuser(AbstractFocuser):
                 # Got an error message! Translate it.
                 try:
                     error_message = error_messages[int(error_match.group())]
-                    self.logger.error("{} returned error message '{}'!".format(self, error_message))
+                    self.logger.error("{} returned error message '{}'!".format(
+                        self, error_message))
                 except Exception:
-                    self.logger.error("Unknown error '{}' from {}!".format(error_match.group(), self))
+                    self.logger.error("Unknown error '{}' from {}!".format(
+                        error_match.group(), self))
 
         return response
 
@@ -379,7 +385,8 @@ class Focuser(AbstractFocuser):
         # Get the hardware version of the adaptor. Accessible as self.hardware_version
         self._get_hardware_version()
 
-        # Get basic lens info (e.g. '400mm,f28' for a 400 mm, f/2.8 lens). Accessible as self.lens_info
+        # Get basic lens info (e.g. '400mm,f28' for a 400 mm, f/2.8 lens). Accessible as
+        # self.lens_info
         self._get_lens_info()
 
         # Initialise the aperture motor. This also has the side effect of fully opening the iris.

--- a/pocs/focuser/focuser.py
+++ b/pocs/focuser/focuser.py
@@ -16,6 +16,7 @@ from threading import Thread
 
 
 from pocs.base import PanBase
+from pocs.camera import AbstractCamera
 from pocs.utils import current_time
 from pocs.utils.images import focus as focus_utils
 
@@ -139,6 +140,10 @@ class AbstractFocuser(PanBase):
 
     @camera.setter
     def camera(self, camera):
+        if not isinstance(camera, AbstractCamera):
+            msg = "Camera must be an instance of pocs.camera.AbstractCamera, got {}".format(camera)
+            self.logger.error(msg)
+            raise ValueError(msg)
         if self._camera:
             self.logger.warning("{} assigned to {}, skipping attempted assignment to {}!",
                                 self, self.camera, camera)

--- a/pocs/focuser/focuser.py
+++ b/pocs/focuser/focuser.py
@@ -16,7 +16,6 @@ from threading import Thread
 
 
 from pocs.base import PanBase
-from pocs.camera import AbstractCamera
 from pocs.utils import current_time
 from pocs.utils.images import focus as focus_utils
 
@@ -140,10 +139,6 @@ class AbstractFocuser(PanBase):
 
     @camera.setter
     def camera(self, camera):
-        if not isinstance(camera, AbstractCamera):
-            msg = "Camera must be an instance of pocs.camera.AbstractCamera, got {}".format(camera)
-            self.logger.error(msg)
-            raise ValueError(msg)
         if self._camera:
             self.logger.warning("{} assigned to {}, skipping attempted assignment to {}!",
                                 self, self.camera, camera)

--- a/pocs/focuser/focuser.py
+++ b/pocs/focuser/focuser.py
@@ -539,7 +539,7 @@ class AbstractFocuser(PanBase):
 
         return initial_focus, final_focus
 
-    def _fits_header(self, header):
+    def _add_fits_keywords(self, header):
         header.set('FOC-NAME', self.name, 'Focuser name')
         header.set('FOC-MOD', self.model, 'Focuser model')
         header.set('FOC-ID', self.uid, 'Focuser serial number')

--- a/pocs/focuser/focuslynx.py
+++ b/pocs/focuser/focuslynx.py
@@ -334,8 +334,8 @@ class Focuser(AbstractFocuser):
                 response = str(self._serial_port.readline(), encoding='ascii').strip()
             return info
 
-    def _fits_header(self, header):
-        header = super()._fits_header(header)
+    def _add_fits_keywords(self, header):
+        header = super()._add_fits_keywords(header)
         header.set('FOC-MOD', self.model, 'Focuser device type')
         header.set('FOC-ID', self.uid, 'Focuser nickname')
         header.set('FOC-HW', self.hardware_version, 'Focuser device type')

--- a/pocs/tests/test_filterwheel.py
+++ b/pocs/tests/test_filterwheel.py
@@ -33,6 +33,11 @@ def test_camera_init():
     assert sim_camera.filterwheel.camera is sim_camera
 
 
+def test_camera_no_filterwheel():
+    sim_camera = SimCamera()
+    assert sim_camera.filterwheel is None
+
+
 def test_camera_association_on_init():
     sim_camera = SimCamera()
     sim_filterwheel = SimFilterWheel(filter_names=['one', 'deux', 'drei', 'quattro'],
@@ -97,11 +102,18 @@ def test_move_bad_number(filterwheel):
     with pytest.raises(ValueError):
         filterwheel.move_to(0, blocking=True)  # No zero based numbering here!
     with pytest.raises(ValueError):
-        filterwheel.position = 99
+        filterwheel.move_to(-1, blocking=True)  # Definitely not
+    with pytest.raises(ValueError):
+        filterwheel.position = 99  # Problems.
+    with pytest.raises(ValueError):
+        filterwheel.move_to(filterwheel._n_positions + 1, blocking=True)  # Close, but...
+    filterwheel.move_to(filterwheel._n_positions, blocking=True)  # OK
 
 
 def test_move_name(filterwheel, caplog):
+    filterwheel.position = 1  # Start from a known position
     e = filterwheel.move_to('quattro')
+    assert filterwheel.current_filter == 'UNKNOWN'  # I'm between filters right now
     e.wait()
     assert filterwheel.current_filter == 'quattro'
     e = filterwheel.move_to('o', blocking=True)  # Matches leading substrings too

--- a/pocs/tests/test_filterwheel.py
+++ b/pocs/tests/test_filterwheel.py
@@ -1,0 +1,148 @@
+import pytest
+import math
+from timeit import timeit
+import time
+
+from astropy import units as u
+
+from pocs.filterwheel.simulator import FilterWheel as SimFilterWheel
+from pocs.camera.simulator import Camera as SimCamera
+
+
+@pytest.fixture(scope='module')
+def filterwheel():
+    sim_filterwheel = SimFilterWheel(filter_names=['one', 'deux', 'drei', 'quattro'],
+                                     move_time=0.1 * u.second,
+                                     timeout=0.5 * u.second)
+    return sim_filterwheel
+
+# intialisation
+
+
+def test_init(filterwheel):
+    assert isinstance(filterwheel, SimFilterWheel)
+    assert filterwheel.is_connected
+
+
+def test_camera_init():
+    sim_camera = SimCamera(filterwheel={'model': 'simulator',
+                                        'filter_names': ['one', 'deux', 'drei', 'quattro']})
+    assert isinstance(sim_camera.filterwheel, SimFilterWheel)
+    assert sim_camera.filterwheel.is_connected
+    assert sim_camera.filterwheel.uid
+    assert sim_camera.filterwheel.camera is sim_camera
+
+
+def test_camera_association_on_init():
+    sim_camera = SimCamera()
+    sim_filterwheel = SimFilterWheel(filter_names=['one', 'deux', 'drei', 'quattro'],
+                                     camera=sim_camera)
+    assert sim_filterwheel.camera is sim_camera
+
+
+def test_with_no_name():
+    with pytest.raises(ValueError):
+        sim_filterwheel = SimFilterWheel()
+
+# Basic property getting and (not) setting
+
+
+def test_model(filterwheel):
+    model = filterwheel.model
+    assert model == 'simulator'
+    with pytest.raises(AttributeError):
+        filterwheel.model = "Airfix"
+
+
+def test_name(filterwheel):
+    name = filterwheel.name
+    assert name == 'Simulated Filter Wheel'
+    with pytest.raises(AttributeError):
+        filterwheel.name = "Phillip"
+
+
+def test_uid(filterwheel):
+    uid = filterwheel.uid
+    assert uid.startswith('SW')
+    assert len(uid) == 6
+    with pytest.raises(AttributeError):
+        filterwheel.uid = "Can't touch this"
+
+
+def test_filter_names(filterwheel):
+    names = filterwheel.filter_names
+    assert isinstance(names, list)
+    for name in names:
+        assert isinstance(name, str)
+    with pytest.raises(AttributeError):
+        filterwheel.filter_names = ["Unsharp mask", "Gaussian blur"]
+
+# Movement
+
+
+def test_move_number(filterwheel):
+    assert filterwheel.position == 1
+    e = filterwheel.move_to(2)
+    assert math.isnan(filterwheel.position)  # position is NaN while between filters
+    e.wait()
+    assert filterwheel.position == 2
+    e = filterwheel.move_to(3, blocking=True)
+    assert e.is_set()
+    assert filterwheel.position == 3
+    filterwheel.position = 4  # Move by assignment to position property blocks until complete
+    assert filterwheel.position == 4
+
+
+def test_move_bad_number(filterwheel):
+    with pytest.raises(ValueError):
+        filterwheel.move_to(0, blocking=True)  # No zero based numbering here!
+    with pytest.raises(ValueError):
+        filterwheel.position = 99
+
+
+def test_move_name(filterwheel, caplog):
+    e = filterwheel.move_to('quattro')
+    e.wait()
+    assert filterwheel.current_filter == 'quattro'
+    e = filterwheel.move_to('o', blocking=True)  # Matches leading substrings too
+    assert filterwheel.current_filter == 'one'
+    filterwheel.position = 'd'  # In case of multiple matches logs a warning & uses the first match
+    assert filterwheel.current_filter == 'deux'
+    # WARNING followed by INFO level record about the move
+    assert caplog.records[-2].levelname == 'WARNING'
+    assert caplog.records[-1].levelname == 'INFO'
+    filterwheel.position = 'deux'  # Check null move. Earlier version of simulator failed this!
+    assert filterwheel.current_filter == 'deux'
+
+
+def test_move_bad_name(filterwheel):
+    with pytest.raises(ValueError):
+        filterwheel.move_to('cinco')
+
+
+def test_move_timeout(caplog):
+    slow_filterwheel = SimFilterWheel(filter_names=['one', 'deux', 'drei', 'quattro'],
+                                      move_time=0.1,
+                                      timeout=0.2)
+    slow_filterwheel.position = 4  # Move should take 0.3 seconds, more than timeout.
+    time.sleep(0.001)  # For some reason takes a moment for the error to get logged.
+    assert caplog.records[-1].levelname == 'ERROR'  # Should have logged an ERROR by now
+    # It raises a pocs.utils.error.Timeout exception too, but because it's in another Thread it
+    # doesn't get passes up to the calling code.
+
+
+@pytest.mark.parametrize("name,bidirectional, expected",
+                         [("monodirectional", False, 0.3),
+                          ("bidirectional", True, 0.1)])
+def test_move_times(name, bidirectional, expected):
+    sim_filterwheel = SimFilterWheel(filter_names=['one', 'deux', 'drei', 'quattro'],
+                                     move_time=0.1 * u.second,
+                                     move_bidirectional=bidirectional,
+                                     timeout=0.5 * u.second)
+    sim_filterwheel.position = 1
+    assert timeit("sim_filterwheel.position = 2", number=1, globals=locals()) == \
+        pytest.approx(0.1, rel=2e-2)
+    assert timeit("sim_filterwheel.position = 4", number=1, globals=locals()) == \
+        pytest.approx(0.2, rel=2e-2)
+    assert timeit("sim_filterwheel.position = 3", number=1, globals=locals()) == \
+        pytest.approx(expected, rel=2e-2)


### PR DESCRIPTION
Addresses #768 by adding support for motorised optical filter wheels. The scope of this PR only includes support for the SBIG filter wheels from Diffraction Limited but with the ground work in place it would not be difficult to add support for other filter wheels.

The design follows the pattern established with the `Camera` and `Focuser` classes. There is an `AbstractFilterWheel` base class as well as implementations of the `FilterWheel` class for both the SBIG filter wheels and simulated hardware. Properties, method names and behaviours have been chosen to be consistent with the `Camera` and `Focuser` classes.

~~Flagging as WIP only because there are a few unrelated changes in here (line length fixes & other minor tweaks) that I need to split out into their own PRs. Otherwise~~ I think this is basically ready to go.