### PR TITLE
Ignore pytest warning errors

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ addopts= --doctest-modules
 doctest_optionflags= ELLIPSIS NORMALIZE_WHITESPACE ALLOW_UNICODE IGNORE_EXCEPTION_DETAIL
 filterwarnings =
     ignore:elementwise == comparison failed:DeprecationWarning
+    ignore::pytest.PytestDeprecationWarning
 
 [metadata]
 author = PANOPTES Team


### PR DESCRIPTION
Fix pytest warnings as per https://docs.pytest.org/en/latest/changelog.html#pytest-5-0-0-2019-06-28

Note that pytes 5.1 will cause this to break again, but the underlying
problem has been fixed in #859.

## Related Issue
#746 #852 #858 are currently failing because of this.

