### PR TITLE
updated depreciated pytest.config at tests at pocs/tests/test_theskyx_utils.py

### DIFF
--- a/pocs/tests/test_theskyx_utils.py
+++ b/pocs/tests/test_theskyx_utils.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+import requests
 
 from mocket import Mocket
 

--- a/pocs/tests/test_theskyx_utils.py
+++ b/pocs/tests/test_theskyx_utils.py
@@ -1,6 +1,5 @@
 import os
 import pytest
-import requests
 
 from mocket import Mocket
 

--- a/pocs/tests/test_theskyx_utils.py
+++ b/pocs/tests/test_theskyx_utils.py
@@ -25,7 +25,7 @@ def skyx(request):
     yield theskyx
 
 
-def test_default_connect():
+def test_default_connect(request):
     """Test connection to TheSkyX
 
     If not running with a real connection then use Mocket

--- a/pocs/tests/test_theskyx_utils.py
+++ b/pocs/tests/test_theskyx_utils.py
@@ -31,7 +31,7 @@ def test_default_connect():
     If not running with a real connection then use Mocket
     """
     # Use `--with-hardware thesky` on cli to run without mock
-    if 'theskyx' not in pytest.config.getoption('--with-hardware'):
+    if 'theskyx' not in request.config.getoption('--with-hardware'):
         Mocket.enable('theskyx', '{}/pocs/tests/data'.format(os.getenv('POCS')))
 
     skyx = TheSkyX()

--- a/pocs/tests/test_theskyx_utils.py
+++ b/pocs/tests/test_theskyx_utils.py
@@ -17,7 +17,7 @@ def skyx(request):
 
     # Use `--with-hardware thesky` on cli to run without mock
     Mocket.enable('theskyx', '{}/pocs/tests/data'.format(os.getenv('POCS')))
-    if 'theskyx' in pytest.config.getoption('--with-hardware'):
+    if 'theskyx' in request.config.getoption('--with-hardware'):
         Mocket.disable()
 
     theskyx = TheSkyX(connect=False)


### PR DESCRIPTION
updated depreciated pytest.config with request.config in line 20 which return the same config object.

