### PR TITLE
Camera refactoring

### DIFF
--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -57,7 +57,7 @@ class AbstractCamera(PanBase):
         self._file_extension = kwargs.get('file_extension', 'fits')
         self._current_observation = None
 
-        self._create_subcomponent(subcomponent=focusr,
+        self._create_subcomponent(subcomponent=focuser,
                                   name='focuser',
                                   class_name='Focuser',
                                   base_class=AbstractFocuser)
@@ -480,7 +480,7 @@ class AbstractCamera(PanBase):
         fits_utils.update_headers(file_path, info)
         return file_path
 
-    def _create_subcomponent(self, subcomponent, name, class, base_class):
+    def _create_subcomponent(self, subcomponent, name, class_name, base_class):
         """
 
         """
@@ -490,7 +490,7 @@ class AbstractCamera(PanBase):
                 setattr(self, name, subcomponent)
                 getattr(self, name).camera = self
             elif isinstance(subcomponent, dict):
-                module_name = 'pocs.{}.{}'.format(name, subcompoent['model'])
+                module_name = 'pocs.{}.{}'.format(name, subcomponent['model'])
                 try:
                     module = load_module(module_name)
                 except AttributeError as err:

--- a/pocs/camera/fli.py
+++ b/pocs/camera/fli.py
@@ -79,7 +79,7 @@ class Camera(AbstractCamera):
                 warn(message)
                 return
             self.logger.debug('Found {} ({}) on {}'.format(
-                name, kwargs['serial_numner'], device_node))
+                name, kwargs['serial_number'], device_node))
             kwargs['port'] = device_node
 
         if kwargs['port'] in Camera._assigned_nodes:

--- a/pocs/camera/fli.py
+++ b/pocs/camera/fli.py
@@ -305,9 +305,6 @@ class Camera(AbstractCamera):
         header.set('XPIXSZ', self._info['pixel width'].value, 'Microns')
         header.set('YPIXSZ', self._info['pixel height'].value, 'Microns')
 
-        if self.focuser:
-            header = self.focuser._fits_header(header)
-
         return header
 
     def _get_camera_info(self):

--- a/pocs/camera/fli.py
+++ b/pocs/camera/fli.py
@@ -33,9 +33,11 @@ class Camera(AbstractCamera):
                  filter_type='M',
                  library_path=False,
                  *args, **kwargs):
+        # FLI cameras should be specified by either serial number (preferred) or 'port' (device
+        # node). For backwards compatibility reasons allow port to be used as an alias of serial
+        # number. If both are given serial number takes precedence
         kwargs['readout_time'] = 1.0
         kwargs['file_extension'] = 'fits'
-        super().__init__(name, *args, **kwargs)
 
         # Create a Lock that will be used to prevent overlapping exposures.
         self._exposure_lock = Lock()
@@ -43,9 +45,10 @@ class Camera(AbstractCamera):
         # Create an instance of the FLI Driver interface
         self._FLIDriver = libfli.FLIDriver(library_path)
 
-        if serial_number_pattern.match(self.port):
+        if kwargs.get('serial_number') or serial_number_pattern.match(kwargs.get('port')):
             # Have been given a serial number instead of a device node
-            self.logger.debug('Looking for {} ({})...'.format(self.name, self.port))
+            kwargs['serial_number'] = kwargs.get('serial_number', kwargs.get('port'))
+            self.logger.debug('Looking for {} ({})...'.format(name, kwargs['serial_number']))
 
             if Camera._fli_nodes is None:
                 # No cached device nodes scanning results. 1st get list of all FLI cameras
@@ -69,21 +72,23 @@ class Camera(AbstractCamera):
 
             # Search in cached device node scanning results for serial number.
             try:
-                device_node = Camera._fli_nodes[self.port]
+                device_node = Camera._fli_nodes[kwargs['serial_number']]
             except KeyError:
-                message = 'Could not find {} ({})!'.format(self.name, self.port)
+                message = 'Could not find {} ({})!'.format(name, kwargs['serial_number'])
                 self.logger.error(message)
                 warn(message)
                 return
-            self.logger.debug('Found {} ({}) on {}'.format(self.name, self.port, device_node))
-            self.port = device_node
+            self.logger.debug('Found {} ({}) on {}'.format(
+                name, kwargs['serial_numner'], device_node))
+            kwargs['port'] = device_node
 
-        if self.port in Camera._assigned_nodes:
-            message = 'Device node {} already in use!'.format(self.port)
+        if kwargs['port'] in Camera._assigned_nodes:
+            message = 'Device node {} already in use!'.format(kwargs['port'])
             self.logger.error(message)
             warn(message)
             return
 
+        super().__init__(name, *args, **kwargs)
         self.connect()
         Camera._assigned_nodes.append(self.port)
         self.filter_type = filter_type

--- a/pocs/camera/sbig.py
+++ b/pocs/camera/sbig.py
@@ -24,9 +24,10 @@ class Camera(AbstractCamera):
                  set_point=None,
                  filter_type=None,
                  *args, **kwargs):
-        # For SBIG cameras serial_number and port are synonymous but at least one must be set
+        # SBIG cameras don't have a 'port' but should have their serial number specified.
+        # For backwards compatibility purposes allow port to be used as an alias of serial number.
         kwargs['serial_number'] = kwargs.get('serial_number', kwargs.get('port'))
-        kwargs['port'] = kwargs.get('port', kwargs.get('serial_number'))
+        kwargs['port'] = None
         kwargs['readout_time'] = 1.0
         kwargs['file_extension'] = 'fits'
         super().__init__(name, *args, **kwargs)
@@ -105,8 +106,8 @@ class Camera(AbstractCamera):
 # Methods
 
     def __str__(self):
-        # For SBIG cameras uid and port are both aliases for serial number so
-        # shouldn't include both
+        # SBIG cameras don't have a port so just include the serial number in the string
+        # representation.
         s = "{} ({})".format(self.name, self.uid)
 
         if self.focuser:
@@ -120,18 +121,18 @@ class Camera(AbstractCamera):
 
         Gets a 'handle', serial number and specs/capabilities from the driver
         """
-        self.logger.debug('Connecting to {} ({})'.format(self.name, self.port))
+        self.logger.debug('Connecting to {}'.format(self))
 
         # Claim handle from the SBIGDriver, store camera info.
-        self._handle, self._info = self._SBIGDriver.assign_handle(serial=self.port)
+        self._handle, self._info = self._SBIGDriver.assign_handle(serial=self.uid)
         if self._handle == INVALID_HANDLE_VALUE:
-            message = 'Could not connect to {} ({})!'.format(self.name, self.port)
+            message = 'Could not connect to {}!'.format(self)
             self.logger.error(message)
             warn(message)
             self._connected = False
             return
 
-        self.logger.debug("{} connected".format(self.name))
+        self.logger.debug("{} connected".format(self))
         self._connected = True
         self._serial_number = self._info['serial number']
         self.model = self._info['camera name']


### PR DESCRIPTION
Minor refactoring of Camera class, prompted by work on #769 (and mostly pulled out of that PR)

- modifications to SBIG & FLI `Camera` initialisation to allow serial number to be specified in `serial_number` keyword argument instead of having to use `port` for something that isn't a port, & to reduce appearance of placeholder UID ('XXXXXX') in the logs.
- convert the `Focuser` attribute creation code to a generic subcomponent creation method of `Camera`
- move calls to `Focuser` FITS header method to base class
- clean up of `__str__` methods