### PR TITLE
Using `full_load` to remove deprecation warning.

### DIFF
--- a/pocs/mount/serial.py
+++ b/pocs/mount/serial.py
@@ -185,7 +185,7 @@ class AbstractSerialMount(AbstractMount):
                         "Loading mount commands file: {}".format(conf_file))
                     try:
                         with open(conf_file, 'r') as f:
-                            commands.update(yaml.load(f.read()))
+                            commands.update(yaml.full_load(f.read()))
                             self.logger.debug(
                                 "Mount commands updated from {}".format(conf_file))
                     except OSError as err:

--- a/pocs/scheduler/scheduler.py
+++ b/pocs/scheduler/scheduler.py
@@ -267,7 +267,7 @@ class BaseScheduler(PanBase):
                 raise FileNotFoundError
 
             with open(self.fields_file, 'r') as f:
-                self._fields_list = yaml.load(f.read())
+                self._fields_list = yaml.full_load(f.read())
 
         if self._fields_list is not None:
             for field_config in self._fields_list:

--- a/pocs/state/machine.py
+++ b/pocs/state/machine.py
@@ -315,7 +315,7 @@ class PanStateMachine(Machine):
 
         try:
             with open(state_table_file, 'r') as f:
-                state_table = yaml.load(f.read())
+                state_table = yaml.full_load(f.read())
         except Exception as err:
             raise error.InvalidConfig(
                 'Problem loading state table yaml file: {} {}'.format(err, state_table_file))

--- a/pocs/tests/test_base_scheduler.py
+++ b/pocs/tests/test_base_scheduler.py
@@ -31,7 +31,7 @@ def observer(config):
 
 @pytest.fixture()
 def field_list():
-    return yaml.load("""
+    return yaml.full_load("""
     -
         name: HD 189733
         position: 20h00m43.7135s +22d42m39.0645s

--- a/pocs/tests/test_constraints.py
+++ b/pocs/tests/test_constraints.py
@@ -42,7 +42,7 @@ def horizon_line(config):
 
 @pytest.fixture
 def field_list():
-    return yaml.load("""
+    return yaml.full_load("""
 -
     name: HD 189733
     position: 20h00m43.7135s +22d42m39.0645s

--- a/pocs/tests/test_dispatch_scheduler.py
+++ b/pocs/tests/test_dispatch_scheduler.py
@@ -39,7 +39,7 @@ def field_file(config):
 
 @pytest.fixture()
 def field_list():
-    return yaml.load("""
+    return yaml.full_load("""
     -
         name: HD 189733
         position: 20h00m43.7135s +22d42m39.0645s

--- a/pocs/utils/config.py
+++ b/pocs/utils/config.py
@@ -148,7 +148,7 @@ def _parse_config(config):
 def _add_to_conf(config, fn):
     try:
         with open(fn, 'r') as f:
-            c = yaml.load(f.read())
+            c = yaml.full_load(f.read())
             if c is not None and isinstance(c, dict):
                 config.update(c)
     except IOError:  # pragma: no cover

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ pymongo >= 3.2.2
 pyserial >= 3.1.1
 pytest >= 3.4.0
 python_dateutil >= 2.5.3
-PyYAML >= 3.11
+PyYAML >= 5.1
 pyzmq >= 15.3.0
 readline
 requests


### PR DESCRIPTION
Deprecation Update

## Description
Uses the new `full_load` feature from PyYAML. Requires PyYAML >= 5.1, so requires an update (`pip install -Ur requirements.txt`).

## Related Issue
#810 

## How Has This Been Tested?
Doesn't change tests or any code but removes DeprecationWarnings from test output.

* [x] **Test output should be checked before merging**

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
