### PR TITLE
pytest deprecation error fix.

### DIFF
--- a/pocs/tests/utils/google/test_storage.py
+++ b/pocs/tests/utils/google/test_storage.py
@@ -1,16 +1,20 @@
-import pytest
 import os
 import shutil
+
+import pytest
 
 from pocs.utils.error import GoogleCloudError
 from pocs.utils.google import is_authenticated
 from pocs.utils.google.storage import PanStorage, upload_observation_to_bucket
 
 
-pytestmark = pytest.mark.skipif(
-    not pytest.config.option.test_cloud_storage,
-    reason="Needs --test-cloud-storage to run."
-)
+@pytest.fixture
+def pytest_mark(request):
+    if (
+            not request.config.option.test_cloud_storage
+    ):
+        raise pytest.skip('Needs --test-cloud-storage to run.')
+
 
 pytestmark = pytest.mark.skipif(
     not is_authenticated(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Pytest deprecation error 
## Description
<!--- Describe your changes in detail -->
This errors appear in my pull request #852, because pytest.config won't work in pytest 5.0.1 and higher versions.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#852 #861 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
