### PR TITLE
Making `set_<hardware>` methods use a positional parameter

### DIFF
--- a/pocs/observatory.py
+++ b/pocs/observatory.py
@@ -209,10 +209,6 @@ class Observatory(PanBase):
 
     def set_scheduler(self, scheduler):
         """Sets the scheduler for the `Observatory`.
-
-        Note:
-            The default argument of `None` will remove the current scheduler.
-
         Args:
             scheduler (`pocs.scheduler.BaseScheduler`): An instance of the `~BaseScheduler` class.
         """
@@ -227,9 +223,6 @@ class Observatory(PanBase):
 
     def set_dome(self, dome):
         """Set's dome or remove the dome for the `Observatory`.
-        Note:
-            The default argument of `None` will remove the current dome.
-
         Args:
             dome (`pocs.dome.AbstractDome`): An instance of the `~AbstractDome` class.
         """
@@ -244,9 +237,6 @@ class Observatory(PanBase):
 
     def set_mount(self, mount):
         """Sets the mount for the `Observatory`.
-        Note:
-            The default argument of `None` will remove the current mount.
-
         Args:
             mount (`pocs.mount.AbstractMount`): An instance of the `~AbstractMount` class.
         """

--- a/pocs/observatory.py
+++ b/pocs/observatory.py
@@ -207,7 +207,7 @@ class Observatory(PanBase):
         self.logger.debug('Removing {}'.format(cam_name))
         del self.cameras[cam_name]
 
-    def set_scheduler(self, scheduler=None):
+    def set_scheduler(self, scheduler):
         """Sets the scheduler for the `Observatory`.
 
         Note:
@@ -225,7 +225,7 @@ class Observatory(PanBase):
         else:
             raise TypeError("Scheduler is not instance of BaseScheduler class, cannot add.")
 
-    def set_dome(self, dome=None):
+    def set_dome(self, dome):
         """Set's dome or remove the dome for the `Observatory`.
         Note:
             The default argument of `None` will remove the current dome.
@@ -242,7 +242,7 @@ class Observatory(PanBase):
         else:
             raise TypeError('Dome is not instance of AbstractDome class, cannot add.')
 
-    def set_mount(self, mount=None):
+    def set_mount(self, mount):
         """Sets the mount for the `Observatory`.
         Note:
             The default argument of `None` will remove the current mount.

--- a/pocs/tests/test_observatory.py
+++ b/pocs/tests/test_observatory.py
@@ -149,6 +149,8 @@ def test_set_scheduler(config, observatory):
     err_msg = 'Scheduler is not instance of BaseScheduler class, cannot add.'
     with pytest.raises(TypeError, message=err_msg):
         observatory.set_scheduler('scheduler')
+    with pytest.raises(TypeError, message=err_msg):
+        observatory.set_scheduler()
 
 
 def test_set_dome(config_with_simulated_dome):
@@ -156,12 +158,15 @@ def test_set_dome(config_with_simulated_dome):
     dome = create_dome_from_config(conf)
     obs = Observatory(config=conf, dome=dome)
     assert obs.has_dome is True
-    obs.set_dome()
+    obs.set_dome(dome=None)
     assert obs.has_dome is False
     obs.set_dome(dome=dome)
     assert obs.has_dome is True
-    with pytest.raises(TypeError, message='Dome is not instance of AbstractDome class, cannot add.'):
+    err_msg = 'Dome is not instance of AbstractDome class, cannot add.'
+    with pytest.raises(TypeError, message=err_msg):
         obs.set_dome('dome')
+    with pytest.raises(TypeError, message=err_msg):
+        obs.set_dome()
 
 
 def test_set_mount(config_with_simulated_mount):
@@ -173,8 +178,11 @@ def test_set_mount(config_with_simulated_mount):
     assert obs.mount is None
     obs.set_mount(mount=mount)
     assert isinstance(obs.mount, AbstractMount) is True
-    with pytest.raises(TypeError, message='Mount is not instance of AbstractMount class, cannot add.'):
+    err_msg = 'Mount is not instance of AbstractMount class, cannot add.'
+    with pytest.raises(TypeError, message=err_msg):
         obs.set_mount(mount='mount')
+    with pytest.raises(TypeError, message=err_msg):
+        obs.set_mount()
 
 
 def test_status(observatory):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->
I have changed argument that automatically assigns to None if it doesn't set. 
`set_scheduler(self, scheduler=None)` ==>  `set_scheduler(self, scheduler)`
`set_mount(self, mount=None)` ==>  `set_mount(self, mount)`
`set_dome(self, dome=None)` ==>  `set_dome(self, dome)`
## Related Issue
#865 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
