### PR TITLE
Prevent filter wheel moving during a camera exposure

### DIFF
--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -167,6 +167,11 @@ class AbstractCamera(PanBase):
         else:
             return self._filter_type
 
+    @property
+    def is_exposing(self):
+        """ True if an exposure is currently under way, otherwise False """
+        raise NotImplementedError
+
 ##################################################################################################
 # Methods
 ##################################################################################################

--- a/pocs/camera/fli.py
+++ b/pocs/camera/fli.py
@@ -170,6 +170,11 @@ class Camera(AbstractCamera):
         """
         return self._FLIDriver.FLIGetCoolerPower(self._handle)
 
+    @property
+    def is_exposing(self):
+        """ True if an exposure is currently under way, otherwise False """
+        return bool(self._FLIDriver.FLIGetExposureStatus(self._handle).value)
+
 # Methods
 
     def connect(self):

--- a/pocs/camera/sbig.py
+++ b/pocs/camera/sbig.py
@@ -103,6 +103,11 @@ class Camera(AbstractCamera):
         """
         return self._SBIGDriver.query_temp_status(self._handle).imagingCCDPower
 
+    @property
+    def is_exposing(self):
+        """ True if an exposure is currently under way, otherwise False """
+        return self._SBIGDriver.get_exposure_status(self._handle) != 'CS_IDLE'
+
 # Methods
 
     def __str__(self):

--- a/pocs/camera/sbigudrv.py
+++ b/pocs/camera/sbigudrv.py
@@ -212,6 +212,19 @@ class SBIGDriver(PanBase):
             self._send_command('CC_SET_TEMPERATURE_REGULATION2', params=set_temp_params)
             self._send_command('CC_SET_TEMPERATURE_REGULATION2', params=set_freeze_params)
 
+    def get_exposure_status(self, handle):
+        """  """
+        query_status_params = QueryCommandStatusParams(command_codes['CC_START_EXPOSURE2'])
+        query_status_results = QueryCommandStatusResults()
+
+        with self._command_lock:
+            self._set_handle(handle)
+            self._send_command('CC_QUERY_COMMAND_STATUS',
+                               params=query_status_params,
+                               results=query_status_results)
+
+        return statuses[query_status_results.status]
+
     def take_exposure(self,
                       handle,
                       seconds,
@@ -270,28 +283,16 @@ class SBIGDriver(PanBase):
         # Make sure there isn't already an exposure in progress on this camera.
         # If there is then we need to wait otherwise we'll cause a hang.
         # Could do this with Locks but it's more robust to directly query the hardware.
-        query_status_params = QueryCommandStatusParams(command_codes['CC_START_EXPOSURE2'])
-        query_status_results = QueryCommandStatusResults()
-
-        with self._command_lock:
-            self._set_handle(handle)
-            self._send_command('CC_QUERY_COMMAND_STATUS',
-                               params=query_status_params,
-                               results=query_status_results)
-
-        if query_status_results.status != status_codes['CS_IDLE']:
+        exposure_status = self.get_exposure_status(handle)
+        if exposure_status != 'CS_IDLE':
             self.logger.warning('Attempt to start exposure on {} while camera busy!'.format(
                 self._ccd_info[handle]['serial number']))
             # Wait until camera is idle
-            while query_status_results.status != status_codes['CS_IDLE']:
+            while exposure_status != 'CS_IDLE':
                 self.logger.warning('Waiting for exposure on {} to complete'.format(
                     self._ccd_info[handle]['serial number']))
                 time.sleep(1)
-                with self._command_lock:
-                    self._set_handle(handle)
-                    self._send_command('CC_QUERY_COMMAND_STATUS',
-                                       params=query_status_params,
-                                       results=query_status_results)
+                exposure_status = self.get_exposure_status(handle)
 
         # Check temerature is OK.
         temp_status = self.query_temp_status(handle)
@@ -585,22 +586,14 @@ class SBIGDriver(PanBase):
         image_data = np.zeros((height, width), dtype=np.uint16)
 
         # Check for the end of the exposure.
-        with self._command_lock:
-            self._set_handle(handle)
-            self._send_command('CC_QUERY_COMMAND_STATUS',
-                               params=query_status_params,
-                               results=query_status_results)
+        exposure_status = self.get_exposure_status(handle)
 
         # Poll if needed.
-        while query_status_results.status != status_codes['CS_INTEGRATION_COMPLETE']:
+        while exposure_status != 'CS_INTEGRATION_COMPLETE':
             self.logger.debug('Waiting for exposure on {} to complete'.format(
                 self._ccd_info[handle]['serial number']))
             time.sleep(0.1)
-            with self._command_lock:
-                self._set_handle(handle)
-                self._send_command('CC_QUERY_COMMAND_STATUS',
-                                   params=query_status_params,
-                                   results=query_status_results)
+            exposure_status = self.get_exposure_status(handle)
 
         self.logger.debug('Exposure on {} complete'.format(self._ccd_info[handle]['serial number']))
 

--- a/pocs/camera/sbigudrv.py
+++ b/pocs/camera/sbigudrv.py
@@ -213,7 +213,7 @@ class SBIGDriver(PanBase):
             self._send_command('CC_SET_TEMPERATURE_REGULATION2', params=set_freeze_params)
 
     def get_exposure_status(self, handle):
-        """  """
+        """Returns the current exposure status of the camera, e.g. 'CS_IDLE', 'CS_INTEGRATING' """
         query_status_params = QueryCommandStatusParams(command_codes['CC_START_EXPOSURE2'])
         query_status_results = QueryCommandStatusResults()
 

--- a/pocs/camera/simulator.py
+++ b/pocs/camera/simulator.py
@@ -17,8 +17,14 @@ class Camera(AbstractCamera):
 
     def __init__(self, name='Simulated Camera', *args, **kwargs):
         super().__init__(name, *args, **kwargs)
+        self._is_exposing = False
         self.logger.debug("Initializing simulated camera")
         self.connect()
+
+    @property
+    def is_exposing(self):
+        """ True if an exposure is currently under way, otherwise False """
+        return self._is_exposing
 
     def connect(self):
         """ Connect to camera simulator
@@ -75,6 +81,7 @@ class Camera(AbstractCamera):
                                 function=self._fake_exposure,
                                 args=[filename, header, exposure_event])
         exposure_thread.start()
+        self._is_exposing = True
 
         if blocking:
             exposure_event.wait()
@@ -95,7 +102,7 @@ class Camera(AbstractCamera):
             fake_data = np.random.randint(low=975, high=1026,
                                           size=fake_data.shape,
                                           dtype=fake_data.dtype)
-
+        self._is_exposing = False
         fits_utils.write_fits(fake_data, header, filename, self.logger, exposure_event)
 
     def _process_fits(self, file_path, info):

--- a/pocs/filterwheel/filterwheel.py
+++ b/pocs/filterwheel/filterwheel.py
@@ -160,7 +160,7 @@ class AbstractFilterWheel(PanBase):
             'g_04'
         """
         assert self.is_connected, self.logger.error("Filter wheel must be connected to move")
-        if self.camera.is_exposing:
+        if self.camera and self.camera.is_exposing:
             msg = "Attempt to move filter wheel {} while camera is exposing, ignoring".format(self)
             raise error.PanError(msg)
 

--- a/pocs/filterwheel/filterwheel.py
+++ b/pocs/filterwheel/filterwheel.py
@@ -4,6 +4,7 @@ from astropy import units as u
 
 from pocs.base import PanBase
 from pocs.utils import listify
+from pocs.utils import error
 
 
 class AbstractFilterWheel(PanBase):
@@ -159,6 +160,10 @@ class AbstractFilterWheel(PanBase):
             'g_04'
         """
         assert self.is_connected, self.logger.error("Filter wheel must be connected to move")
+        if self.camera.is_exposing:
+            msg = "Attempt to move filter wheel {} while camera is exposing, ignoring".format(self)
+            raise error.PanError(msg)
+
         position = self._parse_position(position)
         self.logger.info("Moving {} to position {} ({})".format(
             self, position, self.filter_names[position - 1]))

--- a/pocs/tests/test_camera.py
+++ b/pocs/tests/test_camera.py
@@ -249,14 +249,20 @@ def test_exposure(camera, tmpdir):
     Tests basic take_exposure functionality
     """
     fits_path = str(tmpdir.join('test_exposure.fits'))
+    assert not camera.is_exposing
     # A one second normal exposure.
-    camera.take_exposure(filename=fits_path)
+    exp_event = camera.take_exposure(filename=fits_path)
+    assert camera.is_exposing
+    assert not exp_event.is_set()
     # By default take_exposure is non-blocking, need to give it some time to complete.
     if isinstance(camera, FLICamera):
         time.sleep(10)
     else:
         time.sleep(5)
+    # Output file should exist, Event should be set and camera should say it's not exposing.
     assert os.path.exists(fits_path)
+    assert exp_event.is_set()
+    assert not camera.is_exposing
     # If can retrieve some header data there's a good chance it's a valid FITS file
     header = fits_utils.getheader(fits_path)
     assert header['EXPTIME'] == 1.0

--- a/pocs/tests/test_filterwheel.py
+++ b/pocs/tests/test_filterwheel.py
@@ -169,4 +169,5 @@ def test_move_exposing(tmpdir, caplog):
     with pytest.raises(error.PanError):
         sim_camera.filterwheel.move_to(2, blocking=True)  # Attempt to move while camera is exposing
     assert caplog.records[-1].levelname == 'ERROR'
+    assert sim_camera.filterwheel.position == 1  # Should not have moved
     exp_event.wait()


### PR DESCRIPTION
Fixes #775 by preventing a filter wheel from moving if the associated camera is currently taking an exposure. In the process added an `is_exposing` property to the `AbstractCamera` base class, with implementations for the SBIG, FLI and simulator `Camera` classes.