### PR TITLE
Make simulated filterwheel move time tests more lenient

### DIFF
--- a/pocs/tests/test_filterwheel.py
+++ b/pocs/tests/test_filterwheel.py
@@ -154,11 +154,11 @@ def test_move_times(name, bidirectional, expected):
                                      timeout=0.5 * u.second)
     sim_filterwheel.position = 1
     assert timeit("sim_filterwheel.position = 2", number=1, globals=locals()) == \
-        pytest.approx(0.1, rel=2e-2)
+        pytest.approx(0.1, rel=4e-2)
     assert timeit("sim_filterwheel.position = 4", number=1, globals=locals()) == \
-        pytest.approx(0.2, rel=2e-2)
+        pytest.approx(0.2, rel=4e-2)
     assert timeit("sim_filterwheel.position = 3", number=1, globals=locals()) == \
-        pytest.approx(expected, rel=2e-2)
+        pytest.approx(expected, rel=4e-2)
 
 
 def test_move_exposing(tmpdir, caplog):


### PR DESCRIPTION
Increases the tolerance on the tests of the simulated filterwheel movement times in order to stop occasional test failures when Travis CI is running slowly.