### PR TITLE
add_scheduler/remove_scheduler changed to set_scheduler

### DIFF
--- a/pocs/observatory.py
+++ b/pocs/observatory.py
@@ -203,22 +203,21 @@ class Observatory(PanBase):
         self.logger.debug('Removing {}'.format(cam_name))
         del self.cameras[cam_name]
 
-    def add_scheduler(self, scheduler):
-        """Add scheduler.
+    def set_scheduler(self, scheduler=None):
+        """Add's scheduler or remove's scheduler.
 
         Args:
             scheduler (`pocs.scheduler.BaseScheduler`): An instance of the `~BaseScheduler` class.
         """
         if isinstance(scheduler, BaseScheduler):
-            self.logger.info('Adding scheduler')
+            self.logger.info('Adding scheduler.')
             self.scheduler = scheduler
+        elif scheduler is None:
+            self.logger.info('Removing scheduler.')
+            self.scheduler = None
         else:
             raise TypeError("Scheduler is not instance of BaseScheduler class, cannot add.")
 
-    def remove_scheduler(self):
-        """Remove scheduler. """
-        self.logger.info('Removing scheduler')
-        self.scheduler = None
 
 ##########################################################################
 # Methods

--- a/pocs/tests/test_observatory.py
+++ b/pocs/tests/test_observatory.py
@@ -144,16 +144,16 @@ def test_primary_camera_no_primary_camera(observatory):
     assert observatory.primary_camera is not None
 
 
-def test_add_remove_scheduler(config, observatory, caplog):
+def test_set_scheduler(config, observatory):
     conf = config.copy()
     site_details = create_location_from_config(conf)
     scheduler = create_scheduler_from_config(conf, site_details['observer'])
-    observatory.remove_scheduler()
+    observatory.set_scheduler(scheduler=None)
     assert observatory.scheduler is None
-    observatory.add_scheduler(scheduler)
+    observatory.set_scheduler(scheduler=scheduler)
     assert observatory.scheduler is not None
-    with pytest.raises(TypeError, message="Scheduler is not instance of BaseScheduler class, cannot add."):
-        observatory.add_scheduler("scheduler")
+    with pytest.raises(TypeError, message='Scheduler is not instance of BaseScheduler class, cannot add.'):
+        observatory.set_scheduler('scheduler')
 
 
 def test_status(observatory):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
We decide to remove methods add_scheduler and remove_scheduler, and replace them by set_scheduler.

## Description
<!--- Describe your changes in detail -->
I have merged add_scheduler and remove_scheduler into one method set_scheduler, so that if it receives object of instance of BaseScheduler it will set scheduler, if it's None then it will remove scheduler by setting it to None, else it will throw TypeError.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
