### PR TITLE
Prevent camera exposures when filterwheel is moving

### DIFF
--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -267,6 +267,11 @@ class AbstractCamera(PanBase):
 
         assert filename is not None, self.logger.error("Must pass filename for take_exposure")
 
+        if self.filterwheel and self.filterwheel.is_moving:
+            msg = "Attempt to start exposure on {} while filterwheel is moving, ignoring.".format(
+                self)
+            raise error.PanError(msg)
+
         if not isinstance(seconds, u.Quantity):
             seconds = seconds * u.second
 

--- a/pocs/filterwheel/filterwheel.py
+++ b/pocs/filterwheel/filterwheel.py
@@ -75,6 +75,11 @@ class AbstractFilterWheel(PanBase):
         return self._connected
 
     @property
+    def is_moving(self):
+        """ Is the filterwheel currently moving """
+        raise NotImplementedError
+
+    @property
     def camera(self):
         """
         Reference to the Camera object that the FilterWheel is assigned to, if any. A filter wheel
@@ -161,7 +166,7 @@ class AbstractFilterWheel(PanBase):
         """
         assert self.is_connected, self.logger.error("Filter wheel must be connected to move")
         if self.camera and self.camera.is_exposing:
-            msg = "Attempt to move filter wheel {} while camera is exposing, ignoring".format(self)
+            msg = "Attempt to move filter wheel {} while camera is exposing, ignoring.".format(self)
             raise error.PanError(msg)
 
         position = self._parse_position(position)

--- a/pocs/filterwheel/sbig.py
+++ b/pocs/filterwheel/sbig.py
@@ -67,7 +67,7 @@ class FilterWheel(AbstractFilterWheel):
         """ Is the filterwheel currently moving """
         status = self._SBIGDriver.cfw_query(self._handle)
         if status['status'] == 'UNKNOWN':
-            self.logger.warning("{} returned 'UNKNOWN' status".self)
+            self.logger.warning("{} returned 'UNKNOWN' status".format(self))
         return bool(status['status'] == 'BUSY')
 
 ##################################################################################################

--- a/pocs/filterwheel/sbig.py
+++ b/pocs/filterwheel/sbig.py
@@ -62,6 +62,14 @@ class FilterWheel(AbstractFilterWheel):
             self.logger.warning("Filter wheel position unknown, returning NaN")
         return status['position']
 
+    @property
+    def is_moving(self):
+        """ Is the filterwheel currently moving """
+        status = self._SBIGDriver.cfw_query(self._handle)
+        if status['status'] == 'UNKNOWN':
+            self.logger.warning("{} returned 'UNKNOWN' status".self)
+        return bool(status['status'] == 'BUSY')
+
 ##################################################################################################
 # Methods
 ##################################################################################################

--- a/pocs/filterwheel/simulator.py
+++ b/pocs/filterwheel/simulator.py
@@ -64,6 +64,11 @@ class FilterWheel(AbstractFilterWheel):
             self.logger.warning("Filter wheel position unknown, returning NaN")
         return self._position
 
+    @property
+    def is_moving(self):
+        """ Is the filterwheel currently moving """
+        return self._moving
+
 ##################################################################################################
 # Methods
 ##################################################################################################

--- a/pocs/tests/test_filterwheel.py
+++ b/pocs/tests/test_filterwheel.py
@@ -171,3 +171,12 @@ def test_move_exposing(tmpdir, caplog):
     assert caplog.records[-1].levelname == 'ERROR'
     assert sim_camera.filterwheel.position == 1  # Should not have moved
     exp_event.wait()
+
+
+def test_is_moving(filterwheel):
+    filterwheel.position = 1
+    assert not filterwheel.is_moving
+    e = filterwheel.move_to(2)
+    assert filterwheel.is_moving
+    e.wait()
+    assert not filterwheel.is_moving


### PR DESCRIPTION
Addresses #777 by implementing an `is_moving` property for filterwheels and checking it in the `take_exposure()` method of the `Camera` classes.