### PR TITLE
Creation of scheduler can create observer if it's None

### DIFF
--- a/pocs/scheduler/__init__.py
+++ b/pocs/scheduler/__init__.py
@@ -9,6 +9,7 @@ from pocs.scheduler.scheduler import BaseScheduler  # pragma: no flakes
 from pocs.utils import error
 from pocs.utils import horizon as horizon_utils
 from pocs.utils import load_module
+from pocs.utils.location import create_location_from_config
 from pocs.utils.logger import get_root_logger
 
 
@@ -22,8 +23,8 @@ def create_scheduler_from_config(config, observer=None):
         return None
 
     if not observer:
-        logger.info("No valid Observer found.")
-        return None
+        site_details = create_location_from_config(config)
+        observer = site_details['observer']
 
     scheduler_config = config.get('scheduler', {})
     scheduler_type = scheduler_config.get('type', 'dispatch')

--- a/pocs/scheduler/__init__.py
+++ b/pocs/scheduler/__init__.py
@@ -23,6 +23,7 @@ def create_scheduler_from_config(config, observer=None):
         return None
 
     if not observer:
+        logger.debug(f'No Observer provided, creating from config.')
         site_details = create_location_from_config(config)
         observer = site_details['observer']
 

--- a/pocs/tests/test_scheduler.py
+++ b/pocs/tests/test_scheduler.py
@@ -22,7 +22,7 @@ def test_bad_scheduler_fields_file(config):
 
 
 def test_no_observer(config):
-    assert create_scheduler_from_config(config, observer=None) is None
+    create_scheduler_from_config(config, observer=None)
 
 
 def test_no_scheduler_in_config(config):

--- a/pocs/tests/test_scheduler.py
+++ b/pocs/tests/test_scheduler.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pocs.scheduler import create_scheduler_from_config
+from pocs.scheduler import create_scheduler_from_config, BaseScheduler
 from pocs.utils import error
 from pocs.utils.location import create_location_from_config
 
@@ -22,7 +22,7 @@ def test_bad_scheduler_fields_file(config):
 
 
 def test_no_observer(config):
-    create_scheduler_from_config(config, observer=None)
+    assert isinstance(create_scheduler_from_config(config, observer=None), BaseScheduler) is True
 
 
 def test_no_scheduler_in_config(config):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Creation of scheduler required to observer to be passed. However, when observer is None, it can be created from config. 

## Description
<!--- Describe your changes in detail -->
During creation of scheduler I check if observer is None then it creates observer from config. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#853 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
