### PR TITLE
Force cfitsio into a specific directory during install.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,6 @@ addons:
     - zlib1g-dev
     - libbz2-dev
     - swig
-    - cfitsio-dev
 install:
   - cd $PANDIR
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ before_install:
     - conda info -a # Useful for debugging any issues with conda
     - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
     - source activate test-environment
+    - conda install numpy scipy
 
     # Install astrometry.net
     - wget https://github.com/dstndstn/astrometry.net/releases/download/0.78/astrometry.net-0.78.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,10 +54,9 @@ install:
   - cd $PANDIR
 
   # Install astrometry.net
-  - wget https://github.com/dstndstn/astrometry.net/releases/download/0.72/astrometry.net-0.72.tar.gz
-  - tar zxvf astrometry.net-0.72.tar.gz && cd astrometry.net-0.72
-  - make CFITS_INC="-I/usr/local/include" CFITS_SLIB="/usr/local/lib/libcfitsio.a"
-  - make py && make install INSTALL_DIR=$PANDIR/astrometry
+  - wget https://github.com/dstndstn/astrometry.net/releases/download/0.78/astrometry.net-0.78.tar.gz
+  - tar zxvf astrometry.net-0.78.tar.gz && cd astrometry.net-0.78
+  - make && make py && make install INSTALL_DIR=$PANDIR/astrometry
   - echo 'add_path $PANDIR/astrometry/data' | sudo tee --append $PANDIR/astrometry/etc/astrometry.cfg
 
   # Install miniconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ install:
   # Install astrometry.net
   - wget https://github.com/dstndstn/astrometry.net/releases/download/0.72/astrometry.net-0.72.tar.gz
   - tar zxvf astrometry.net-0.72.tar.gz && cd astrometry.net-0.72
-  - make CFITS_INC="-I/usr/local/" CFITS_SLIB="/usr/local/lib/libcfitsio.a"
+  - make CFITS_INC="-I/usr/local/include" CFITS_SLIB="/usr/local/lib/libcfitsio.a"
   - make py && make install INSTALL_DIR=$PANDIR/astrometry
   - echo 'add_path $PANDIR/astrometry/data' | sudo tee --append $PANDIR/astrometry/etc/astrometry.cfg
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,8 @@ addons:
     - libbz2-dev
     - swig
     - cfitsio-dev
-    - cfitsio
+    - libcfitsio-bin
+    - libcfitsio-dev
 install:
   - cd $PANDIR
   # install POCS and requirements

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,8 +55,9 @@ install:
 
   # Install astrometry.net
   - wget https://github.com/dstndstn/astrometry.net/releases/download/0.72/astrometry.net-0.72.tar.gz
-  - tar zxvf astrometry.net-0.72.tar.gz
-  - cd astrometry.net-0.72 && make && make py && make install INSTALL_DIR=$PANDIR/astrometry
+  - tar zxvf astrometry.net-0.72.tar.gz && cd astrometry.net-0.72
+  - make CFITS_INC="-I/usr/local/include" CFITS_LIB="-L/usr/local/lib -lcfitsio"
+  - make py && make install INSTALL_DIR=$PANDIR/astrometry
   - echo 'add_path $PANDIR/astrometry/data' | sudo tee --append $PANDIR/astrometry/etc/astrometry.cfg
 
   # Install miniconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ install:
   # Install astrometry.net
   - wget https://github.com/dstndstn/astrometry.net/releases/download/0.72/astrometry.net-0.72.tar.gz
   - tar zxvf astrometry.net-0.72.tar.gz && cd astrometry.net-0.72
-  - make CFITS_INC="-I/usr/local/include" CFITS_LIB="-L/usr/local/lib -lcfitsio"
+  - make make CFITS_INC="-I/usr/local/" CFITS_SLIB="/usr/local/lib/libcfitsio.a"
   - make py && make install INSTALL_DIR=$PANDIR/astrometry
   - echo 'add_path $PANDIR/astrometry/data' | sudo tee --append $PANDIR/astrometry/etc/astrometry.cfg
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
     - mkdir cfitsio
     - tar zxf cfitsio.tgz -C cfitsio --strip-components=1
     - cd cfitsio
-    - ./configure
+    - ./configure --prefix=/usr/local
     - make
     - make fpack
     - make funpack

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,18 +14,6 @@ before_install:
     - pip install -U pip
     - pip install coveralls
 
-    # Install cfitsio
-    - cd $PANDIR
-    - wget http://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio_latest.tar.gz -O cfitsio.tgz
-    - mkdir cfitsio
-    - tar zxf cfitsio.tgz -C cfitsio --strip-components=1
-    - cd cfitsio
-    - ./configure --prefix=/usr/local
-    - make
-    - make fpack
-    - make funpack
-    - sudo make install
-
     # Install arudino files
     - cd $PANDIR
     - export DISPLAY=:1.0
@@ -34,47 +22,47 @@ before_install:
     - tar xf arduino-${ARDUINO_VERSION}-linux64.tar.xz
     - sudo mv arduino-${ARDUINO_VERSION} /usr/local/share/arduino
     - sudo ln -s /usr/local/share/arduino/arduino /usr/local/bin/arduino
+
+    # Install miniconda
+    - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    - bash miniconda.sh -b -p $HOME/miniconda
+    - export PATH="$HOME/miniconda/bin:$HOME/cfitsio/bin:$PANDIR/astrometry/bin:$PATH"
+    - hash -r
+
+    - conda config --set always_yes yes --set changeps1 no
+    - conda update -q conda
+    - conda info -a # Useful for debugging any issues with conda
+    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
+    - source activate test-environment
+
+    # Install astrometry.net
+    - wget https://github.com/dstndstn/astrometry.net/releases/download/0.78/astrometry.net-0.78.tar.gz
+    - tar zxvf astrometry.net-0.78.tar.gz
+    - cd astrometry.net-0.78 && make && make py && make install INSTALL_DIR=$PANDIR/astrometry
+    - echo 'add_path $PANDIR/astrometry/data' | sudo tee --append $PANDIR/astrometry/etc/astrometry.cfg
 addons:
   apt:
     packages:
     - gphoto2
+    - libbz2-dev
     - libcairo2-dev
-    - libnetpbm10-dev
-    - netpbm
-    - libpng12-dev
+    - libcfitsio-bin
+    - libcfitsio-dev
     - libjpeg-dev
+    - libnetpbm10-dev
+    - libpng12-dev
+    - netpbm
+    - python-dev
     - python-numpy
     - python-pyfits
-    - python-dev
-    - zlib1g-dev
-    - libbz2-dev
     - swig
+    - zlib1g-dev
 install:
-  - cd $PANDIR
-
-  # Install astrometry.net
-  - wget https://github.com/dstndstn/astrometry.net/releases/download/0.72/astrometry.net-0.72.tar.gz
-  - tar zxvf astrometry.net-0.72.tar.gz
-  - cd astrometry.net-0.72 && make && make py && make install INSTALL_DIR=$PANDIR/astrometry
-  - echo 'add_path $PANDIR/astrometry/data' | sudo tee --append $PANDIR/astrometry/etc/astrometry.cfg
-
-  # Install miniconda
-  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$HOME/cfitsio/bin:$PANDIR/astrometry/bin:$PATH"
-  - hash -r
-
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
-  - conda info -a # Useful for debugging any issues with conda
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
-  - source activate test-environment
-
   # install POCS and requirements
   - cd $POCS
   - pip install -r requirements.txt
   - pip install -r docs/requirements.txt
-  - pip install -e .
+  - pip install .
   - python pocs/utils/data.py --folder $PANDIR/astrometry/data
 script:
   - export BOARD="arduino:avr:micro"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: required
 language: python
 services:
@@ -56,8 +56,7 @@ addons:
     - libbz2-dev
     - swig
     - cfitsio-dev
-    - libcfitsio-bin
-    - libcfitsio-dev
+    - cfitsio
 install:
   - cd $PANDIR
   # install POCS and requirements

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
     # Install miniconda
     - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
     - bash miniconda.sh -b -p $HOME/miniconda
-    - export PATH="$HOME/miniconda/bin:$HOME/cfitsio/bin:$PANDIR/astrometry/bin:$PATH"
+    - export PATH="$HOME/miniconda/bin:$PANDIR/astrometry/bin:$PATH"
     - hash -r
 
     - conda config --set always_yes yes --set changeps1 no

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,9 @@ before_install:
 
     # Install cfitsio
     - cd $PANDIR
-    - wget http://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio_latest.tar.gz
-    - tar zxf cfitsio_latest.tar.gz
+    - wget http://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio_latest.tar.gz -O cfitsio.tgz
+    - mkdir cfitsio
+    - tar zxf cfitsio_latest.tar.gz -C cfitsio --strip-components=1
     - cd cfitsio
     - ./configure
     - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: required
 language: python
 services:
@@ -34,6 +34,8 @@ before_install:
     - conda info -a # Useful for debugging any issues with conda
     - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
     - source activate test-environment
+    # CFITSIO
+    - conda install -c conda-forge cfitsio
 
     # Install astrometry.net
     - wget https://github.com/dstndstn/astrometry.net/releases/download/0.78/astrometry.net-0.78.tar.gz
@@ -46,8 +48,6 @@ addons:
     - gphoto2
     - libbz2-dev
     - libcairo2-dev
-    - libcfitsio-bin
-    - libcfitsio-dev
     - libjpeg-dev
     - libnetpbm10-dev
     - libpng12-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
     - cd $PANDIR
     - wget http://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio_latest.tar.gz -O cfitsio.tgz
     - mkdir cfitsio
-    - tar zxf cfitsio_latest.tar.gz -C cfitsio --strip-components=1
+    - tar zxf cfitsio.tgz -C cfitsio --strip-components=1
     - cd cfitsio
     - ./configure
     - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,18 +14,6 @@ before_install:
     - pip install -U pip
     - pip install coveralls
 
-    # Install cfitsio
-    - cd $PANDIR
-    - wget http://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio_latest.tar.gz
-    - mkdir cfitsio
-    - tar zxf cfitsio_latest.tar.gz -C cfitsio --strip-components=1
-    - cd cfitsio
-    - ./configure --prefix=/usr/local
-    - make
-    - make fpack
-    - make funpack
-    - sudo make install
-
     # Install arudino files
     - cd $PANDIR
     - export DISPLAY=:1.0
@@ -34,6 +22,24 @@ before_install:
     - tar xf arduino-${ARDUINO_VERSION}-linux64.tar.xz
     - sudo mv arduino-${ARDUINO_VERSION} /usr/local/share/arduino
     - sudo ln -s /usr/local/share/arduino/arduino /usr/local/bin/arduino
+
+    # Install miniconda
+    - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    - bash miniconda.sh -b -p $HOME/miniconda
+    - export PATH="$HOME/miniconda/bin:$HOME/cfitsio/bin:$PANDIR/astrometry/bin:$PATH"
+    - hash -r
+
+    - conda config --set always_yes yes --set changeps1 no
+    - conda update -q conda
+    - conda info -a # Useful for debugging any issues with conda
+    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
+    - source activate test-environment
+
+    # Install astrometry.net
+    - wget https://github.com/dstndstn/astrometry.net/releases/download/0.78/astrometry.net-0.78.tar.gz
+    - tar zxvf astrometry.net-0.78.tar.gz && cd astrometry.net-0.78
+    - make && make py && make install INSTALL_DIR=$PANDIR/astrometry
+    - echo 'add_path $PANDIR/astrometry/data' | sudo tee --append $PANDIR/astrometry/etc/astrometry.cfg
 addons:
   apt:
     packages:
@@ -50,27 +56,9 @@ addons:
     - libbz2-dev
     - swig
     - cfitsio-dev
+    - cfitsio
 install:
   - cd $PANDIR
-
-  # Install astrometry.net
-  - wget https://github.com/dstndstn/astrometry.net/releases/download/0.78/astrometry.net-0.78.tar.gz
-  - tar zxvf astrometry.net-0.78.tar.gz && cd astrometry.net-0.78
-  - make && make py && make install INSTALL_DIR=$PANDIR/astrometry
-  - echo 'add_path $PANDIR/astrometry/data' | sudo tee --append $PANDIR/astrometry/etc/astrometry.cfg
-
-  # Install miniconda
-  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$HOME/cfitsio/bin:$PANDIR/astrometry/bin:$PATH"
-  - hash -r
-
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
-  - conda info -a # Useful for debugging any issues with conda
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
-  - source activate test-environment
-
   # install POCS and requirements
   - cd $POCS
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: trusty
 sudo: required
 language: python
 services:
@@ -14,6 +14,18 @@ before_install:
     - pip install -U pip
     - pip install coveralls
 
+    # Install cfitsio
+    - cd $PANDIR
+    - wget http://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio_latest.tar.gz
+    - mkdir cfitsio
+    - tar zxf cfitsio_latest.tar.gz -C cfitsio --strip-components=1
+    - cd cfitsio
+    - ./configure --prefix=/usr/local
+    - make
+    - make fpack
+    - make funpack
+    - sudo make install
+
     # Install arudino files
     - cd $PANDIR
     - export DISPLAY=:1.0
@@ -22,47 +34,48 @@ before_install:
     - tar xf arduino-${ARDUINO_VERSION}-linux64.tar.xz
     - sudo mv arduino-${ARDUINO_VERSION} /usr/local/share/arduino
     - sudo ln -s /usr/local/share/arduino/arduino /usr/local/bin/arduino
-
-    # Install miniconda
-    - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    - bash miniconda.sh -b -p $HOME/miniconda
-    - export PATH="$HOME/miniconda/bin:$HOME/cfitsio/bin:$PANDIR/astrometry/bin:$PATH"
-    - hash -r
-
-    - conda config --set always_yes yes --set changeps1 no
-    - conda update -q conda
-    - conda info -a # Useful for debugging any issues with conda
-    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
-    - source activate test-environment
-    # CFITSIO
-    - conda install -c conda-forge cfitsio
-
-    # Install astrometry.net
-    - wget https://github.com/dstndstn/astrometry.net/releases/download/0.78/astrometry.net-0.78.tar.gz
-    - tar zxvf astrometry.net-0.78.tar.gz
-    - cd astrometry.net-0.78 && make && make py && make install INSTALL_DIR=$PANDIR/astrometry
-    - echo 'add_path $PANDIR/astrometry/data' | sudo tee --append $PANDIR/astrometry/etc/astrometry.cfg
 addons:
   apt:
     packages:
     - gphoto2
-    - libbz2-dev
     - libcairo2-dev
-    - libjpeg-dev
     - libnetpbm10-dev
-    - libpng12-dev
     - netpbm
-    - python-dev
+    - libpng12-dev
+    - libjpeg-dev
     - python-numpy
     - python-pyfits
-    - swig
+    - python-dev
     - zlib1g-dev
+    - libbz2-dev
+    - swig
+    - cfitsio-dev
 install:
+  - cd $PANDIR
+
+  # Install astrometry.net
+  - wget https://github.com/dstndstn/astrometry.net/releases/download/0.72/astrometry.net-0.72.tar.gz
+  - tar zxvf astrometry.net-0.72.tar.gz
+  - cd astrometry.net-0.72 && make && make py && make install INSTALL_DIR=$PANDIR/astrometry
+  - echo 'add_path $PANDIR/astrometry/data' | sudo tee --append $PANDIR/astrometry/etc/astrometry.cfg
+
+  # Install miniconda
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$HOME/cfitsio/bin:$PANDIR/astrometry/bin:$PATH"
+  - hash -r
+
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda info -a # Useful for debugging any issues with conda
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
+  - source activate test-environment
+
   # install POCS and requirements
   - cd $POCS
   - pip install -r requirements.txt
   - pip install -r docs/requirements.txt
-  - pip install .
+  - pip install -e .
   - python pocs/utils/data.py --folder $PANDIR/astrometry/data
 script:
   - export BOARD="arduino:avr:micro"

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,6 @@ addons:
     - zlib1g-dev
     - libbz2-dev
     - swig
-    - cfitsio-dev
     - libcfitsio-bin
     - libcfitsio-dev
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ install:
   # Install astrometry.net
   - wget https://github.com/dstndstn/astrometry.net/releases/download/0.72/astrometry.net-0.72.tar.gz
   - tar zxvf astrometry.net-0.72.tar.gz && cd astrometry.net-0.72
-  - make make CFITS_INC="-I/usr/local/" CFITS_SLIB="/usr/local/lib/libcfitsio.a"
+  - make CFITS_INC="-I/usr/local/" CFITS_SLIB="/usr/local/lib/libcfitsio.a"
   - make py && make install INSTALL_DIR=$PANDIR/astrometry
   - echo 'add_path $PANDIR/astrometry/data' | sudo tee --append $PANDIR/astrometry/etc/astrometry.cfg
 


### PR DESCRIPTION
## Description
Changes the installation of cfitsio so that the downloaded file has a specific name and the `tar` command outputs to a specific directory. Done to avoid the naming issues discussed in #834.

## Related Issue
Closes #834 
