### PR TITLE
Simulator Camera creation no longer requires dummy camera config entries

### DIFF
--- a/pocs/camera/__init__.py
+++ b/pocs/camera/__init__.py
@@ -87,11 +87,9 @@ def create_cameras_from_config(config=None, logger=None, **kwargs):
             return cameras
         else:
             # Create a minimal dummy camera config to get a simulated camera
-            camera_info = [{'autodetect': False,
-                            'devices': [
-                                {'model': 'simulator'},
-                                ]
-                            }, ]
+            camera_info = {'autodetect': False,
+                           'devices': [
+                               {'model': 'simulator'}, ]}
 
     logger.debug("Camera config: {}".format(camera_info))
 

--- a/pocs/camera/__init__.py
+++ b/pocs/camera/__init__.py
@@ -74,17 +74,27 @@ def create_cameras_from_config(config=None, logger=None, **kwargs):
     def kwargs_or_config(item, default=None):
         return kwargs.get(item, config.get(item, default))
 
-    cameras = OrderedDict()
-    camera_info = kwargs_or_config('cameras')
-    if not camera_info:
-        logger.info('No camera information in config.')
-        return cameras
-
-    logger.debug("Camera config: {}".format(camera_info))
-
     simulator_names = hardware.get_simulator_names(config=config, kwargs=kwargs)
     logger.debug(f'simulator_names = {", ".join(simulator_names)}')
     a_simulator = 'camera' in simulator_names
+
+    cameras = OrderedDict()
+    camera_info = kwargs_or_config('cameras')
+    if not camera_info:
+        # cameras section either missing or empty
+        if not a_simulator:
+            logger.info('No camera information in config.')
+            return cameras
+        else:
+            # Create a minimal dummy camera config to get a simulated camera
+            camera_info = [{'autodetect': False,
+                            'devices': [
+                                {'model': 'simulator'},
+                                ]
+                            }, ]
+
+    logger.debug("Camera config: {}".format(camera_info))
+
     auto_detect = camera_info.get('auto_detect', False)
 
     ports = list()

--- a/pocs/tests/test_camera.py
+++ b/pocs/tests/test_camera.py
@@ -118,6 +118,13 @@ def test_create_cameras_from_empty_config():
     assert len(cameras) == 1
 
 
+def test_dont_create_cameras_from_empty_config():
+    # Can't pass a completely empty config otherwise default config will get loaded in its place.
+    really_empty_config = {'i_need_to_evaluate_to': True}
+    cameras = create_cameras_from_config(config=really_empty_config)
+    assert len(cameras) == 0
+
+
 # Hardware independent tests, mostly use simulator:
 
 def test_sim_create_focuser():

--- a/pocs/tests/test_camera.py
+++ b/pocs/tests/test_camera.py
@@ -111,6 +111,13 @@ def test_create_cameras_from_config_fail(config):
         create_cameras_from_config(config, simulator=simulator)
 
 
+def test_create_cameras_from_empty_config():
+    # create_cameras_from_cpnfig should work with no camera config, if cameras simulation is set
+    empty_config = {'simulator': ['camera', ], }
+    cameras = create_cameras_from_config(config=empty_config)
+    assert len(cameras) == 1
+
+
 # Hardware independent tests, mostly use simulator:
 
 def test_sim_create_focuser():

--- a/pocs/tests/test_camera.py
+++ b/pocs/tests/test_camera.py
@@ -112,7 +112,7 @@ def test_create_cameras_from_config_fail(config):
 
 
 def test_create_cameras_from_empty_config():
-    # create_cameras_from_cpnfig should work with no camera config, if cameras simulation is set
+    # create_cameras_from_config should work with no camera config, if cameras simulation is set
     empty_config = {'simulator': ['camera', ], }
     cameras = create_cameras_from_config(config=empty_config)
     assert len(cameras) == 1


### PR DESCRIPTION
Fixes #733 by creating a dummy camera config if camera simulation is enabled and the camera config section is either absent or empty.