### PR TITLE
Refactor Camera and Driver classes

### DIFF
--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -285,7 +285,7 @@ class AbstractCamera(PanBase):
 
         header = self._fits_header(seconds, dark)
 
-        if not self._exposure_event.is_set:
+        if not self._exposure_event.is_set():
             self.logger.warning('Exposure started on {} while one in progress! Waiting.'.format(
                 self))
             self._exposure_event.wait()

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -294,7 +294,7 @@ class AbstractCamera(PanBase):
         self._exposure_event.clear()
 
         try:
-            # Cmmera type specific exposure set up and start
+            # Camera type specific exposure set up and start
             readout_args = self._start_exposure(seconds, filename, dark, header, *args, *kwargs)
         except (RuntimeError, ValueError, error.PanError) as err:
             self._exposure_event.set()

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -293,11 +293,8 @@ class AbstractCamera(PanBase):
         # Clear event now to prevent any other exposures starting before this one is finsihed.
         self._exposure_event.clear()
 
-        # Cmmera type specific exposure set up
-        readout_args = self._setup_exposure(seconds, filename, dark, header, *args, *kwargs)
-
-        # Camera type specific exposure start
-        self._start_exposure()
+        # Cmmera type specific exposure set up and start
+        readout_args = self._start_exposure(seconds, filename, dark, header, *args, *kwargs)
 
         # Start polling thread that will call camera type specific _readout method when done
         readout_thread = threading.Timer(interval=get_quantity_value(seconds, unit=u.second),
@@ -465,9 +462,6 @@ class AbstractCamera(PanBase):
             os.unlink(file_path)
         thumbnail = img_utils.crop_data(image, box_width=thumbnail_size)
         return thumbnail
-
-    def _setup_exposure(self, *args, **kwargs):
-        raise NotImplementedError
 
     def _start_exposure(self):
         raise NotImplementedError

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -290,7 +290,7 @@ class AbstractCamera(PanBase):
                 self))
             self._exposure_event.wait()
 
-        # Clear event now to prevent any other exposures starting before this one is finsihed.
+        # Clear event now to prevent any other exposures starting before this one is finished.
         self._exposure_event.clear()
 
         try:

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -473,13 +473,11 @@ class AbstractCamera(PanBase):
     def _poll_exposure(self, readout_args):
         timer = CountdownTimer(duration=self._timeout)
         try:
-            is_exposing = self.is_exposing
-            while is_exposing:
+            while self._is_exposing:
                 if timer.expired():
                     msg = "Timeout waiting for exposure on {} to complete".format(self)
                     raise error.Timeout(msg)
                 time.sleep(0.01)
-                is_exposing = self.is_exposing
         except (RuntimeError, error.PanError) as err:
             # Error returned by driver at some point while polling
             self.logger.error('Error while waiting for exposure on {}: {}'.format(self, err))
@@ -488,7 +486,7 @@ class AbstractCamera(PanBase):
             # Camera type specific readout function
             self._readout(*readout_args)
         finally:
-            self._exposure_event.set()  # write_fits will have already set this, *if* it got called.
+            self._exposure_event.set()  # Need to make sure this gets set regardless of any errors
 
     def _readout(self, *args):
         raise NotImplementedError

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -69,12 +69,14 @@ class AbstractCamera(PanBase):
         self.is_primary = primary
 
         self._filter_type = kwargs.get('filter_type', 'RGGB')
-
-        self._connected = False
         self._serial_number = kwargs.get('serial_number', 'XXXXXX')
         self._readout_time = kwargs.get('readout_time', 5.0)
         self._file_extension = kwargs.get('file_extension', 'fits')
+        self._timeout = get_quantity_value(kwargs.get('timeout'), unit=u.second)
+
+        self._connected = False
         self._current_observation = None
+        self._exposure_event = threading.Event
 
         self._create_subcomponent(subcomponent=focuser,
                                   sub_name='focuser',

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -307,6 +307,7 @@ class AbstractCamera(PanBase):
         readout_thread.start()
 
         if blocking:
+            self.logger.debug("Blocking on exposure event for {}".format(self))
             self._exposure_event.wait()
 
         return self._exposure_event

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -480,7 +480,7 @@ class AbstractCamera(PanBase):
                     raise error.Timeout(msg)
                 time.sleep(0.01)
                 is_exposing = self.is_exposing
-        except RuntimeError as err:
+        except (RuntimeError, error.PanError) as err:
             # Error returned by driver at some point while polling
             self.logger.error('Error while waiting for exposure on {}: {}'.format(self, err))
             raise err

--- a/pocs/camera/fli.py
+++ b/pocs/camera/fli.py
@@ -73,9 +73,9 @@ class Camera(AbstractSDKCamera):
         return True
 
     @ccd_cooling_enabled.setter
-    def ccd_cooling_enabled(self, enabled):
+    def ccd_cooling_enabled(self, enable):
         # Cooling is always enabled on FLI cameras
-        if not enabled:
+        if not enable:
             raise error.NotSupported("Cannot disable cooling on {}".format(self.name))
 
     @property

--- a/pocs/camera/fli.py
+++ b/pocs/camera/fli.py
@@ -1,5 +1,4 @@
 import time
-import re
 from warnings import warn
 from threading import Event
 from threading import Timer
@@ -10,129 +9,42 @@ import numpy as np
 
 from astropy import units as u
 
-from pocs.camera.camera import AbstractCamera
-from pocs.camera import libfli
+from pocs.camera.sdk import AbstractSDKCamera
+from pocs.camera.libfli import FLIDriver
 from pocs.camera import libfliconstants as c
 from pocs.utils.images import fits as fits_utils
-from pocs.utils.logger import get_root_logger
-
-# FLI camera serial numbers have pairs of letters followed by a sequence of numbers
-serial_number_pattern = re.compile(r'^(ML|PL|KL|HP)\d+$')
+from pocs.utils import error
 
 
-class Camera(AbstractCamera):
-
-    # Class variable to cache the device node scanning results
-    _fli_nodes = None
-
-    # Class variable to store the device nodes already in use. Prevents scanning known Birgers &
-    # acts as a check against Birgers assigned to incorrect ports.
-    _assigned_nodes = []
+class Camera(AbstractSDKCamera):
+    _driver = None
+    _cameras = {}
+    _assigned_cameras = set()
 
     def __init__(self,
                  name='FLI Camera',
                  set_point=25 * u.Celsius,
                  filter_type='M',
-                 library_path=None,
                  *args, **kwargs):
-        # FLI cameras should be specified by either serial number (preferred) or 'port' (device
-        # node). For backwards compatibility reasons allow port to be used as an alias of serial
-        # number. If both are given serial number takes precedence
-        kwargs['readout_time'] = kwargs.get('readout_time', 1.0)
-        kwargs['file_extension'] = 'fits'
-
-        # Create a Lock that will be used to prevent overlapping exposures.
-        self._exposure_lock = Lock()
-
-        # Create an instance of the FLI Driver interface
-        self._FLIDriver = libfli.FLIDriver(library_path)
-
-        # Would usually use self.logger but that won't exist until after calling super().__init__(),
-        # and don't want to do that until after the serial number and port have both been determined
-        # in order to avoid log entries with misleading values. To enable logging during the device
-        # scanning phase use get_root_logger() instead.
-        logger = get_root_logger()
-
-        if kwargs.get('serial_number') or serial_number_pattern.match(kwargs.get('port')):
-            # Have been given a serial number instead of a device node
-            kwargs['serial_number'] = kwargs.get('serial_number', kwargs.get('port'))
-            logger.debug('Looking for {} ({})...'.format(name, kwargs['serial_number']))
-
-            if Camera._fli_nodes is None:
-                # No cached device nodes scanning results. 1st get list of all FLI cameras
-                logger.debug('Getting serial numbers for all connected FLI cameras')
-                Camera._fli_nodes = {}
-                device_list = self._FLIDriver.FLIList(interface_type=c.FLIDOMAIN_USB,
-                                                      device_type=c.FLIDEVICE_CAMERA)
-                if not device_list:
-                    message = 'No FLI camera devices found!'
-                    logger.error(message)
-                    warn(message)
-                    return
-
-                # Get serial numbers for all connected FLI cameras
-                for device in device_list:
-                    handle = self._FLIDriver.FLIOpen(port=device[0])
-                    serial_number = self._FLIDriver.FLIGetSerialString(handle)
-                    self._FLIDriver.FLIClose(handle)
-                    Camera._fli_nodes[serial_number] = device[0]
-                logger.debug('Connected FLI cameras: {}'.format(Camera._fli_nodes))
-
-            # Search in cached device node scanning results for serial number.
-            try:
-                device_node = Camera._fli_nodes[kwargs['serial_number']]
-            except KeyError:
-                message = 'Could not find {} ({})!'.format(name, kwargs['serial_number'])
-                logger.error(message)
-                warn(message)
-                return
-            logger.debug('Found {} ({}) on {}'.format(
-                name, kwargs['serial_number'], device_node))
-            kwargs['port'] = device_node
-
-        if kwargs['port'] in Camera._assigned_nodes:
-            message = 'Device node {} already in use!'.format(kwargs['port'])
-            logger.error(message)
-            warn(message)
-            return
-
-        super().__init__(name, *args, **kwargs)
-        self.connect()
-        Camera._assigned_nodes.append(self.port)
-        self.filter_type = filter_type
-
-        if self.is_connected:
-            self.ccd_set_point = set_point
-            self.logger.info('{} initialised'.format(self))
+        kwargs['timeout'] = kwargs.get('timeout', 5)
+        super().__init__(name, FLIDriver, *args, **kwargs)
+        self.logger.info('{} initialised'.format(self))
 
     def __del__(self):
         with suppress(AttributeError):
-            device_node = self.port
-            Camera._assigned_nodes.remove(device_node)
-            self.logger.debug('Removed {} from assigned nodes list'.fomat(device_node))
-        with suppress(AttributeError):
             handle = self._handle
-            self._FLIDriver.FLIClose(handle)
+            self._driver.FLIClose(handle)
             self.logger.debug('Closed FLI camera handle {}'.format(handle.value))
+        super().__del__()
 
 # Properties
-
-    @AbstractCamera.uid.getter
-    def uid(self):
-        """Return unique identifier for camera.
-
-        Need to overide this because the base class only returns the 1st
-        6 characters of the serial number, which is not a unique identifier
-        for most of the camera types
-        """
-        return self._serial_number
 
     @property
     def ccd_temp(self):
         """
         Current temperature of the camera's image sensor.
         """
-        return self._FLIDriver.FLIGetTemperature(self._handle)
+        return self._driver.FLIGetTemperature(self._handle)
 
     @property
     def ccd_set_point(self):
@@ -147,7 +59,7 @@ class Camera(AbstractCamera):
     @ccd_set_point.setter
     def ccd_set_point(self, set_point):
         self.logger.debug("Setting {} cooling set point to {}".format(self.name, set_point))
-        self._FLIDriver.FLISetTemperature(self._handle, set_point)
+        self._driver.FLISetTemperature(self._handle, set_point)
         if isinstance(set_point, u.Quantity):
             self._set_point = set_point
         else:
@@ -172,17 +84,12 @@ class Camera(AbstractCamera):
         Current power level of the camera's image sensor cooling system (as
         a percentage of the maximum).
         """
-        return self._FLIDriver.FLIGetCoolerPower(self._handle)
+        return self._driver.FLIGetCoolerPower(self._handle)
 
     @property
     def is_exposing(self):
         """ True if an exposure is currently under way, otherwise False """
-        return bool(self._FLIDriver.FLIGetExposureStatus(self._handle).value)
-
-    @property
-    def properties(self):
-        """ A collection of camera properties as read from the camera """
-        return self._info
+        return bool(self._driver.FLIGetExposureStatus(self._handle).value)
 
 # Methods
 
@@ -192,31 +99,18 @@ class Camera(AbstractCamera):
 
         Gets a 'handle', serial number and specs/capabilities from the driver
         """
-        self.logger.debug('Connecting to {} on {}'.format(self.name, self.port))
-
-        # Get handle from the SBIGDriver.
-        self._handle = self._FLIDriver.FLIOpen(port=self.port)
+        self.logger.debug('Connecting to {}'.format(self))
+        self._handle = self._driver.FLIOpen(port=self._address)
         if self._handle == c.FLI_INVALID_DEVICE:
-            message = 'Could not connect to {} on {}!'.format(self.name, self.port)
-            self.logger.error(message)
-            warn(message)
-            self._connected = False
-            return
-
-        self._connected = True
+            message = 'Could not connect to {} on {}!'.format(self.name, self._camera_address)
+            raise error.PanError(message)
         self._get_camera_info()
-        self._serial_number = self._info['serial number']
         self.model = self._info['camera model']
-        self.logger.debug("{} connected".format(self))
+        self._connected = True
 
 # Private Methods
 
-    def _take_exposure(self, seconds, filename, dark, exposure_event, header, *args, **kwargs):
-        if not self._exposure_lock.acquire(blocking=False):
-            self.logger.warning('Exposure started on {} while one in progress! Waiting.'.format(
-                self))
-            self._exposure_lock.acquire(blocking=True)
-
+    def _start_exposure(self, seconds, filename, dark, header, *args, **kwargs):
         self._FLIDriver.FLISetExposureTime(self._handle, exposure_time=seconds)
 
         if dark:
@@ -239,44 +133,32 @@ class Camera(AbstractCamera):
         self._FLIDriver.FLISetNFlushes(self._handle, n_flushes=0)
 
         # In principle can set bit depth here (16 or 8 bit) but most FLI cameras don't support it.
-        # Leave alone for now.
 
         # Start exposure
         self._FLIDriver.FLIExposeFrame(self._handle)
 
-        # Start readout thread
         readout_args = (filename,
                         self._info['visible width'],
                         self._info['visible height'],
                         header,
                         exposure_event)
-        readout_thread = Timer(interval=self._FLIDriver.FLIGetExposureStatus(self._handle).value,
-                               function=self._readout,
-                               args=readout_args)
-        readout_thread.start()
+        return readout_args
 
-    def _readout(self, filename, width, height, header, exposure_event):
-
-        # Wait for exposure to complete. This should have a timeout in case something goes wrong.
-        while self._FLIDriver.FLIGetExposureStatus(self._handle) > 0 * u.second:
-            time.sleep(self._FLIDriver.FLIGetExposureStatus(self._handle).value)
-
-        # Readout.
+    def _readout(self, filename, width, height, header):
         # Use FLIGrabRow for now at least because I can't get FLIGrabFrame to work.
         # image_data = self._FLIDriver.FLIGrabFrame(self._handle, width, height)
         image_data = np.zeros((height, width), dtype=np.uint16)
-        for i in range(image_data.shape[0]):
-            try:
+        rows_got = 0
+        try:
+            for i in range(image_data.shape[0]):
                 image_data[i] = self._FLIDriver.FLIGrabRow(self._handle, image_data.shape[1])
-            except RuntimeError as err:
-                message = 'Readout error: expected {} rows, got {}!'.format(image_data.shape[0], i)
-                self.logger.error(message)
-                self.logger.error(err)
-                warn(message)
-                break
-
-        fits_utils.write_fits(image_data, header, filename, self.logger, exposure_event)
-        self._exposure_lock.release()
+                rows_got += 1
+        except RuntimeError as err:
+            message = 'Readout error, expected {} rows, got {}: {}'.format(
+                image_data.shape[0], rows_got, err)
+            raise error.PanError(message)
+        else:
+            fits_utils.write_fits(image_data, header, filename, self.logger, self._exposure_event)
 
     def _fits_header(self, seconds, dark):
         header = super()._fits_header(seconds, dark)
@@ -290,14 +172,14 @@ class Camera(AbstractCamera):
 
     def _get_camera_info(self):
 
-        serial_number = self._FLIDriver.FLIGetSerialString(self._handle)
-        camera_model = self._FLIDriver.FLIGetModel(self._handle)
-        hardware_version = self._FLIDriver.FLIGetHWRevision(self._handle)
-        firmware_version = self._FLIDriver.FLIGetFWRevision(self._handle)
+        serial_number = self._driver.FLIGetSerialString(self._handle)
+        camera_model = self._driver.FLIGetModel(self._handle)
+        hardware_version = self._driver.FLIGetHWRevision(self._handle)
+        firmware_version = self._driver.FLIGetFWRevision(self._handle)
 
-        pixel_width, pixel_height = self._FLIDriver.FLIGetPixelSize(self._handle)
-        ccd_corners = self._FLIDriver.FLIGetArrayArea(self._handle)
-        visible_corners = self._FLIDriver.FLIGetVisibleArea(self._handle)
+        pixel_width, pixel_height = self._driver.FLIGetPixelSize(self._handle)
+        ccd_corners = self._driver.FLIGetArrayArea(self._handle)
+        visible_corners = self._driver.FLIGetVisibleArea(self._handle)
 
         self._info = {
             'serial number': serial_number,

--- a/pocs/camera/fli.py
+++ b/pocs/camera/fli.py
@@ -61,7 +61,7 @@ class Camera(AbstractSDKCamera):
             set_point = set_point * u.Celsius
         self.logger.debug("Setting {} cooling set point to {}".format(self, set_point))
         self._driver.FLISetTemperature(self._handle, set_point)
-        self._set_point = set_point * u.Celsius
+        self._set_point = set_point
 
     @property
     def ccd_cooling_enabled(self):

--- a/pocs/camera/libasi.py
+++ b/pocs/camera/libasi.py
@@ -64,7 +64,8 @@ class ASIDriver(AbstractSDKDriver):
         # Get the IDs
         cameras = {}
         for camera_index in range(n_cameras):
-            # Can get IDs without opening cameras by parsing the name string
+            # Can get IDs without opening cameras by parsing the 'name' string, which has the format
+            # "model(string_id)" if the string ID has been set, otherwise it is just the model name.
             info = self.get_camera_property(camera_index)
             model, _, string_id = info['name'].partition('(')
             if not string_id:

--- a/pocs/camera/libasi.py
+++ b/pocs/camera/libasi.py
@@ -52,8 +52,10 @@ class ASIDriver(AbstractSDKDriver):
         return version
 
     def get_cameras(self):
-        """Convenience function to get a dictionary of all currently connected camera string IDs
-        and their corresponding integer camera IDs.
+        """Gets currently connected camera info.
+
+        Returns:
+            dict: All currently connected camera string IDs with corresponding integer camera IDs.
         """
         n_cameras = self.get_num_of_connected_cameras()
         if n_cameras == 0:

--- a/pocs/camera/libasi.py
+++ b/pocs/camera/libasi.py
@@ -4,9 +4,8 @@ import enum
 import numpy as np
 from astropy import units as u
 
-from pocs.base import PanBase
+from pocs.camera.sdk import AbstractSDKDriver
 from pocs.utils import error
-from pocs.utils.library import load_library
 from pocs.utils import get_quantity_value
 
 ####################################################################################################
@@ -19,8 +18,8 @@ from pocs.utils import get_quantity_value
 ####################################################################################################
 
 
-class ASIDriver(PanBase):
-    def __init__(self, library_path=None, *args, **kwargs):
+class ASIDriver(AbstractSDKDriver):
+    def __init__(self, library_path=None, **kwargs):
         """Main class representing the ZWO ASI library interface.
 
         On construction loads the shared object/dynamically linked version of the ASI SDK library,
@@ -40,17 +39,7 @@ class ASIDriver(PanBase):
                 locate the library.
             OSError: raises if the ctypes.CDLL loader cannot load the library.
         """
-        super().__init__(*args, **kwargs)
-        library = load_library(name='ASICamera2', path=library_path, logger=self.logger)
-        self._CDLL = library
-        self._version = self.get_SDK_version()
-
-    # Properties
-
-    @property
-    def version(self):
-        """ Version of the ZWO ASI SDK """
-        return self._version
+        super().__init__(name='ASICamera2', path=library_path, **kwargs)
 
     # Methods
 

--- a/pocs/camera/libasi.py
+++ b/pocs/camera/libasi.py
@@ -39,7 +39,7 @@ class ASIDriver(AbstractSDKDriver):
                 locate the library.
             OSError: raises if the ctypes.CDLL loader cannot load the library.
         """
-        super().__init__(name='ASICamera2', path=library_path, **kwargs)
+        super().__init__(name='ASICamera2', library_path=library_path, **kwargs)
 
     # Methods
 

--- a/pocs/camera/libfli.py
+++ b/pocs/camera/libfli.py
@@ -10,8 +10,7 @@ import numpy as np
 
 import astropy.units as u
 
-from pocs.base import PanBase
-from pocs.utils.library import load_library
+from pocs.camera.sdk import AbstractSDKDriver
 import pocs.camera.libfliconstants as c
 
 valid_values = {'interface type': (c.FLIDOMAIN_PARALLEL_PORT,
@@ -36,9 +35,9 @@ valid_values = {'interface type': (c.FLIDOMAIN_PARALLEL_PORT,
 ################################################################################
 
 
-class FLIDriver(PanBase):
+class FLIDriver(AbstractSDKDriver):
 
-    def __init__(self, library_path=None, *args, **kwargs):
+    def __init__(self, library_path=None, **kwargs):
         """
         Main class representing the FLI library interface. On construction loads
         the shared object/dynamically linked version of the FLI library, which
@@ -62,22 +61,16 @@ class FLIDriver(PanBase):
                 locate the library.
             OSError: raises if the ctypes.CDLL loader cannot load the library.
         """
-        super().__init__(*args, **kwargs)
-        self._CDLL = load_library(name='fli', path=library_path, logger=self.logger)
+        super().__init__(name='fli', library_path=library_path, **kwargs)
 
+    # Public methods
+
+    def get_SDK_version(self):
         # Get library version.
         version = ctypes.create_string_buffer(64)
         length = ctypes.c_size_t(64)
         self._call_function('getting library version', self._CDLL.FLIGetLibVersion, version, length)
-        self._version = version.value.decode('ascii')
-
-    # Properties
-
-    @property
-    def version(self):
-        return self._version
-
-    # Public methods
+        return version.value.decode('ascii')
 
     def FLIList(self, interface_type=c.FLIDOMAIN_USB, device_type=c.FLIDEVICE_CAMERA):
         """

--- a/pocs/camera/libfli.py
+++ b/pocs/camera/libfli.py
@@ -85,10 +85,20 @@ class FLIDriver(AbstractSDKDriver):
         cameras = {}
         for device in device_list:
             port = device[0]
-            handle = self.FLIOpen(port)
-            serial_number = self.FLIGetSerialString(handle)
-            self.FLIClose(handle)
-            cameras[serial_number] = port
+            try:
+                handle = self.FLIOpen(port)
+            except RuntimeError as err:
+                self.logger.error("Couldn't open FLI camera at {}: {}".format(port, err))
+            else:
+                try:
+                    serial_number = self.FLIGetSerialString(handle)
+                except RuntimeError as err:
+                    self.logger.error("Couldn't get serial number from FLI camera at {}: {}".format(
+                        port, err))
+                else:
+                    cameras[serial_number] = port
+            finally:
+                self.FLIClose(handle)
 
         return cameras
 

--- a/pocs/camera/libfli.py
+++ b/pocs/camera/libfli.py
@@ -74,8 +74,10 @@ class FLIDriver(AbstractSDKDriver):
         return version.value.decode('ascii')
 
     def get_cameras(self):
-        """Convenience function to get a dictionary of all currently connected camera serial numbers
-        and their corresponding device nodes.
+        """Gets currently connected camera info.
+
+        Returns:
+            dict: All currently connected camera serial numbers with corresponding device nodes.
         """
         device_list = self.FLIList(interface_type=c.FLIDOMAIN_USB,
                                    device_type=c.FLIDEVICE_CAMERA)

--- a/pocs/camera/libfli.py
+++ b/pocs/camera/libfli.py
@@ -12,6 +12,7 @@ from astropy import units as u
 from pocs.camera.sdk import AbstractSDKDriver
 from pocs.camera import libfliconstants as c
 from pocs.utils import error
+from pocs.utils import get_quantity_value
 
 valid_values = {'interface type': (c.FLIDOMAIN_PARALLEL_PORT,
                                    c.FLIDOMAIN_USB,
@@ -268,9 +269,7 @@ class FLIDriver(AbstractSDKDriver):
                 to. A simple numeric type can be given instead of a Quantity, in which case the
                 units are assumed to be degrees Celsius.
         """
-        if isinstance(temperature, u.Quantity):
-            temperature = temperature.to(u.Celsius)
-            temperature = temperature.value
+        temperature = get_quantity_value(temperature, unit=u.Celsius)
         temperature = ctypes.c_double(temperature)
 
         self._call_function('setting temperature', self._CDLL.FLISetTemperature,
@@ -301,9 +300,7 @@ class FLIDriver(AbstractSDKDriver):
                 can be given instead of a Quantity, in which case the units are assumed
                 to be seconds.
         """
-        if isinstance(exposure_time, u.Quantity):
-            exposure_time = exposure_time.to(u.second)
-            exposure_time = exposure_time.value
+        exposure_time = get_quantity_value(exposure_time, unit=u.second)
         milliseconds = ctypes.c_long(int(exposure_time * 1000))
         self._call_function('setting exposure time', self._CDLL.FLISetExposureTime,
                             handle, milliseconds)

--- a/pocs/camera/sbig.py
+++ b/pocs/camera/sbig.py
@@ -71,10 +71,10 @@ class Camera(AbstractSDKCamera):
         return temp_status['cooling_enabled']
 
     @ccd_cooling_enabled.setter
-    def ccd_cooling_enabled(self, enabled):
-        self.logger.debug("Setting {} cooling enabled to {}".format(self.name, enabled))
+    def ccd_cooling_enabled(self, enable):
+        self.logger.debug("Setting {} cooling enabled to {}".format(self.name, enable))
         set_point = self.ccd_set_point
-        self._driver.set_temp_regulation(self._handle, set_point, enabled)
+        self._driver.set_temp_regulation(self._handle, set_point, enable)
 
     @property
     def ccd_cooling_power(self):

--- a/pocs/camera/sbig.py
+++ b/pocs/camera/sbig.py
@@ -3,47 +3,25 @@ from warnings import warn
 
 from astropy import units as u
 
-from pocs.camera import AbstractCamera
+from pocs.camera.sdk import AbstractSDKCamera
 from pocs.camera.sbigudrv import INVALID_HANDLE_VALUE
 from pocs.camera.sbigudrv import SBIGDriver
 
 
-class Camera(AbstractCamera):
-
-    # Class variable to store reference to the one and only one instance of SBIGDriver
-    _SBIGDriver = None
-
-    def __new__(cls, *args, **kwargs):
-        if Camera._SBIGDriver is None:
-            # Creating a camera but there's no SBIGDriver instance yet. Create one.
-            Camera._SBIGDriver = SBIGDriver(*args, **kwargs)
-        return super().__new__(cls)
+class Camera(AbstractSDKCamera):
+    _driver = None
+    _cameras = {}
+    _assigned_cameras = set()
 
     def __init__(self,
                  name='SBIG Camera',
-                 set_point=None,
-                 filter_type=None,
+                 temperature_tolerance=0.5 * u.Celsius,
                  *args, **kwargs):
-        # SBIG cameras don't have a 'port' but should have their serial number specified.
-        # For backwards compatibility purposes allow port to be used as an alias of serial number.
-        kwargs['serial_number'] = kwargs.get('serial_number', kwargs.get('port'))
-        kwargs['port'] = None
-        kwargs['readout_time'] = 1.0
-        kwargs['file_extension'] = 'fits'
-        super().__init__(name, *args, **kwargs)
-        self.connect()
-        if filter_type is not None:
-            # connect() will have set this based on camera info, but that doesn't know about filters
-            # upstream of the CCD. Can be set manually here, or handled by a filterwheel attribute.
-            self._filter_type = filter_type
-        if self.is_connected:
-            # Set and enable cooling, if a set point has been given.
-            if set_point is not None:
-                self.ccd_set_point = set_point
-                self.ccd_cooling_enabled = True
-            else:
-                self.ccd_cooling_enabled = False
-            self.logger.info('{} initialised'.format(self))
+        super().__init__(name, SBIGDriver, *args, **kwargs)
+        if not isinstance(temperature_tolerance, u.Quantity):
+            temperature_tolerance = temperature_tolerance * u.Celsius
+        self._temperature_tolerance = temperature_tolerance
+        self.logger.info('{} initialised'.format(self))
 
 # Properties
 
@@ -62,7 +40,8 @@ class Camera(AbstractCamera):
         """
         Current temperature of the camera's image sensor.
         """
-        return self._SBIGDriver.query_temp_status(self._handle).imagingCCDTemperature * u.Celsius
+        temp_status = self._driver.query_temp_status(self._handle)
+        return temp_status['imaging_ccd_temperature']
 
     @property
     def ccd_set_point(self):
@@ -72,13 +51,16 @@ class Camera(AbstractCamera):
 
         Can be set by assigning an astropy.units.Quantity.
         """
-        return self._SBIGDriver.query_temp_status(self._handle).ccdSetpoint * u.Celsius
+        temp_status = self._driver.query_temp_status(self._handle)
+        return temp_status['ccd_set_point']
 
     @ccd_set_point.setter
     def ccd_set_point(self, set_point):
-        self.logger.debug("Setting {} cooling set point to {}".format(self.name, set_point))
+        if not isinstance(set_point, u.Quantity):
+            set_point = set_point * u.Celsius
+        self.logger.debug("Setting {} cooling set point to {}".format(self, set_point))
         enabled = self.ccd_cooling_enabled
-        self._SBIGDriver.set_temp_regulation(self._handle, set_point, enabled)
+        self._driver.set_temp_regulation(self._handle, set_point, enabled)
 
     @property
     def ccd_cooling_enabled(self):
@@ -87,13 +69,14 @@ class Camera(AbstractCamera):
 
         Can be set by assigning a bool.
         """
-        return bool(self._SBIGDriver.query_temp_status(self._handle).coolingEnabled)
+        temp_status = self._driver.query_temp_status(self._handle)
+        return temp_status['cooling_enabled']
 
     @ccd_cooling_enabled.setter
     def ccd_cooling_enabled(self, enabled):
         self.logger.debug("Setting {} cooling enabled to {}".format(self.name, enabled))
         set_point = self.ccd_set_point
-        self._SBIGDriver.set_temp_regulation(self._handle, set_point, enabled)
+        self._driver.set_temp_regulation(self._handle, set_point, enabled)
 
     @property
     def ccd_cooling_power(self):
@@ -101,33 +84,15 @@ class Camera(AbstractCamera):
         Current power level of the camera's image sensor cooling system (as
         a percentage of the maximum).
         """
-        return self._SBIGDriver.query_temp_status(self._handle).imagingCCDPower * u.percent
+        temp_status = self._driver.query_temp_status(self._handle)
+        return temp_status['imaging_ccd_power']
 
     @property
     def is_exposing(self):
         """ True if an exposure is currently under way, otherwise False """
-        return self._SBIGDriver.get_exposure_status(self._handle) != 'CS_IDLE'
-
-    @property
-    def properties(self):
-        """ A collection of camera properties as read from the camera """
-        return self._info
+        return self._driver.get_exposure_status(self._handle) == 'CS_INTEGRATING'
 
 # Methods
-
-    def __str__(self):
-        # SBIG cameras don't have a port so just include the serial number in the string
-        # representation.
-        s = "{} ({})".format(self.name, self.uid)
-
-        if self.focuser:
-            s += ' with {}'.format(self.focuser.name)
-            if self.filterwheel:
-                s += ' & {}'.format(self.filterwheel.name)
-        elif self.filterwheel:
-            s += ' with {}'.format(self.filterwheel.name)
-
-        return s
 
     def connect(self):
         """
@@ -136,28 +101,32 @@ class Camera(AbstractCamera):
         Gets a 'handle', serial number and specs/capabilities from the driver
         """
         self.logger.debug('Connecting to {}'.format(self))
-
-        # Claim handle from the SBIGDriver, store camera info.
-        self._handle, self._info = self._SBIGDriver.assign_handle(serial=self.uid)
+        # This will close device and driver, ensuring it is ready to access a new camera
+        self._driver.set_handle()
+        self._driver.open_driver()
+        self._driver.open_device(self._address)
+        self._driver.establish_link()
+        link_status = self._driver.get_link_status()
+        if not link_status['established']:
+            raise error.PanError("Could not establish link to {}.".format(self))
+        self._handle = self._driver.get_handle()
         if self._handle == INVALID_HANDLE_VALUE:
-            message = 'Could not connect to {}!'.format(self)
-            self.logger.error(message)
-            warn(message)
-            self._connected = False
-            return
+            raise error.PanError("Could not connect to {}.".format(self))
 
-        self.logger.debug("{} connected".format(self))
-        self._connected = True
-        self._serial_number = self._info['serial number']
-        self.model = self._info['camera name']
-
-        if self._info['colour']:
-            if self._info['Truesense']:
+        self._info = self._driver.get_ccd_info(handle)
+        self.model = self.properties['camera name']
+        if self.properties['colour']:
+            if self.properties['Truesense']:
                 self._filter_type = 'CRGB'
             else:
                 self._filter_type = 'RGGB'
         else:
             self._filter_type = 'M'
+
+        # Stop camera from skipping lowering of Vdd for exposures of 3 seconds of less
+        self._driver.disable_vdd_optimized(handle)
+
+        self._connected = True
 
         if self.filterwheel and not self.filterwheel.is_connected:
             # Need to defer connection of SBIG filter wheels until after camera is connected
@@ -166,9 +135,56 @@ class Camera(AbstractCamera):
 
 # Private methods
 
-    def _take_exposure(self, seconds, filename, dark, exposure_event, header, *args, **kwargs):
-        self._SBIGDriver.take_exposure(self._handle, seconds, filename,
-                                       exposure_event, dark, header)
+    def _start_exposure(self, seconds, filename, dark, header, *args, **kwargs):
+        # Check temerature is OK.
+        if self.ccd_cooling_enabled:
+            t_error = abs(self.ccd_temp - self.ccd_set_point)
+            if t_error > self._temperature_tolerance or self.ccd_cooling_power = 100 * u.percent:
+                self.logger.warning('Unstable CCD temperature in {}'.format(self))
+
+        readout_mode = 'RM_1x1'  # Unbinned mode
+        self._driver.start_exposure(handle=self._handle,
+                                    seconds=seconds,
+                                    dark=dark,
+                                    antiblooming=self.properties['imaging ABG'],
+                                    readout_mode=readout_mode,
+                                    top=0,
+                                    left=0,
+                                    height=self.properties['readout_modes'][readout_mode]['height'],
+                                    width=self.properties['readout_modes'][readout_mode]['width'])
+
+        readout_args = (filename,
+                        readout_mode,
+                        top,
+                        left,
+                        height,
+                        width,
+                        header)
+        return readout_args
+
+    def _readout(self, readout_mode, top, left, height, width, header):
+        exposure_status = Camera._driver.get_exposure_status(self._handle)
+        if exposure_status == 'CS_INTEGRATION_COMPLETE':
+            try:
+                image_data = Camera._driver.readout(self._handle,
+                                                    readout_mode,
+                                                    top,
+                                                    left,
+                                                    height,
+                                                    width)
+            except RuntimeError as err:
+                raise error.PanError('Readout error on {}, {}'.format(self, err))
+            else:
+                fits_utils.write_fits(image_data,
+                                      header,
+                                      filename,
+                                      self.logger,
+                                      self._exposure_event)
+        elif exposure_status == 'CS_IDLE':
+            raise error.PanError("Exposure missing on {}".format(self))
+        else:
+            raise error.PanError("Unexpected exposure status on {}: '{}'".format(
+                self, exposure_status))
 
     def _fits_header(self, seconds, dark):
         header = super()._fits_header(seconds, dark)

--- a/pocs/camera/sbig.py
+++ b/pocs/camera/sbig.py
@@ -25,16 +25,6 @@ class Camera(AbstractSDKCamera):
 
 # Properties
 
-    @AbstractCamera.uid.getter
-    def uid(self):
-        """Return unique identifier for camera.
-
-        Need to overide this because the base class only returns the 1st
-        6 characters of the serial number, which is not a unique identifier
-        for most of the camera types
-        """
-        return self._serial_number
-
     @property
     def ccd_temp(self):
         """
@@ -139,7 +129,7 @@ class Camera(AbstractSDKCamera):
         # Check temerature is OK.
         if self.ccd_cooling_enabled:
             t_error = abs(self.ccd_temp - self.ccd_set_point)
-            if t_error > self._temperature_tolerance or self.ccd_cooling_power = 100 * u.percent:
+            if t_error > self._temperature_tolerance or self.ccd_cooling_power == 100 * u.percent:
                 self.logger.warning('Unstable CCD temperature in {}'.format(self))
 
         readout_mode = 'RM_1x1'  # Unbinned mode

--- a/pocs/camera/sbig.py
+++ b/pocs/camera/sbig.py
@@ -1,5 +1,6 @@
 from threading import Event
 from warnings import warn
+from contextlib import suppress
 
 from astropy import units as u
 
@@ -22,6 +23,15 @@ class Camera(AbstractSDKCamera):
             temperature_tolerance = temperature_tolerance * u.Celsius
         self._temperature_tolerance = temperature_tolerance
         self.logger.info('{} initialised'.format(self))
+
+    del __del__(self):
+        with suppress(AttributeError):
+            handle = self._handle
+            self._driver.set_handle(handle)
+            self._driver.close_device()
+            self._driver.close_driver()
+            self.logger.debug("Closed SBIG camera device & driver for handle {}.".format(handle))
+        super().__del__()
 
 # Properties
 

--- a/pocs/camera/sbigudrv.py
+++ b/pocs/camera/sbigudrv.py
@@ -153,8 +153,8 @@ class SBIGDriver(AbstractSDKDriver):
         ccd_info_params2 = GetCCDInfoParams(ccd_info_request_codes['CCD_INFO_EXTENDED'])
         ccd_info_results2 = GetCCDInfoResults2()
 
-        # 'CCD_INFO_EXTENDED2_IMAGING' will info like full frame/frame transfer, interline or not,
-        # presence of internal frame buffer, etc.
+        # 'CCD_INFO_EXTENDED2_IMAGING' will get info like full frame/frame transfer, interline or
+        # not, presence of internal frame buffer, etc.
         ccd_info_params4 = GetCCDInfoParams(ccd_info_request_codes['CCD_INFO_EXTENDED2_IMAGING'])
         ccd_info_results4 = GetCCDInfoResults4()
 
@@ -205,6 +205,8 @@ class SBIGDriver(AbstractSDKDriver):
 
     def disable_vdd_optimized(self, handle):
         """
+        Stops selective lowering of the CCD's Vdd voltage to ensure consistent bias structures.
+
         There are many driver control parameters, almost all of which we would not want to change
         from their default values. The one exception is DCP_VDD_OPTIMIZED. From the SBIG manual:
 

--- a/pocs/camera/sbigudrv.py
+++ b/pocs/camera/sbigudrv.py
@@ -86,8 +86,10 @@ class SBIGDriver(AbstractSDKDriver):
         return version_string
 
     def get_cameras(self):
-        """Convenience function to get a dictionary of all currently connected camera serial numbers
-        and their corresponding handles.
+        """Gets currently connected camera inf.
+
+        Returns:
+            dict: All currently connected camera serial numbers with corresponding handles.
         """
         camera_info = QueryUSBResults2()
         with self._command_lock:

--- a/pocs/camera/sbigudrv.py
+++ b/pocs/camera/sbigudrv.py
@@ -689,7 +689,7 @@ class SBIGDriver(AbstractSDKDriver):
                 not recognised
         """
         # Look up integer command code for the given command string, raises
-        # KeyError if no matches found.++
+        # KeyError if no matches found.
         try:
             command_code = command_codes[command]
         except KeyError:

--- a/pocs/camera/sbigudrv.py
+++ b/pocs/camera/sbigudrv.py
@@ -23,6 +23,7 @@ from pocs.camera.sdk import AbstractSDKDriver
 from pocs.utils.images import fits as fits_utils
 from pocs.utils import error
 from pocs.utils import CountdownTimer
+from pocs.utils import get_quantity_value
 
 ################################################################################
 # Main SBIGDriver class
@@ -60,44 +61,7 @@ class SBIGDriver(AbstractSDKDriver):
         self._retries = retries
         super().__init__(name='sbigudrv', library_path=library_path, **kwargs)
 
-        # Query USB bus for connected cameras, store basic camera info.
-        self.logger.debug('Searching for connected SBIG cameras')
-        self._camera_info = QueryUSBResults2()
-        self._send_command('CC_QUERY_USB2', results=self._camera_info)
-        self._send_command('CC_CLOSE_DRIVER')
-
-        # Connect to each camera in turn, obtain its 'handle' and and store.
-        self._handles = []
-
-        for i in range(self._camera_info.camerasFound):
-            self._send_command('CC_OPEN_DRIVER')
-            odp = OpenDeviceParams(device_type_codes['DEV_USB{}'.format(i + 1)],
-                                   0, 0)
-            self._send_command('CC_OPEN_DEVICE', params=odp)
-
-            elp = EstablishLinkParams()
-            elr = EstablishLinkResults()
-            self._send_command('CC_ESTABLISH_LINK', params=elp, results=elr)
-
-            ghr = GetDriverHandleResults()
-            self._send_command('CC_GET_DRIVER_HANDLE', results=ghr)
-            self._handles.append(ghr.handle)
-
-            # This seems to have the side effect of closing both device and
-            # driver.
-            shp = SetDriverHandleParams(INVALID_HANDLE_VALUE)
-            self._send_command('CC_SET_DRIVER_HANDLE', params=shp)
-
-        # Prepare to keep track of which handles have been assigned to Camera objects
-        self._handle_assigned = [False] * len(self._handles)
-
-        self._ccd_info = {}
-
-        # Reopen driver ready for next command
-        self._send_command('CC_OPEN_DRIVER')
-
-        self.logger.info('SBIGDriver initialised: found {} cameras'.format(
-            self._camera_info.camerasFound))
+    # Properties
 
     @property
     def retries(self):
@@ -110,92 +74,188 @@ class SBIGDriver(AbstractSDKDriver):
             raise ValueError("retries should be 1 or greater, got {}!".format(retries))
         self._retries = retries
 
+    # Methods
+
     def get_SDK_version(self, request_type='DRIVER_STD'):
-        # Make sure the driver is open
-        with self._command_lock:
-            error = self._send_command('CC_OPEN_DRIVER')
-        # Get the driver info
         driver_info_params = GetDriverInfoParams(driver_request_codes[request_type])
         driver_info_results = GetDriverInfoResults0()
+        self.open_driver()  # Make sure driver is open
         with self._command_lock:
             self._send_command('CC_GET_DRIVER_INFO', driver_info_params, driver_info_results)
         version_string = "{}, {}".format(driver_info_results.name.decode('ascii'),
                                          self._bcd_to_string(driver_info_results.version))
         return version_string
 
-    def assign_handle(self, serial=None):
+    def get_cameras(self):
+        """Convenience function to get a dictionary of all currently connected camera serial numbers
+        and their corresponding handles.
         """
-        Returns the next unassigned camera handle, along with basic info on the coresponding camera.
-        If passed a serial number will attempt to assign the handle corresponding to a camera
-        with that serial number, raising an error if one is not available.
+        camera_info = QueryUSBResults3()
+        with self._command_lock:
+            self._send_command('CC_QUERY_USB3', results=camera_info)
+        if not camera_info.camerasFound:
+            raise error.PanError("No SBIG camera devices found.")
+
+        cameras = {}
+        for i in range(camera_info.camerasFound):
+            serial_number = camera_info[i].serialNumber.decode('ascii')
+            device_type = "DEV_USB{}".format(i + 1)
+            cameras[serial_number] = device_type
+
+        return cameras
+
+    def open_driver(self):
+        with self._command_lock:
+            self._send_command('CC_OPEN_DRIVER')
+
+    def open_device(self, device_type):
+        odp = OpenDeviceParams(device_type_codes[device_type])
+        with self._command_lock:
+            self._send_command('CC_OPEN_DEVICE')
+
+    def establish_link(self):
+        elp = EstablishLinkParams()
+        elr = EstablishLinkResults()
+        with self._command_lock:
+            self._send_command('CC_ESTABLISH_LINK', params=elp, results=elr)
+
+    def get_link_status(self):
+        lsr = GetLinkStatusResults()
+        with self._command_lock:
+            self._send_command('CC_GET_LINK_STATUS', params=lsr)
+        link_status = {'established': bool(lsr.linkEstablished),
+                       'base_address': int(lsr.baseAddress),
+                       'camera_type': camera_types[lsr.cameraType],
+                       'com_total': int(lsr.comTotal),
+                       'com_failed': int(lsr.comFailed)}
+        return link_status
+
+    def get_driver_handle(self):
+        ghr = GetDriverHandleResults()
+        with self._command_lock:
+            self._send_command('CC_GET_DRIVER_HANDLE', results=ghr)
+        return ghr.handle
+
+    def set_handle(self, handle):
+        if not handle:
+            handle = INVALID_HANDLE_VALUE
+        set_handle_params = SetDriverHandleParams(handle)
+        self._send_command('CC_SET_DRIVER_HANDLE', params=set_handle_params)
+
+    def get_ccd_info(self, handle):
         """
+        Use Get CCD Info to gather all relevant info about CCD capabilities. Already
+        have camera type, 'name' and serial number, this gets the rest.
+        """
+        # 'CCD_INFO_IMAGING' will get firmware version, and a list of readout modes (binning)
+        # with corresponding image widths, heights, gains and also physical pixel width, height.
+        ccd_info_params0 = GetCCDInfoParams(ccd_info_request_codes['CCD_INFO_IMAGING'])
+        ccd_info_results0 = GetCCDInfoResults0()
 
-        if serial:
-            # Look for a connected, unassigned camera with matching serial number
+        # 'CCD_INFO_EXTENDED' will get bad column info, and whether the CCD has ABG or not.
+        ccd_info_params2 = GetCCDInfoParams(ccd_info_request_codes['CCD_INFO_EXTENDED'])
+        ccd_info_results2 = GetCCDInfoResults2()
 
-            # List of serial numbers
-            serials = [str(self._camera_info.usbInfo[i].serialNumber, encoding='ascii')
-                       for i in range(self._camera_info.camerasFound)]
+        # 'CCD_INFO_EXTENDED2_IMAGING' will info like full frame/frame transfer, interline or not,
+        # presence of internal frame buffer, etc.
+        ccd_info_params4 = GetCCDInfoParams(ccd_info_request_codes['CCD_INFO_EXTENDED2_IMAGING'])
+        ccd_info_results4 = GetCCDInfoResults4()
 
-            if serial not in serials:
-                # Camera we're looking for is not connected!
-                self.logger.error('SBIG camera serial number {} not connected!'.format(serial))
-                return (INVALID_HANDLE_VALUE, None)
-
-            index = serials.index(serial)
-
-            if self._handle_assigned[index]:
-                # Camera we're looking for has already been assigned!
-                self.logger.error('SBIG camera serial number {} already assigned!'.format(serial))
-                return (INVALID_HANDLE_VALUE, None)
-
-        else:
-            # No serial number specified, just take the first unassigned handle
-            try:
-                index = self._handle_assigned.index(False)
-            except ValueError:
-                # All handles already assigned, must be trying to intialising more cameras than are
-                # connected.
-                self.logger.error('No connected SBIG cameras available!')
-                return (INVALID_HANDLE_VALUE, None)
-
-        handle = self._handles[index]
-
-        self.logger.debug('Assigning handle {} to SBIG camera'.format(handle))
-        self._handle_assigned[index] = True
-
-        # Get all the information from the camera
-        self.logger.debug('Obtaining SBIG camera info from {}'.format(handle))
-        ccd_info = self._get_ccd_info(handle)
-
-        # Serial number, name and type should match with those from Query USB Info obtained earlier
-        camera_serial = str(self._camera_info.usbInfo[index].serialNumber, encoding='ascii')
-        assert camera_serial == ccd_info['serial number'], \
-            self.logger.error('Serial number mismatch!')
-
-        # Keep camera info.
-        self._ccd_info[handle] = ccd_info
-
-        # Stop camera from skipping lowering of Vdd for exposures of 3 seconds of less
-        self._disable_vdd_optimized(handle)
-
-        # Return both a handle and the dictionary of camera info
-        return (handle, ccd_info)
-
-    def query_temp_status(self, handle):
-        query_temp_params = QueryTemperatureStatusParams(
-            temp_status_request_codes['TEMP_STATUS_ADVANCED2'])
-        query_temp_results = QueryTemperatureStatusResults2()
+        # 'CCD_INFO_EXTENDED3' will get info like mechanical shutter or not, mono/colour,
+        # Bayer/Truesense.
+        ccd_info_params6 = GetCCDInfoParams(ccd_info_request_codes['CCD_INFO_EXTENDED3'])
+        ccd_info_results6 = GetCCDInfoResults6()
 
         with self._command_lock:
-            self._set_handle(handle)
-            self._send_command('CC_QUERY_TEMPERATURE_STATUS', query_temp_params, query_temp_results)
+            self.set_handle(handle)
+            self._send_command('CC_GET_CCD_INFO',
+                               params=ccd_info_params0,
+                               results=ccd_info_results0)
+            self._send_command('CC_GET_CCD_INFO',
+                               params=ccd_info_params2,
+                               results=ccd_info_results2)
+            self._send_command('CC_GET_CCD_INFO',
+                               params=ccd_info_params4,
+                               results=ccd_info_results4)
+            self._send_command('CC_GET_CCD_INFO',
+                               params=ccd_info_params6,
+                               results=ccd_info_results6)
 
-        return query_temp_results
+        # Now to convert all this ctypes stuff into Pythonic data structures.
+        ccd_info = {'firmware version': self._bcd_to_string(ccd_info_results0.firmwareVersion),
+                    'camera type': camera_types[ccd_info_results0.cameraType],
+                    'camera name': str(ccd_info_results0.name, encoding='ascii'),
+                    'bad columns': ccd_info_results2.columns[0:ccd_info_results2.badColumns],
+                    'imaging ABG': bool(ccd_info_results2.imagingABG),
+                    'serial number': str(ccd_info_results2.serialNumber, encoding='ascii'),
+                    'frame transfer': bool(ccd_info_results4.capabilities_b0),
+                    'electronic shutter': bool(ccd_info_results4.capabilities_b1),
+                    'remote guide head support': bool(ccd_info_results4.capabilities_b2),
+                    'Biorad TDI support': bool(ccd_info_results4.capabilities_b3),
+                    'AO8': bool(ccd_info_results4.capabilities_b4),
+                    'frame buffer': bool(ccd_info_results4.capabilities_b5),
+                    'dump extra': ccd_info_results4.dumpExtra,
+                    'STXL': bool(ccd_info_results6.camera_b0),
+                    'mechanical shutter': not bool(ccd_info_results6.camera_b1),
+                    'colour': bool(ccd_info_results6.ccd_b0),
+                    'Truesense': bool(ccd_info_results6.ccd_b1)}
+
+        readout_mode_info = self._parse_readout_info(
+            ccd_info_results0.readoutInfo[0:ccd_info_results0.readoutModes])
+        ccd_info['readout modes'] = readout_mode_info
+
+        return ccd_info
+
+    def disable_vdd_optimized(self, handle):
+        """
+        There are many driver control parameters, almost all of which we would not want to change
+        from their default values. The one exception is DCP_VDD_OPTIMIZED. From the SBIG manual:
+
+        The DCP_VDD_OPTIMIZED parameter defaults to TRUE which lowers the CCD’s Vdd (which reduces
+        amplifier glow) only for images 3 seconds and longer. This was done to increase the image
+        throughput for short exposures as raising and lowering Vdd takes 100s of milliseconds. The
+        lowering and subsequent raising of Vdd delays the image readout slightly which causes short
+        exposures to have a different bias structure than long exposures. Setting this parameter to
+        FALSE stops the short exposure optimization from occurring.
+
+        The default behaviour will improve image throughput for exposure times of 3 seconds or less
+        but at the penalty of altering the bias structure between short and long exposures. This
+        could cause systematic errors in bias frames, dark current measurements, etc. It's probably
+        not worth it.
+        """
+        set_driver_control_params = SetDriverControlParams(
+            driver_control_codes['DCP_VDD_OPTIMIZED'], 0)
+        self.logger.debug('Disabling DCP_VDD_OPTIMIZE on {}'.format(handle))
+        with self._command_lock:
+            self.set_handle(handle)
+            self._send_command('CC_SET_DRIVER_CONTROL', params=set_driver_control_params)
+
+    def query_temp_status(self, handle):
+        qtp = QueryTemperatureStatusParams(temp_status_request_codes['TEMP_STATUS_ADVANCED2'])
+        qtr = QueryTemperatureStatusResults2()
+        with self._command_lock:
+            self.set_handle(handle)
+            self._send_command('CC_QUERY_TEMPERATURE_STATUS', qtp, qtr)
+
+        temp_status = {'cooling_enabled': bool(qtr.coolingEnabled),
+                       'fan_enabled': bool(qtr.fanEnabled),
+                       'ccd_set_point': qtr.ccdSetpoint * u.Celsius,
+                       'imaging_ccd_temperature': qtr.imageCCDTemperature * u.Celsius,
+                       'tracking_ccd_temperature': qtr.trackingCCDTemperature * u.Celsius,
+                       'external_ccd_temperature': qtr.externalTrackingCCDTemperature * u.Celsius,
+                       'ambient_temperature': qtr.ambientTemperature * u.Celsius,
+                       'imaging_ccd_power': qtr.imagingCCDPower * u.percent,
+                       'tracking_ccd_power': qtr.trackingCCDPower * u.percent,
+                       'external_ccd_power': qtr.extrenalTrackingCCDPower * u.percent,
+                       'heatsink_temperature': qtr.heatsinkTemperature * u.Celsius,
+                       'fan_power': qtr.fanPower * u.percent,
+                       'fan_speed': qtr.fanSpeed / u.minute,
+                       'tracking_ccd_set_point': qtr.trackingCCDSetpoint * u.Celsius}
+
+        return temp_status
 
     def set_temp_regulation(self, handle, set_point, enabled):
-        if isinstance(set_point, u.Quantity):
-            set_point = set_point.to(u.Celsius).value
+        set_point = get_quantity_value(set_point, unit=u.Celsius)
 
         if enabled:
             enable_code = temperature_regulation_codes['REGULATION_ON']
@@ -209,7 +269,7 @@ class SBIGDriver(AbstractSDKDriver):
         set_freeze_params = SetTemperatureRegulationParams2(autofreeze_code, set_point)
 
         with self._command_lock:
-            self._set_handle(handle)
+            self.set_handle(handle)
             self._send_command('CC_SET_TEMPERATURE_REGULATION2', params=set_temp_params)
             self._send_command('CC_SET_TEMPERATURE_REGULATION2', params=set_freeze_params)
 
@@ -219,35 +279,30 @@ class SBIGDriver(AbstractSDKDriver):
         query_status_results = QueryCommandStatusResults()
 
         with self._command_lock:
-            self._set_handle(handle)
+            self.set_handle(handle)
             self._send_command('CC_QUERY_COMMAND_STATUS',
                                params=query_status_params,
                                results=query_status_results)
 
         return statuses[query_status_results.status]
 
-    def take_exposure(self,
-                      handle,
-                      seconds,
-                      filename,
-                      exposure_event=None,
-                      dark=False,
-                      header=None):
-        """
-        Starts an exposure and spawns thread that will perform readout and write
-        to file when the exposure is complete.
-        """
-        ccd_info = self._ccd_info[handle]
-
+    def start_exposure(self,
+                       handle,
+                       seconds,
+                       dark,
+                       antiblooming,
+                       readout_mode,
+                       top,
+                       left,
+                       height,
+                       width):
         # SBIG driver expects exposure time in 100ths of a second.
-        if isinstance(seconds, u.Quantity):
-            seconds = seconds.to(u.second).value
-        centiseconds = int(seconds * 100)
+        centiseconds = int(get_quantity_value(seconds, unit=u.second) * 100)
 
         # This setting is ignored by most cameras (even if they do have ABG), only exceptions are
         # the TC211 versions of the Tracking CCD on the ST-7/8/etc. and the Imaging CCD of the
         # PixCel255
-        if ccd_info['imaging ABG']:
+        if antiblooming:
             # Camera supports anti-blooming, use it on medium setting?
             abg_command_code = abg_state_codes['ABG_CLK_MED7']
         else:
@@ -261,66 +316,71 @@ class SBIGDriver(AbstractSDKDriver):
             # Dark frame, will keep shutter closed throughout
             shutter_command_code = shutter_command_codes['SC_CLOSE_SHUTTER']
 
-        # TODO: implement control of binning readout modes.
-        # For now use standard unbinned mode.
-        readout_mode = 'RM_1X1'
-        readout_mode_code = readout_mode_codes[readout_mode]
-
-        # TODO: implement windowed readout.
-        # For now use full image size for unbinned mode.
-        top = 0
-        left = 0
-        height = int(ccd_info['readout modes'][readout_mode]['height'].value)
-        width = int(ccd_info['readout modes'][readout_mode]['width'].value)
-
         start_exposure_params = StartExposureParams2(ccd_codes['CCD_IMAGING'],
                                                      centiseconds,
                                                      abg_command_code,
                                                      shutter_command_code,
-                                                     readout_mode_code,
-                                                     top, left,
-                                                     height, width)
-
-        # Make sure there isn't already an exposure in progress on this camera.
-        # If there is then we need to wait otherwise we'll cause a hang.
-        # Could do this with Locks but it's more robust to directly query the hardware.
-        exposure_status = self.get_exposure_status(handle)
-        if exposure_status != 'CS_IDLE':
-            self.logger.warning('Attempt to start exposure on {} while camera busy!'.format(
-                self._ccd_info[handle]['serial number']))
-            # Wait until camera is idle
-            while exposure_status != 'CS_IDLE':
-                self.logger.warning('Waiting for exposure on {} to complete'.format(
-                    self._ccd_info[handle]['serial number']))
-                time.sleep(1)
-                exposure_status = self.get_exposure_status(handle)
-
-        # Check temerature is OK.
-        temp_status = self.query_temp_status(handle)
-        if temp_status.coolingEnabled:
-            if abs(temp_status.imagingCCDTemperature - temp_status.ccdSetpoint) > 0.5 or \
-               temp_status.imagingCCDPower == 100.0:
-                self.logger.warning('Unstable CCD temperature in {}'.format(
-                    self._ccd_info[handle]['serial number']))
-
-        # Start exposure
-        self.logger.debug('Starting {} second exposure on {}'.format(
-            seconds, self._ccd_info[handle]['serial number']))
+                                                     readout_mode_code[readout_mode],
+                                                     int(get_quantity_value(top, u.pixel)),
+                                                     int(get_quantity_valur(left, u.pixel)),
+                                                     int(get_quantity_value(height, u.pixel)),
+                                                     int(get_quantity_value(width, u.pixel)))
         with self._command_lock:
-            self._set_handle(handle)
+            self.set_handle(handle)
             self._send_command('CC_START_EXPOSURE2', params=start_exposure_params)
 
-        # Use a Timer to schedule the exposure readout and return a reference to the Timer.
-        wait = seconds - 0.1 if seconds > 0.1 else 0.0
-        readout_args = (handle, centiseconds, filename, readout_mode_code,
-                        top, left, height, width,
-                        header, exposure_event)
-        readout_thread = threading.Timer(interval=wait,
-                                         function=self._readout,
-                                         args=readout_args)
-        readout_thread.start()
+    def readout(self,
+                handle,
+                readout_mode,
+                top,
+                left,
+                height,
+                width):
+        # Set up all the parameter and result Structures that will be needed.
+        top = int(get_quantity_value(top, unit=u.pixel))
+        left = int(get_quantity_value(left, unit=u.pixel))
+        height = int(get_quantity_value(height, unit=u.pixel))
+        width = int(get_quantity_value(width, unit=u.pixel))
 
-        return readout_thread
+        end_exposure_params = EndExposureParams(ccd_codes['CCD_IMAGING'])
+
+        start_readout_params = StartReadoutParams(ccd_codes['CCD_IMAGING'],
+                                                  readout_mode_codes[readout_mode],
+                                                  top, left,
+                                                  height, width)
+
+        readout_line_params = ReadoutLineParams(ccd_codes['CCD_IMAGING'],
+                                                readout_mode_code,
+                                                left, width)
+
+        end_readout_params = EndReadoutParams(ccd_codes['CCD_IMAGING'])
+
+        # Array to hold the image data
+        image_data = np.zeros((height, width), dtype=np.uint16)
+        rows_got = 0
+
+        # Readout data
+        with self._command_lock:
+            self.set_handle(handle)
+            self._send_command('CC_END_EXPOSURE', params=end_exposure_params)
+            self._send_command('CC_START_READOUT', params=start_readout_params)
+            try:
+                for i in range(height):
+                    self._send_command('CC_READOUT_LINE',
+                                       params=readout_line_params,
+                                       results=as_ctypes(image_data[i]))
+                    rows_got += 1
+            except RuntimeError as err:
+                message = 'expected {} rows, got {}: {}'.format(height, rows_got, err)
+                raise RuntimeError(message)
+
+            try:
+                self._send_command('CC_END_READOUT', params=end_readout_params)
+            except RuntimeError as err:
+                message = "error ending readout: {}".format(err)
+                raise RuntimeError(message)
+
+        return image_data
 
     def cfw_init(self, handle, model='AUTO', timeout=10 * u.second):
         """
@@ -558,141 +618,9 @@ class SBIGDriver(AbstractSDKDriver):
         cfw_params = CFWParams(CFWModelSelect[model], *args)
         cfw_results = CFWResults()
         with self._command_lock:
-            self._set_handle(handle)
+            self.set_handle(handle)
             self._send_command('CC_CFW', cfw_params, cfw_results)
         return cfw_results
-
-    def _readout(self, handle, centiseconds, filename, readout_mode_code,
-                 top, left, height, width,
-                 header, exposure_event=None):
-        # Set up all the parameter and result Structures that will be needed.
-        end_exposure_params = EndExposureParams(ccd_codes['CCD_IMAGING'])
-
-        start_readout_params = StartReadoutParams(ccd_codes['CCD_IMAGING'],
-                                                  readout_mode_code,
-                                                  top, left,
-                                                  height, width)
-
-        query_status_params = QueryCommandStatusParams(command_codes['CC_START_EXPOSURE2'])
-
-        query_status_results = QueryCommandStatusResults()
-
-        readout_line_params = ReadoutLineParams(ccd_codes['CCD_IMAGING'],
-                                                readout_mode_code,
-                                                left, width)
-
-        end_readout_params = EndReadoutParams(ccd_codes['CCD_IMAGING'])
-
-        # Array to hold the image data
-        image_data = np.zeros((height, width), dtype=np.uint16)
-
-        # Check for the end of the exposure.
-        exposure_status = self.get_exposure_status(handle)
-
-        # Poll if needed.
-        while exposure_status != 'CS_INTEGRATION_COMPLETE':
-            self.logger.debug('Waiting for exposure on {} to complete'.format(
-                self._ccd_info[handle]['serial number']))
-            time.sleep(0.1)
-            exposure_status = self.get_exposure_status(handle)
-
-        self.logger.debug('Exposure on {} complete'.format(self._ccd_info[handle]['serial number']))
-
-        # Readout data
-        with self._command_lock:
-            self._set_handle(handle)
-            self._send_command('CC_END_EXPOSURE', params=end_exposure_params)
-            self._send_command('CC_START_READOUT', params=start_readout_params)
-            for i in range(height):
-                try:
-                    self._send_command('CC_READOUT_LINE',
-                                       params=readout_line_params,
-                                       results=as_ctypes(image_data[i]))
-                except RuntimeError as err:
-                    message = 'Readout error on {}: expected {} rows, got {}!'.format(
-                        self._ccd_info[handle]['serial number'], height, i)
-                    self.logger.error(message)
-                    self.logger.error(err)
-                    warn(message)
-                    break
-
-            try:
-                self.logger.debug("Ending readout on {}".format(
-                    self._ccd_info[handle]['serial number']))
-                self._send_command('CC_END_READOUT', params=end_readout_params)
-            except RuntimeError as err:
-                message = "Error ending readout on {}: {}".format(
-                    self._ccd_info[handle]['serial number'], err)
-                self.logger.error(message)
-            else:
-                self.logger.debug('Readout on {} complete'.format(
-                    self._ccd_info[handle]['serial number']))
-            finally:
-                fits_utils.write_fits(image_data, header, filename, self.logger, exposure_event)
-
-    def _get_ccd_info(self, handle):
-        """
-        Use Get CCD Info to gather all relevant info about CCD capabilities. Already
-        have camera type, 'name' and serial number, this gets the rest.
-        """
-        # 'CCD_INFO_IMAGING' will get firmware version, and a list of readout modes (binning)
-        # with corresponding image widths, heights, gains and also physical pixel width, height.
-        ccd_info_params0 = GetCCDInfoParams(ccd_info_request_codes['CCD_INFO_IMAGING'])
-        ccd_info_results0 = GetCCDInfoResults0()
-
-        # 'CCD_INFO_EXTENDED' will get bad column info, and whether the CCD has ABG or not.
-        ccd_info_params2 = GetCCDInfoParams(ccd_info_request_codes['CCD_INFO_EXTENDED'])
-        ccd_info_results2 = GetCCDInfoResults2()
-
-        # 'CCD_INFO_EXTENDED2_IMAGING' will info like full frame/frame transfer, interline or not,
-        # presence of internal frame buffer, etc.
-        ccd_info_params4 = GetCCDInfoParams(ccd_info_request_codes['CCD_INFO_EXTENDED2_IMAGING'])
-        ccd_info_results4 = GetCCDInfoResults4()
-
-        # 'CCD_INFO_EXTENDED3' will get info like mechanical shutter or not, mono/colour,
-        # Bayer/Truesense.
-        ccd_info_params6 = GetCCDInfoParams(ccd_info_request_codes['CCD_INFO_EXTENDED3'])
-        ccd_info_results6 = GetCCDInfoResults6()
-
-        with self._command_lock:
-            self._set_handle(handle)
-            self._send_command('CC_GET_CCD_INFO',
-                               params=ccd_info_params0,
-                               results=ccd_info_results0)
-            self._send_command('CC_GET_CCD_INFO',
-                               params=ccd_info_params2,
-                               results=ccd_info_results2)
-            self._send_command('CC_GET_CCD_INFO',
-                               params=ccd_info_params4,
-                               results=ccd_info_results4)
-            self._send_command('CC_GET_CCD_INFO',
-                               params=ccd_info_params6,
-                               results=ccd_info_results6)
-
-        # Now to convert all this ctypes stuff into Pythonic data structures.
-        ccd_info = {'firmware version': self._bcd_to_string(ccd_info_results0.firmwareVersion),
-                    'camera type': camera_types[ccd_info_results0.cameraType],
-                    'camera name': str(ccd_info_results0.name, encoding='ascii'),
-                    'bad columns': ccd_info_results2.columns[0:ccd_info_results2.badColumns],
-                    'imaging ABG': bool(ccd_info_results2.imagingABG),
-                    'serial number': str(ccd_info_results2.serialNumber, encoding='ascii'),
-                    'frame transfer': bool(ccd_info_results4.capabilities_b0),
-                    'electronic shutter': bool(ccd_info_results4.capabilities_b1),
-                    'remote guide head support': bool(ccd_info_results4.capabilities_b2),
-                    'Biorad TDI support': bool(ccd_info_results4.capabilities_b3),
-                    'AO8': bool(ccd_info_results4.capabilities_b4),
-                    'frame buffer': bool(ccd_info_results4.capabilities_b5),
-                    'dump extra': ccd_info_results4.dumpExtra,
-                    'STXL': bool(ccd_info_results6.camera_b0),
-                    'mechanical shutter': not bool(ccd_info_results6.camera_b1),
-                    'colour': bool(ccd_info_results6.ccd_b0),
-                    'Truesense': bool(ccd_info_results6.ccd_b1)}
-
-        readout_mode_info = self._parse_readout_info(
-            ccd_info_results0.readoutInfo[0:ccd_info_results0.readoutModes])
-        ccd_info['readout modes'] = readout_mode_info
-
-        return ccd_info
 
     def _bcd_to_int(self, bcd, int_type='ushort'):
         """
@@ -742,34 +670,6 @@ class SBIGDriver(AbstractSDKDriver):
 
         return readout_mode_info
 
-    def _disable_vdd_optimized(self, handle):
-        """
-        There are many driver control parameters, almost all of which we would not want to change
-        from their default values. The one exception is DCP_VDD_OPTIMIZED. From the SBIG manual:
-
-        The DCP_VDD_OPTIMIZED parameter defaults to TRUE which lowers the CCD’s Vdd (which reduces
-        amplifier glow) only for images 3 seconds and longer. This was done to increase the image
-        throughput for short exposures as raising and lowering Vdd takes 100s of milliseconds. The
-        lowering and subsequent raising of Vdd delays the image readout slightly which causes short
-        exposures to have a different bias structure than long exposures. Setting this parameter to
-        FALSE stops the short exposure optimization from occurring.
-
-        The default behaviour will improve image throughput for exposure times of 3 seconds or less
-        but at the penalty of altering the bias structure between short and long exposures. This
-        could cause systematic errors in bias frames, dark current measurements, etc. It's probably
-        not worth it.
-        """
-        set_driver_control_params = SetDriverControlParams(
-            driver_control_codes['DCP_VDD_OPTIMIZED'], 0)
-        self.logger.debug('Disabling DCP_VDD_OPTIMIZE on {}'.format(handle))
-        with self._command_lock:
-            self._set_handle(handle)
-            self._send_command('CC_SET_DRIVER_CONTROL', params=set_driver_control_params)
-
-    def _set_handle(self, handle):
-        set_handle_params = SetDriverHandleParams(handle)
-        self._send_command('CC_SET_DRIVER_HANDLE', params=set_handle_params)
-
     def _send_command(self, command, params=None, results=None):
         """
         Function for sending a command to the SBIG Universal Driver/Library.
@@ -791,7 +691,7 @@ class SBIGDriver(AbstractSDKDriver):
                 not recognised
         """
         # Look up integer command code for the given command string, raises
-        # KeyError if no matches found.
+        # KeyError if no matches found.++
         try:
             command_code = command_codes[command]
         except KeyError:
@@ -992,7 +892,7 @@ class QueryUSBInfo(ctypes.Structure):
 
 class QueryUSBResults(ctypes.Structure):
     """
-    ctypes Structure used to hold the results from 'CC_QUERY_USB' command
+    ctypes Structure used to hold the results from 'CC_QUERY_USB' command (max 4 cameras).
     """
     _fields_ = [('camerasFound', ctypes.c_ushort),
                 ('usbInfo', QueryUSBInfo * 4)]
@@ -1000,10 +900,18 @@ class QueryUSBResults(ctypes.Structure):
 
 class QueryUSBResults2(ctypes.Structure):
     """
-    ctypes Structure used to hold the results from 'CC_QUERY_USB2' command
+    ctypes Structure used to hold the results from 'CC_QUERY_USB2' command (max 8 cameras).
     """
     _fields_ = [('camerasFound', ctypes.c_ushort),
                 ('usbInfo', QueryUSBInfo * 8)]
+
+
+class QueryUSBResults3(ctypes.Structure):
+    """
+    ctypes Structure used to hold the results from 'CC_QUERY_USB3' command (max 24 cameras).
+    """
+    _fields_ = [('camerasFound', ctypes.c_ushort),
+                ('usbInfo', QueryUSBInfo * 24)]
 
 
 # Camera type codes, returned by Query USB Info, Establish Link, Get CCD Info, etc.

--- a/pocs/camera/sbigudrv.py
+++ b/pocs/camera/sbigudrv.py
@@ -90,9 +90,9 @@ class SBIGDriver(AbstractSDKDriver):
         """Convenience function to get a dictionary of all currently connected camera serial numbers
         and their corresponding handles.
         """
-        camera_info = QueryUSBResults3()
+        camera_info = QueryUSBResults2()
         with self._command_lock:
-            self._send_command('CC_QUERY_USB3', results=camera_info)
+            self._send_command('CC_QUERY_USB2', results=camera_info)
         if not camera_info.camerasFound:
             raise error.PanError("No SBIG camera devices found.")
 

--- a/pocs/camera/sdk.py
+++ b/pocs/camera/sdk.py
@@ -88,6 +88,7 @@ class AbstractSDKCamera(AbstractCamera):
 
         if not type(self)._cameras:
             # No cached camera details, need to probe for connected cameras
+            # This will raise a PanError if there are no cameras.
             type(self)._cameras = type(self)._driver.get_cameras()
             logger.debug("Connected {}s: {}".format(name, type(self)._cameras))
 

--- a/pocs/camera/sdk.py
+++ b/pocs/camera/sdk.py
@@ -1,0 +1,120 @@
+from pocs.base import PanBase
+from pocs.camera.camera import AbstractCamera
+from pocs.utils import error
+from pocs.utils.library import load_library
+
+
+class AbstractSDKDriver(PanBase):
+    def __init__(self, name, library_path=None, **kwargs):
+        """Base class for all camera SDK interfaces.
+
+        On construction loads the shared object/dynamically linked version of the camera SDK
+        library, which must be already installed.
+
+        The name and location of the shared library can be manually specified with the library_path
+        argument, otherwise the ctypes.util.find_library function will be used to try to locate it.
+
+        Args:
+            name (str): name of the library (without 'lib' prefix or any suffixes, e.g. 'fli').
+            library_path (str, optional): path to the libary e.g. '/usr/local/lib/libASICamera2.so'
+
+        Returns:
+            `~pocs.camera.libasi.ASIDriver`
+
+        Raises:
+            pocs.utils.error.NotFound: raised if library_path not given & find_libary fails to
+                locate the library.
+            OSError: raises if the ctypes.CDLL loader cannot load the library.
+        """
+        super().__init__(**kwargs)
+        self._CDLL = load_library(name=name, path=library_path, logger=self.logger)
+        self._version = self.get_SDK_version()
+
+    # Properties
+
+    @property
+    def version(self):
+        return self._version
+
+    # Methods
+
+    def get_SDK_version(self):
+        """ Get the version of the SDK """
+        raise NotImplementedError
+
+    def get_cameras(self):
+        """Convenience function to get a dictionary of all currently connected camera UIDs
+        and their corresponding device nodes/handles/camera IDs.
+        """
+        raise NotImplementedError
+
+
+class AbstractSDKCamera(AbstractCamera):
+    _driver = None
+    _cameras = {}
+    _assigned_cameras = set()
+
+    def __init__(self,
+                 name='Generic SDK camera',
+                 driver=AbstractSDKDriver,
+                 library_path=None,
+                 filter_type=None,
+                 set_point=None,
+                 *args, **kwargs):
+        # Would usually use self.logger but that won't exist until after calling super().__init__(),
+        # and don't want to do that until after the serial number and port have both been determined
+        # in order to avoid log entries with misleading values. To enable logging during the device
+        # scanning phase use get_root_logger() instead.
+        logger = get_root_logger()
+
+        # The SDK cameras don't have a 'port', they are identified by a serial_number, which
+        # is some form of unique ID readable via the camera SDK.
+        kwargs['port'] = None
+        serial_number = kwargs.get('serial_number')
+        if not serial_number:
+            msg = "Must specify serial_number for {}.".format(name)
+            logger.error(msg)
+            raise ValueError(msg)
+
+        if type(self)._driver is None:
+            # Initialise the driver if it hasn't already been done
+            type(self)._driver = driver(library_path=library_path)
+
+        logger.debug("Looking for {} with UID '{}'.".format(name, serial_number))
+
+        if not type(self)._cameras:
+            # No cached camera details, need to probe for connected cameras
+            type(self)._cameras = type(self)._driver.get_cameras()
+
+        if serial_number in type(self)._cameras:
+            logger.debug("Found {} with UID '{}' at {}.".format(
+                name, serial_number, type(self)._cameras[serial_number]))
+        else:
+            raise error.PanError("Could not find {} with UID '{}'.".format(
+                name, serial_number))
+
+        if serial_number in type(self)._assigned_cameras:
+            raise error.PanError("{} with UID '{}' already in use.".format(
+                name, serial_number))
+
+        type(self)._assigned_cameras.add(serial_number)
+        super().__init__(name, *args, **kwargs)
+        self.connect()
+        assert self.is_connected, error.PanError("Could not connect to {}.".format(self))
+
+        if filter_type:
+            # connect() will have set this based on camera info, but that doesn't know about filters
+            # upstream of the CCD. Can be set manually here, or handled by a filterwheel attribute.
+            self._filter_type = filter_type
+
+        if set_point:
+            self.ccd_set_point = set_point
+            self.ccd_cooling_enabled = True
+
+    def __del__(self):
+        """ Attempt some clean up """
+        with suppress(AttributeError):
+            uid = self.uid
+            type(self)._assigned_cameras.discard(uid)
+            self.logger.debug('Removed {} from assigned cameras list'.format(uid))
+        super().__del__()

--- a/pocs/camera/sdk.py
+++ b/pocs/camera/sdk.py
@@ -71,8 +71,8 @@ class AbstractSDKCamera(AbstractCamera):
         # scanning phase use get_root_logger() instead.
         logger = get_root_logger()
 
-        # The SDK cameras don't have a 'port', they are identified by a serial_number, which
-        # is some form of unique ID readable via the camera SDK.
+        # The SDK cameras don't generally have a 'port', they are identified by a serial_number,
+        # which is some form of unique ID readable via the camera SDK.
         kwargs['port'] = None
         serial_number = kwargs.get('serial_number')
         if not serial_number:
@@ -104,7 +104,7 @@ class AbstractSDKCamera(AbstractCamera):
 
         type(self)._assigned_cameras.add(serial_number)
         super().__init__(name, *args, **kwargs)
-        self._camera_ID = type(self)._cameras[self.uid]
+        self._address = type(self)._cameras[self.uid]
         self.connect()
         assert self.is_connected, error.PanError("Could not connect to {}.".format(self))
 

--- a/pocs/camera/sdk.py
+++ b/pocs/camera/sdk.py
@@ -1,3 +1,4 @@
+from abc import ABCMeta, abstractmethod
 from contextlib import suppress
 
 from pocs.base import PanBase
@@ -7,7 +8,7 @@ from pocs.utils.library import load_library
 from pocs.utils.logger import get_root_logger
 
 
-class AbstractSDKDriver(PanBase):
+class AbstractSDKDriver(PanBase, metaclass=ABCMeta):
     def __init__(self, name, library_path=None, **kwargs):
         """Base class for all camera SDK interfaces.
 
@@ -39,10 +40,12 @@ class AbstractSDKDriver(PanBase):
 
     # Methods
 
+    @abstractmethod
     def get_SDK_version(self):
         """ Get the version of the SDK """
         raise NotImplementedError
 
+    @abstractmethod
     def get_cameras(self):
         """Convenience function to get a dictionary of all currently connected camera UIDs
         and their corresponding device nodes/handles/camera IDs.

--- a/pocs/camera/sdk.py
+++ b/pocs/camera/sdk.py
@@ -114,7 +114,7 @@ class AbstractSDKCamera(AbstractCamera):
             # upstream of the CCD. Can be set manually here, or handled by a filterwheel attribute.
             self._filter_type = filter_type
 
-        if set_point:
+        if set_point is not None:
             self.ccd_set_point = set_point
             self.ccd_cooling_enabled = True
 

--- a/pocs/camera/simulator.py
+++ b/pocs/camera/simulator.py
@@ -18,14 +18,8 @@ class Camera(AbstractCamera):
 
     def __init__(self, name='Simulated Camera', *args, **kwargs):
         super().__init__(name, *args, **kwargs)
-        self._is_exposing = False
         self.connect()
         self.logger.info("{} initialised".format(self))
-
-    @property
-    def is_exposing(self):
-        """ True if an exposure is currently under way, otherwise False """
-        return self._is_exposing
 
     def connect(self):
         """ Connect to camera simulator

--- a/pocs/camera/simulator.py
+++ b/pocs/camera/simulator.py
@@ -51,19 +51,16 @@ class Camera(AbstractCamera):
                                         *args,
                                         **kwargs)
 
-    def _setup_exposure(self, seconds, filename, dark, header, *args, **kwargs):
-        self._seconds = seconds
-        readout_args = (filename, header)
-        return readout_args
-
     def _end_exposure(self):
         self._is_exposing = False
 
-    def _start_exposure(self):
-        exposure_thread = Timer(interval=get_quantity_value(self._seconds, unit=u.second) + 0.05,
+    def _start_exposure(self, seconds, filename, dark, header, *args, **kwargs):
+        exposure_thread = Timer(interval=get_quantity_value(seconds, unit=u.second) + 0.05,
                                 function=self._end_exposure)
         self._is_exposing = True
         exposure_thread.start()
+        readout_args = (filename, header)
+        return readout_args
 
     def _readout(self, filename, header):
         # Get example FITS file from test data directory

--- a/pocs/camera/simulator.py
+++ b/pocs/camera/simulator.py
@@ -9,7 +9,8 @@ import numpy as np
 from astropy import units as u
 from astropy.io import fits
 
-from pocs.camera import AbstractCamera
+from pocs.base import PanBase
+from pocs.camera import AbstractCamera, AbstractSDKCamera
 from pocs.utils.images import fits as fits_utils
 
 
@@ -94,3 +95,7 @@ class Camera(AbstractCamera):
 
         self.logger.debug("Headers updated for simulated image.")
         return file_path
+
+
+class SimSDKCamera(AbstractSDKCamera):
+    pass

--- a/pocs/camera/simulator.py
+++ b/pocs/camera/simulator.py
@@ -28,7 +28,7 @@ class Camera(AbstractCamera):
 
         The simulator merely markes the `connected` property.
         """
-        # Create a random serial number if onw hasn't been specified
+        # Create a random serial number if one hasn't been specified
         if self._serial_number == 'XXXXXX':
             self._serial_number = 'SC{:04d}'.format(random.randint(0, 9999))
 

--- a/pocs/camera/simulator.py
+++ b/pocs/camera/simulator.py
@@ -17,6 +17,7 @@ from pocs.utils import get_quantity_value
 class Camera(AbstractCamera):
 
     def __init__(self, name='Simulated Camera', *args, **kwargs):
+        kwargs['timeout'] = kwargs.get('timeout', 0.5 * u.second)
         super().__init__(name, *args, **kwargs)
         self.connect()
         self.logger.info("{} initialised".format(self))

--- a/pocs/camera/simulator.py
+++ b/pocs/camera/simulator.py
@@ -10,6 +10,7 @@ from astropy import units as u
 from astropy.io import fits
 
 from pocs.camera import AbstractCamera
+from pocs.camera.sdk import AbstractSDKDriver, AbstractSDKCamera
 from pocs.utils.images import fits as fits_utils
 from pocs.utils import get_quantity_value
 
@@ -27,8 +28,9 @@ class Camera(AbstractCamera):
 
         The simulator merely markes the `connected` property.
         """
-        # Create a random serial number
-        self._serial_number = 'SC{:04d}'.format(random.randint(0, 9999))
+        # Create a random serial number if onw hasn't been specified
+        if self._serial_number == 'XXXXXX':
+            self._serial_number = 'SC{:04d}'.format(random.randint(0, 9999))
 
         self._connected = True
         self.logger.debug('{} connected'.format(self.name))
@@ -90,3 +92,26 @@ class Camera(AbstractCamera):
 
         self.logger.debug("Headers updated for simulated image.")
         return file_path
+
+
+class SDKDriver(AbstractSDKDriver):
+    def __init__(self, library_path=None, **kwargs):
+        # Get library loader to load libc, which should usually be present...
+        super().__init__(name='c', library_path=library_path, **kwargs)
+
+    def get_SDK_version(self):
+        return "Simulated SDK Driver v0.001"
+
+    def get_cameras(self):
+        cameras = {'SSC007': 'DEV_USB0',
+                   'SSC101': 'DEV_USB1',
+                   'SSC999': 'DEV_USB2'}
+        return cameras
+
+
+class SDKCamera(AbstractSDKCamera, Camera):
+    def __init__(self,
+                 name='Simulated SDK camera',
+                 driver=SDKDriver,
+                 *args, **kwargs):
+        super().__init__(name, driver, *args, **kwargs)

--- a/pocs/camera/simulator.py
+++ b/pocs/camera/simulator.py
@@ -79,7 +79,7 @@ class Camera(AbstractCamera):
             fake_data = np.random.randint(low=975, high=1026,
                                           size=fake_data.shape,
                                           dtype=fake_data.dtype)
-        fits_utils.write_fits(fake_data, header, filename, self.logger)
+        fits_utils.write_fits(fake_data, header, filename, self.logger, self._exposure_event)
 
     def _process_fits(self, file_path, info):
         file_path = super()._process_fits(file_path, info)

--- a/pocs/camera/simulator.py
+++ b/pocs/camera/simulator.py
@@ -9,7 +9,6 @@ import numpy as np
 from astropy import units as u
 from astropy.io import fits
 
-from pocs.base import PanBase
 from pocs.camera import AbstractCamera
 from pocs.utils.images import fits as fits_utils
 from pocs.utils import get_quantity_value
@@ -25,6 +24,7 @@ class Camera(AbstractCamera):
 
     @property
     def is_exposing(self):
+        """ True if an exposure is currently under way, otherwise False """
         return self._is_exposing
 
     def connect(self):

--- a/pocs/camera/zwo.py
+++ b/pocs/camera/zwo.py
@@ -99,8 +99,8 @@ class Camera(AbstractSDKCamera):
         return self._control_getter('COOLER_ON')[0]
 
     @ccd_cooling_enabled.setter
-    def ccd_cooling_enabled(self, on):
-        self._control_setter('COOLER_ON', on)
+    def ccd_cooling_enabled(self, enable):
+        self._control_setter('COOLER_ON', enable)
 
     @property
     def ccd_cooling_power(self):

--- a/pocs/camera/zwo.py
+++ b/pocs/camera/zwo.py
@@ -10,8 +10,6 @@ from pocs.camera.sdk import AbstractSDKCamera
 from pocs.camera.libasi import ASIDriver
 from pocs.utils.images import fits as fits_utils
 from pocs.utils import error
-from pocs.utils import CountdownTimer
-from pocs.utils.logger import get_root_logger
 from pocs.utils import get_quantity_value
 
 
@@ -30,13 +28,12 @@ class Camera(AbstractSDKCamera):
         # camera_ID and, optionally, an 8 byte ID that can be written to the camera firmware
         # by the user (using ASICap, or pocs.camera.libasi.ASIDriver.set_ID()). We will use
         # the latter as a serial number string.
-        kwargs['port'] = None
-        kwargs['file_extension'] = 'fits'
         kwargs['readout_time'] = kwargs.get('readout_time', 0.1)
+        kwargs['timeout'] = kwargs.get('timeout', 0.5)
 
         self._video_event = threading.Event()
 
-        super().__init__(name, libasi.ASIDriver, *args, **kwargs)
+        super().__init__(name, ASIDriver, *args, **kwargs)
 
         if gain:
             self.gain = gain
@@ -45,7 +42,7 @@ class Camera(AbstractSDKCamera):
             self.image_type = image_type
         else:
             # Take monochrome 12 bit raw images by default, if we can
-            if 'RAW16' in self._info['supported_video_format']:
+            if 'RAW16' in self.properties['supported_video_format']:
                 self.image_type = 'RAW16'
 
         self.logger.info('{} initialised'.format(self))
@@ -54,37 +51,27 @@ class Camera(AbstractSDKCamera):
         """ Attempt some clean up """
         with suppress(AttributeError):
             camera_ID = self._camera_ID
-            Camera._ASIDriver.close_camera(camera_ID)
+            Camera._driver.close_camera(camera_ID)
             self.logger.debug("Closed ZWO camera {}".format(camera_ID))
         super().__del__()
 
     # Properties
 
-    @AbstractCamera.uid.getter
-    def uid(self):
-        """Return unique identifier for camera.
-
-        Need to override this because the base class only returns the 1st
-        6 characters of the serial number, which is not a unique identifier
-        for most of the camera types.
-        """
-        return self._serial_number
-
     @property
     def image_type(self):
         """ Current camera image type, one of 'RAW8', 'RAW16', 'Y8', 'RGB24' """
-        roi_format = Camera._ASIDriver.get_roi_format(self._camera_ID)
+        roi_format = Camera._driver.get_roi_format(self._camera_ID)
         return roi_format['image_type']
 
     @image_type.setter
     def image_type(self, new_image_type):
-        if new_image_type not in self._info['supported_video_format']:
+        if new_image_type not in self.properties['supported_video_format']:
             msg = "Image type '{} not supported by {}".format(new_image_type, self.model)
             self.logger.error(msg)
             raise ValueError(msg)
-        roi_format = self._ASIDriver.get_roi_format(self._camera_ID)
+        roi_format = self._driver.get_roi_format(self._camera_ID)
         roi_format['image_type'] = new_image_type
-        Camera._ASIDriver.set_roi_format(self._camera_ID, **roi_format)
+        Camera._driver.set_roi_format(self._camera_ID, **roi_format)
 
     @property
     def ccd_temp(self):
@@ -135,33 +122,14 @@ class Camera(AbstractSDKCamera):
     def egain(self):
         """ Nominal value of the image sensor gain for the camera's current gain setting """
         self._refresh_info()
-        return self._info['e_per_adu']
+        return self.properties['e_per_adu']
 
     @property
     def is_exposing(self):
         """ True if an exposure is currently under way, otherwise False """
-        return Camera._ASIDriver.get_exposure_status(self._camera_ID) == "WORKING"
-
-    @property
-    def properties(self):
-        """ A collection of camera properties as read from the camera """
-        return self._info
+        return Camera._driver.get_exposure_status(self._camera_ID) == "WORKING"
 
     # Methods
-
-    def __str__(self):
-        # ZWO ASI cameras don't have a port so just include the serial number in the string
-        # representation.
-        s = "{} ({})".format(self.name, self.uid)
-
-        if self.focuser:
-            s += ' with {}'.format(self.focuser.name)
-            if self.filterwheel:
-                s += ' & {}'.format(self.filterwheel.name)
-        elif self.filterwheel:
-            s += ' with {}'.format(self.filterwheel.name)
-
-        return s
 
     def connect(self):
         """
@@ -171,17 +139,22 @@ class Camera(AbstractSDKCamera):
         of available camera commands/parameters.
         """
         self.logger.debug("Connecting to {}".format(self))
+        # Some confusing fiddling with camera_ID and camera_index here because the ASI Driver
+        # has *two* distinct integer IDs for each camera which are not guaranteed to be identical
+        # The initial scan gives camera_index, which is used to get camera info, then camera_ID
+        # is used for everything else.
+        self._camera_index = self._camera_ID
         self._refresh_info()
-        self._camera_ID = self._info['camera_ID']
-        self.model, _, _ = self._info['name'].partition('(')
-        if self._info['is_color_camera']:
-            self._filter_type = self._info['bayer_pattern']
+        self._camera_ID = self.properties['camera_ID']
+        self.model, _, _ = self.properties['name'].partition('(')
+        if self.properties['is_color_camera']:
+            self._filter_type = self.properties['bayer_pattern']
         else:
             self._filter_type = 'M'  # Monochrome
-        Camera._ASIDriver.open_camera(self._camera_ID)
-        Camera._ASIDriver.init_camera(self._camera_ID)
-        self._control_info = Camera._ASIDriver.get_control_caps(self._camera_ID)
-
+        Camera._driver.open_camera(self._camera_ID)
+        Camera._driver.init_camera(self._camera_ID)
+        self._control_info = Camera._driver.get_control_caps(self._camera_ID)
+        self._info['control_info'] = self._control_info  # control info accessible via properties
         self._connected = True
 
     def start_video(self, seconds, filename_root, max_frames, image_type=None):
@@ -191,7 +164,7 @@ class Camera(AbstractSDKCamera):
         if image_type:
             self.image_type = image_type
 
-        roi_format = Camera._ASIDriver.get_roi_format(self._camera_ID)
+        roi_format = Camera._driver.get_roi_format(self._camera_ID)
         width = int(get_quantity_value(roi_format['width'], unit=u.pixel))
         height = int(get_quantity_value(roi_format['height'], unit=u.pixel))
         image_type = roi_format['image_type']
@@ -210,14 +183,14 @@ class Camera(AbstractSDKCamera):
                                         args=video_args,
                                         daemon=True)
 
-        Camera._ASIDriver.start_video_capture(self._camera_ID)
+        Camera._driver.start_video_capture(self._camera_ID)
         self._video_event.clear()
         video_thread.start()
         self.logger.debug("Video capture started on {}".format(self))
 
     def stop_video(self):
         self._video_event.set()
-        Camera._ASIDriver.stop_video_capture(self._camera_ID)
+        Camera._driver.stop_video_capture(self._camera_ID)
         self.logger.debug("Video capture stopped on {}".format(self))
 
     # Private methods
@@ -239,11 +212,11 @@ class Camera(AbstractSDKCamera):
             if self._video_event.is_set():
                 break
             # This call will block for up to timeout milliseconds waiting for a frame
-            video_data = Camera._ASIDriver.get_video_data(self._camera_ID,
-                                                          width,
-                                                          height,
-                                                          image_type,
-                                                          timeout)
+            video_data = Camera._driver.get_video_data(self._camera_ID,
+                                                       width,
+                                                       height,
+                                                       image_type,
+                                                       timeout)
             if video_data is not None:
                 now = Time.now()
                 header.set('DATE-OBS', now.fits, 'End of exposure + readout')
@@ -265,81 +238,58 @@ class Camera(AbstractSDKCamera):
             get_quantity_value(good_frames / elapsed_time),
             bad_frames))
 
-    def _take_exposure(self, seconds, filename, dark, exposure_event, header, *args, **kwargs):
-        if not self._exposure_lock.acquire(blocking=False):
-            self.logger.warning('Exposure started on {} while one in progress! Waiting.'.format(
-                self))
-            self._exposure_lock.acquire(blocking=True)
-
+    def _setup_exposure(self, seconds, filename, dark, header, *args, **kwargs):
         self._control_setter('EXPOSURE', seconds)
-        roi_format = Camera._ASIDriver.get_roi_format(self._camera_ID)
-
-        # Start exposure
-        Camera._ASIDriver.start_exposure(self._camera_ID)
-
-        # Start readout thread
+        roi_format = Camera._driver.get_roi_format(self._camera_ID)
         readout_args = (filename,
                         roi_format['width'],
                         roi_format['height'],
-                        header,
-                        exposure_event)
-        readout_thread = threading.Timer(interval=seconds.value,
-                                         function=self._readout,
-                                         args=readout_args)
-        readout_thread.start()
+                        header)
+        return readout_args
 
-    def _readout(self, filename, width, height, header, exposure_event):
-        timer = CountdownTimer(duration=self._timeout)
-        try:
-            exposure_status = Camera._ASIDriver.get_exposure_status(self._camera_ID)
-            while exposure_status == 'WORKING':
-                if timer.expired():
-                    msg = "Timeout waiting for exposure on {} to complete".format(self)
-                    raise error.Timeout(msg)
-                time.sleep(0.01)
-                exposure_status = Camera._ASIDriver.get_exposure_status(self._camera_ID)
-        except RuntimeError as err:
-            # Error returned by driver at some point while polling
-            self.logger.error('Error while waiting for exposure on {}: {}'.format(self, err))
-            raise err
-        else:
-            if exposure_status == 'SUCCESS':
-                try:
-                    image_data = Camera._ASIDriver.get_exposure_data(self._camera_ID,
-                                                                     width,
-                                                                     height,
-                                                                     self.image_type)
-                except RuntimeError as err:
-                    raise error.PanError('Error getting image data from {}: {}'.format(self, err))
-                else:
-                    fits_utils.write_fits(image_data, header, filename, self.logger, exposure_event)
-            elif exposure_status == 'FAILED':
-                raise error.PanError("Exposure failed on {}".format(self))
-            elif exposure_status == 'IDLE':
-                raise error.PanError("Exposure missing on {}".format(self))
+    def _start_exposure(self):
+        Camera._driver.start_exposure(self._camera_ID)
+
+    def _readout(self, filename, width, height, header):
+        exposure_status = Camera._driver.get_exposure_status(self._camera_ID)
+        if exposure_status == 'SUCCESS':
+            try:
+                image_data = Camera._driver.get_exposure_data(self._camera_ID,
+                                                              width,
+                                                              height,
+                                                              self.image_type)
+            except RuntimeError as err:
+                raise error.PanError('Error getting image data from {}: {}'.format(self, err))
             else:
-                raise error.PanError("Unexpected exposure status on {}: '{}'".format(
-                    self, exposure_status))
-        finally:
-            exposure_event.set()  # write_fits will have already set this, *if* it got called.
-            self._exposure_lock.release()
+                fits_utils.write_fits(image_data,
+                                      header,
+                                      filename,
+                                      self.logger,
+                                      self._exposure_event)
+        elif exposure_status == 'FAILED':
+            raise error.PanError("Exposure failed on {}".format(self))
+        elif exposure_status == 'IDLE':
+            raise error.PanError("Exposure missing on {}".format(self))
+        else:
+            raise error.PanError("Unexpected exposure status on {}: '{}'".format(
+                self, exposure_status))
 
     def _fits_header(self, seconds, dark):
         header = super()._fits_header(seconds, dark)
         header.set('CAM-GAIN', self.gain, 'Internal units')
-        header.set('CAM-BITS', int(get_quantity_value(self._info['bit_depth'], u.bit)),
+        header.set('CAM-BITS', int(get_quantity_value(self.properties['bit_depth'], u.bit)),
                    'ADC bit depth')
-        header.set('XPIXSZ', get_quantity_value(self._info['pixel_size'], u.um), 'Microns')
-        header.set('YPIXSZ', get_quantity_value(self._info['pixel_size'], u.um), 'Microns')
+        header.set('XPIXSZ', get_quantity_value(self.properties['pixel_size'], u.um), 'Microns')
+        header.set('YPIXSZ', get_quantity_value(self.properties['pixel_size'], u.um), 'Microns')
         header.set('EGAIN', get_quantity_value(self.egain, u.electron / u.adu), 'Electrons/ADU')
         return header
 
     def _refresh_info(self):
-        self._info = Camera._ASIDriver.get_camera_property(self._camera_index)
+        self._info = Camera._driver.get_camera_property(self._camera_index)
 
     def _control_getter(self, control_type):
         if control_type in self._control_info:
-            return Camera._ASIDriver.get_control_value(self._camera_ID, control_type)
+            return Camera._driver.get_control_value(self._camera_ID, control_type)
         else:
             raise error.NotSupported("{} has no '{}' parameter".format(self.model, control_type))
 
@@ -358,18 +308,18 @@ class Camera(AbstractSDKCamera):
             if value > max_value:
                 msg = "Cannot set {} to {}, clipping to max value {}".format(
                     control_name, value, max_value)
-                Camera._ASIDriver.set_control_value(self._camera_ID, control_type, max_value)
+                Camera._driver.set_control_value(self._camera_ID, control_type, max_value)
                 raise error.IllegalValue(msg)
 
             min_value = self._control_info[control_type]['min_value']
             if value < min_value:
                 msg = "Cannot set {} to {}, clipping to min value {}".format(
                     control_name, value, min_value)
-                Camera._ASIDriver.set_control_value(self._camera_ID, control_type, min_value)
+                Camera._driver.set_control_value(self._camera_ID, control_type, min_value)
                 raise error.IllegalValue(msg)
         else:
             if not self._control_info[control_type]['is_auto_supported']:
                 msg = "{} cannot set {} to AUTO".format(self.model, control_name)
                 raise error.IllegalValue(msg)
 
-        Camera._ASIDriver.set_control_value(self._camera_ID, control_type, value)
+        Camera._driver.set_control_value(self._camera_ID, control_type, value)

--- a/pocs/camera/zwo.py
+++ b/pocs/camera/zwo.py
@@ -248,6 +248,7 @@ class Camera(AbstractSDKCamera):
         return readout_args
 
     def _start_exposure(self):
+        self._exposure_event.clear()
         Camera._driver.start_exposure(self._camera_ID)
 
     def _readout(self, filename, width, height, header):

--- a/pocs/camera/zwo.py
+++ b/pocs/camera/zwo.py
@@ -90,6 +90,7 @@ class Camera(AbstractSDKCamera):
     def ccd_set_point(self, set_point):
         if not isinstance(set_point, u.Quantity):
             set_point = set_point * u.Celsius
+        self.logger.debug("Setting {} cooling set point to {}".format(self, set_point))
         self._control_setter('TARGET_TEMP', set_point)
 
     @property

--- a/pocs/tests/test_camera.py
+++ b/pocs/tests/test_camera.py
@@ -23,8 +23,8 @@ from pocs.utils import error
 from pocs import hardware
 
 
-params = [SimCamera, SBIGCamera, FLICamera, ZWOCamera]
-ids = ['simulator', 'sbig', 'fli', 'zwo']
+params = [SimCamera, SimCamera, SimCamera, SBIGCamera, FLICamera, ZWOCamera]
+ids = ['simulator', 'simulator_focuser', 'simulator_filterwheel', 'sbig', 'fli', 'zwo']
 
 
 @pytest.fixture(scope='module')
@@ -36,7 +36,9 @@ def images_dir(tmpdir_factory):
 # Ugly hack to access id inside fixture
 @pytest.fixture(scope='module', params=zip(params, ids), ids=ids)
 def camera(request, images_dir):
-    if request.param[0] == SimCamera:
+    if request.param[1] == 'simulator':
+        camera = SimCamera()
+    elif request.param[1] == 'simulator_focuser':
         camera = SimCamera(focuser={'model': 'simulator',
                                     'focus_port': '/dev/ttyFAKE',
                                     'initial_position': 20000,
@@ -44,11 +46,12 @@ def camera(request, images_dir):
                                     'autofocus_step': (10, 20),
                                     'autofocus_seconds': 0.1,
                                     'autofocus_size': 500,
-                                    'autofocus_keep_files': False},
-                           filterwheel={'model': 'simulator',
-                                        'filter_names': ['one', 'deux', 'drei', 'quattro'],
-                                        'move_time': 0.1,
-                                        'timeout': 0.5})
+                                    'autofocus_keep_files': False})
+    elif request.param[1] == 'simulator_filterwheel':
+            camera = SimCamera(filterwheel={'model': 'simulator',
+                                            'filter_names': ['one', 'deux', 'drei', 'quattro'],
+                                            'move_time': 0.1,
+                                            'timeout': 0.5})
     else:
         # Load the local config file and look for camera configurations of the specified type
         configs = []

--- a/pocs/tests/test_camera.py
+++ b/pocs/tests/test_camera.py
@@ -328,15 +328,15 @@ def test_exposure_collision(camera, tmpdir):
     fits_path_1 = str(tmpdir.join('test_exposure_collision1.fits'))
     fits_path_2 = str(tmpdir.join('test_exposure_collision2.fits'))
     camera.take_exposure(2 * u.second, filename=fits_path_1)
-    camera.take_exposure(1 * u.second, filename=fits_path_2)
+    with pytest.raises(error.PanError):
+        camera.take_exposure(1 * u.second, filename=fits_path_2)
     if isinstance(camera, FLICamera):
         time.sleep(10)
     else:
         time.sleep(5)
     assert os.path.exists(fits_path_1)
-    assert os.path.exists(fits_path_2)
+    assert not os.path.exists(fits_path_2)
     assert fits_utils.getval(fits_path_1, 'EXPTIME') == 2.0
-    assert fits_utils.getval(fits_path_2, 'EXPTIME') == 1.0
 
 
 def test_exposure_no_filename(camera):

--- a/pocs/tests/test_camera.py
+++ b/pocs/tests/test_camera.py
@@ -193,11 +193,8 @@ def test_sbig_bad_serial():
     """
     if find_library('sbigudrv') is None:
         pytest.skip("Test requires SBIG camera driver to be installed")
-    camera = SBIGCamera(port='NOTAREALSERIALNUMBER')
-    assert camera._connected is False
-    if isinstance(camera, SBIGCamera):
-        assert camera._handle == INVALID_HANDLE_VALUE
-
+    with pytest.raises(error.PanError):
+        camera = SBIGCamera(serial_number='NOTAREALSERIALNUMBER')
 
 # *Potentially* hardware dependant tests:
 


### PR DESCRIPTION
Refactoring (again) the `Camera` and `Driver` classes for reasons explained in #786. The changes in this PR are intended to resolve inconsistencies between the ZWO, FLI & SBIG code, and move at much as possible into base classes.

I've introduced new `AbstractSDKCamera` and `AbstractSDKDriver` base classes, into which I've moved driver initialisation and location of cameras by serial number. I've also moved more functionality into the `AbstractCamera` base class, in particular the polling of exposure status, preventing exposure collisions, etc. These changes address points 1-3 and 5 of #786, I'm keeping point 4 out of this PR.

Currently the new code has been tested against the simulator and real ZWO and FLI cameras. I'll test with an SBIG camera on Friday. Still some work to do regardless, mostly updating tests and general tidying up.