### PR TITLE
Implement is_exposing property for ZWO

### DIFF
--- a/pocs/camera/zwo.py
+++ b/pocs/camera/zwo.py
@@ -221,6 +221,11 @@ class Camera(AbstractCamera):
         return self._info['e_per_adu']
 
     @property
+    def is_exposing(self):
+        """ True if an exposure is currently under way, otherwise False """
+        return Camera._ASIDriver.get_exposure_status(self._camera_ID) == "WORKING"
+
+    @property
     def properties(self):
         """ A collection of camera properties as read from the camera """
         return self._info


### PR DESCRIPTION
Implements missing `is_exposing` property for the ZWO `Camera` class. This property was added to the simulator, SBIG and FLI `Camera` classes while the ZWO class was still under development so the ZWO class didn't get one at that time.

Needed for #775.