### PR TITLE
Fix DSLR 812

### DIFF
--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -284,7 +284,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
 
         self.logger.debug('Taking {} exposure on {}: {}'.format(seconds, self.name, filename))
 
-        header = self._fits_header(seconds, dark)
+        header = self._create_fits_header(seconds, dark)
 
         if not self._exposure_event.is_set():
             msg = "Attempt to take exposure on {} while one already in progress.".format(self)
@@ -523,7 +523,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         finally:
             self._exposure_event.set()  # Make sure this gets set regardless of readout errors
 
-    def _fits_header(self, seconds, dark=None):
+    def _create_fits_header(self, seconds, dark=None):
         header = fits.Header()
         header.set('INSTRUME', self.uid, 'Camera serial number')
         now = Time.now()

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -496,7 +496,8 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         """Performs the camera-specific readout after exposure.
 
         This method is called from the `_poll_exposure` private method and is responsible
-        for the camera-specific readout commands.
+        for the camera-specific readout commands. This method is responsible for actually
+        writing the FITS file.
 
         Note:
             Each sub-class is required to implement this abstract method. The derived
@@ -630,7 +631,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         Add FITS headers from info the same as images.cr2_to_fits()
         """
         self.logger.debug("Updating FITS headers: {}".format(file_path))
-        fits_utils.update_headers(file_path, info)
+        fits_utils.update_observation_headers(file_path, info)
         return file_path
 
     def _create_subcomponent(self, subcomponent, sub_name, class_name, base_class):

--- a/pocs/camera/fli.py
+++ b/pocs/camera/fli.py
@@ -153,7 +153,6 @@ class Camera(AbstractSDKCamera):
             raise error.PanError(message)
         else:
             fits_utils.write_fits(image_data, header, filename, self.logger)
-            self._exposure_event.set()
 
     def _fits_header(self, seconds, dark):
         header = super()._fits_header(seconds, dark)

--- a/pocs/camera/fli.py
+++ b/pocs/camera/fli.py
@@ -154,8 +154,8 @@ class Camera(AbstractSDKCamera):
         else:
             fits_utils.write_fits(image_data, header, filename, self.logger)
 
-    def _fits_header(self, seconds, dark):
-        header = super()._fits_header(seconds, dark)
+    def _create_fits_header(self, seconds, dark):
+        header = super()._create_fits_header(seconds, dark)
 
         header.set('CAM-HW', self._info['hardware version'], 'Camera hardware version')
         header.set('CAM-FW', self._info['firmware version'], 'Camera firmware version')

--- a/pocs/camera/fli.py
+++ b/pocs/camera/fli.py
@@ -1,8 +1,3 @@
-import time
-from warnings import warn
-from threading import Event
-from threading import Timer
-from threading import Lock
 from contextlib import suppress
 
 import numpy as np
@@ -157,7 +152,8 @@ class Camera(AbstractSDKCamera):
                 self, image_data.shape[0], rows_got, err)
             raise error.PanError(message)
         else:
-            fits_utils.write_fits(image_data, header, filename, self.logger, self._exposure_event)
+            fits_utils.write_fits(image_data, header, filename, self.logger)
+            self._exposure_event.set()
 
     def _fits_header(self, seconds, dark):
         header = super()._fits_header(seconds, dark)

--- a/pocs/camera/sbig.py
+++ b/pocs/camera/sbig.py
@@ -186,8 +186,8 @@ class Camera(AbstractSDKCamera):
             raise error.PanError("Unexpected exposure status on {}: '{}'".format(
                 self, exposure_status))
 
-    def _fits_header(self, seconds, dark):
-        header = super()._fits_header(seconds, dark)
+    def _create_fits_header(self, seconds, dark):
+        header = super()._create_fits_header(seconds, dark)
 
         # Unbinned. Need to chance if binning gets implemented.
         readout_mode = 'RM_1X1'

--- a/pocs/camera/sbig.py
+++ b/pocs/camera/sbig.py
@@ -1,5 +1,3 @@
-from threading import Event
-from warnings import warn
 from contextlib import suppress
 
 from astropy import units as u
@@ -8,6 +6,7 @@ from pocs.camera.sdk import AbstractSDKCamera
 from pocs.camera.sbigudrv import INVALID_HANDLE_VALUE
 from pocs.camera.sbigudrv import SBIGDriver
 from pocs.utils.images import fits as fits_utils
+from pocs.utils import error
 
 
 class Camera(AbstractSDKCamera):
@@ -180,8 +179,8 @@ class Camera(AbstractSDKCamera):
                 fits_utils.write_fits(image_data,
                                       header,
                                       filename,
-                                      self.logger,
-                                      self._exposure_event)
+                                      self.logger)
+                self._exposure_event.set()
         elif exposure_status == 'CS_IDLE':
             raise error.PanError("Exposure missing on {}".format(self))
         else:

--- a/pocs/camera/sbig.py
+++ b/pocs/camera/sbig.py
@@ -180,7 +180,6 @@ class Camera(AbstractSDKCamera):
                                       header,
                                       filename,
                                       self.logger)
-                self._exposure_event.set()
         elif exposure_status == 'CS_IDLE':
             raise error.PanError("Exposure missing on {}".format(self))
         else:

--- a/pocs/camera/simulator.py
+++ b/pocs/camera/simulator.py
@@ -73,7 +73,6 @@ class Camera(AbstractCamera):
                                           size=fake_data.shape,
                                           dtype=fake_data.dtype)
         fits_utils.write_fits(fake_data, header, filename, self.logger)
-        self._exposure_event.set()
 
     def _process_fits(self, file_path, info):
         file_path = super()._process_fits(file_path, info)

--- a/pocs/camera/simulator.py
+++ b/pocs/camera/simulator.py
@@ -1,7 +1,6 @@
 import os
 import random
 
-from threading import Event
 from threading import Timer
 
 import numpy as np
@@ -73,7 +72,8 @@ class Camera(AbstractCamera):
             fake_data = np.random.randint(low=975, high=1026,
                                           size=fake_data.shape,
                                           dtype=fake_data.dtype)
-        fits_utils.write_fits(fake_data, header, filename, self.logger, self._exposure_event)
+        fits_utils.write_fits(fake_data, header, filename, self.logger)
+        self._exposure_event.set()
 
     def _process_fits(self, file_path, info):
         file_path = super()._process_fits(file_path, info)

--- a/pocs/camera/zwo.py
+++ b/pocs/camera/zwo.py
@@ -258,8 +258,8 @@ class Camera(AbstractSDKCamera):
                 fits_utils.write_fits(image_data,
                                       header,
                                       filename,
-                                      self.logger,
-                                      self._exposure_event)
+                                      self.logger)
+                self._exposure_event.set()
         elif exposure_status == 'FAILED':
             raise error.PanError("Exposure failed on {}".format(self))
         elif exposure_status == 'IDLE':

--- a/pocs/camera/zwo.py
+++ b/pocs/camera/zwo.py
@@ -259,7 +259,6 @@ class Camera(AbstractSDKCamera):
                                       header,
                                       filename,
                                       self.logger)
-                self._exposure_event.set()
         elif exposure_status == 'FAILED':
             raise error.PanError("Exposure failed on {}".format(self))
         elif exposure_status == 'IDLE':

--- a/pocs/camera/zwo.py
+++ b/pocs/camera/zwo.py
@@ -174,7 +174,7 @@ class Camera(AbstractSDKCamera):
                       filename_root,
                       self.file_extension,
                       int(max_frames),
-                      self._fits_header(seconds, dark=False))
+                      self._create_fits_header(seconds, dark=False))
         video_thread = threading.Thread(target=self._video_readout,
                                         args=video_args,
                                         daemon=True)
@@ -267,8 +267,8 @@ class Camera(AbstractSDKCamera):
             raise error.PanError("Unexpected exposure status on {}: '{}'".format(
                 self, exposure_status))
 
-    def _fits_header(self, seconds, dark):
-        header = super()._fits_header(seconds, dark)
+    def _create_fits_header(self, seconds, dark):
+        header = super()._create_fits_header(seconds, dark)
         header.set('CAM-GAIN', self.gain, 'Internal units')
         header.set('CAM-BITS', int(get_quantity_value(self.properties['bit_depth'], u.bit)),
                    'ADC bit depth')

--- a/pocs/utils/images/cr2.py
+++ b/pocs/utils/images/cr2.py
@@ -107,7 +107,7 @@ def cr2_to_fits(
             if remove_cr2:
                 os.unlink(cr2_fname)
 
-        fits_utils.update_headers(fits_fname, headers)
+        fits_utils.update_observation_headers(fits_fname, headers)
 
     return fits_fname
 

--- a/pocs/utils/images/fits.py
+++ b/pocs/utils/images/fits.py
@@ -349,7 +349,7 @@ def funpack(*args, **kwargs):
     return fpack(*args, unpack=True, **kwargs)
 
 
-def write_fits(data, header, filename, logger=None, exposure_event=None):
+def write_fits(data, header, filename, logger=None):
     """
     Write FITS file to requested location
     """
@@ -368,9 +368,6 @@ def write_fits(data, header, filename, logger=None, exposure_event=None):
     else:
         if logger:
             logger.debug('Image written to {}'.format(filename))
-    finally:
-        if exposure_event:
-            exposure_event.set()
 
 
 def update_headers(file_path, info):

--- a/pocs/utils/images/fits.py
+++ b/pocs/utils/images/fits.py
@@ -370,7 +370,7 @@ def write_fits(data, header, filename, logger=None):
             logger.debug('Image written to {}'.format(filename))
 
 
-def update_headers(file_path, info):
+def update_observation_headers(file_path, info):
     with fits.open(file_path, 'update') as f:
         hdu = f[0]
         hdu.header.set('IMAGEID', info.get('image_id', ''))


### PR DESCRIPTION
Fixes the DSLR cameras (`canon_gphoto2`) with respect to the changes introduced in #787 

## Description
Adds the `_start_exposure` and `_readout` methods to the gphoto2 cameras to bring them in line with the base classes.

* Add docstrings for abstract `_readout` and `_start_exposure` methods.
* Update `canon_gphoto2` to use `_start_exposure` and `_readout`.
    * Note that this makes the `_start_exposure` method return a filename rather than the underlying subprocess. It *should* still all be handled correctly but this needs to be checked.
* Remove the `_exposure_event.set()` call from the camera's `_readout` methods as that relies on the user knowing that is required, which might not happen. The same call happens at the end of `_poll_exposure` so the calls were redundant anyway.
* Renames methods to make them more explicit:
    * `_fits_headers` to `_create_fits_headers`
    * `update_headers` to `update_observation_headers`
* Minor cleanup and fixes.

## Related Issue
Closes #812 
#787 

## How Has This Been Tested?

Confirmed with hardware.