### PR TITLE
Add TESS north fields

### DIFF
--- a/resources/targets/tess_sectors_north.yaml
+++ b/resources/targets/tess_sectors_north.yaml
@@ -1,0 +1,208 @@
+- 
+  name: TESS_SEC01_CAM01
+  position: 324.5670deg -33.1730deg
+  priority: 100
+- 
+  name: TESS_SEC01_CAM02
+  position: 338.5766deg -55.0789deg
+  priority: 100
+- 
+  name: TESS_SEC01_CAM03
+  position: 19.4927deg -71.9781deg
+  priority: 100
+- 
+  name: TESS_SEC01_CAM04
+  position: 90.0042deg -66.5647deg
+  priority: 100
+- 
+  name: TESS_SEC02_CAM01
+  position: 352.0795deg -23.0645deg
+  priority: 100
+- 
+  name: TESS_SEC02_CAM02
+  position: 5.6956deg -44.3080deg
+  priority: 100
+- 
+  name: TESS_SEC02_CAM03
+  position: 33.3558deg -62.1878deg
+  priority: 100
+- 
+  name: TESS_SEC02_CAM04
+  position: 90.0022deg -66.5654deg
+  priority: 100
+- 
+  name: TESS_SEC03_CAM01
+  position: 17.1728deg -12.2229deg
+  priority: 100
+- 
+  name: TESS_SEC03_CAM02
+  position: 28.4640deg -33.9055deg
+  priority: 100
+- 
+  name: TESS_SEC03_CAM03
+  position: 47.3926deg -53.8504deg
+  priority: 100
+- 
+  name: TESS_SEC03_CAM04
+  position: 89.9996deg -66.5654deg
+  priority: 100
+- 
+  name: TESS_SEC04_CAM01
+  position: 41.8084deg -2.7600deg
+  priority: 100
+- 
+  name: TESS_SEC04_CAM02
+  position: 49.8806deg -25.4686deg
+  priority: 100
+- 
+  name: TESS_SEC04_CAM03
+  position: 61.8676deg -47.5211deg
+  priority: 100
+- 
+  name: TESS_SEC04_CAM04
+  position: 89.9973deg -66.5649deg
+  priority: 100
+- 
+  name: TESS_SEC05_CAM01
+  position: 67.0563deg 3.5339deg
+  priority: 100
+- 
+  name: TESS_SEC05_CAM02
+  position: 71.1053deg -20.1344deg
+  priority: 100
+- 
+  name: TESS_SEC05_CAM03
+  position: 76.6971deg -43.6751deg
+  priority: 100
+- 
+  name: TESS_SEC05_CAM04
+  position: 89.9956deg -66.5642deg
+  priority: 100
+- 
+  name: TESS_SEC06_CAM01
+  position: 92.8145deg 5.4079deg
+  priority: 500
+- 
+  name: TESS_SEC06_CAM02
+  position: 92.3086deg -18.5869deg
+  priority: 500
+- 
+  name: TESS_SEC06_CAM03
+  position: 91.6247deg -42.5799deg
+  priority: 500
+- 
+  name: TESS_SEC06_CAM04
+  position: 89.9947deg -66.5632deg
+  priority: 500
+- 
+  name: TESS_SEC07_CAM01
+  position: 118.1810deg 2.5749deg
+  priority: 100
+- 
+  name: TESS_SEC07_CAM02
+  position: 113.2461deg -20.9331deg
+  priority: 100
+- 
+  name: TESS_SEC07_CAM03
+  position: 106.3563deg -44.2432deg
+  priority: 100
+- 
+  name: TESS_SEC07_CAM04
+  position: 89.9954deg -66.5621deg
+  priority: 100
+- 
+  name: TESS_SEC08_CAM01
+  position: 142.3675deg -4.1754deg
+  priority: 100
+- 
+  name: TESS_SEC08_CAM02
+  position: 133.6943deg -26.6971deg
+  priority: 100
+- 
+  name: TESS_SEC08_CAM03
+  position: 120.5958deg -48.4220deg
+  priority: 100
+- 
+  name: TESS_SEC08_CAM04
+  position: 89.9978deg -66.5616deg
+  priority: 100
+- 
+  name: TESS_SEC09_CAM01
+  position: 165.7044deg -13.4558deg
+  priority: 100
+- 
+  name: TESS_SEC09_CAM02
+  position: 154.0889deg -35.0441deg
+  priority: 100
+- 
+  name: TESS_SEC09_CAM03
+  position: 134.2662deg -54.7292deg
+  priority: 100
+- 
+  name: TESS_SEC09_CAM04
+  position: 90.0001deg -66.5617deg
+  priority: 100
+- 
+  name: TESS_SEC10_CAM01
+  position: 189.9002deg -23.8878deg
+  priority: 100
+- 
+  name: TESS_SEC10_CAM02
+  position: 176.1577deg -45.1375deg
+  priority: 100
+- 
+  name: TESS_SEC10_CAM03
+  position: 147.6953deg -62.8858deg
+  priority: 100
+- 
+  name: TESS_SEC10_CAM04
+  position: 90.0019deg -66.5620deg
+  priority: 100
+- 
+  name: TESS_SEC11_CAM01
+  position: 217.3031deg -33.7306deg
+  priority: 100
+- 
+  name: TESS_SEC11_CAM02
+  position: 203.4026deg -55.7183deg
+  priority: 100
+- 
+  name: TESS_SEC11_CAM03
+  position: 161.3942deg -72.6301deg
+  priority: 100
+- 
+  name: TESS_SEC11_CAM04
+  position: 90.0037deg -66.5622deg
+  priority: 100
+- 
+  name: TESS_SEC12_CAM01
+  position: 249.3404deg -40.2646deg
+  priority: 100
+- 
+  name: TESS_SEC12_CAM02
+  position: 241.5203deg -63.8197deg
+  priority: 100
+- 
+  name: TESS_SEC12_CAM03
+  position: 177.2960deg -83.3792deg
+  priority: 100
+- 
+  name: TESS_SEC12_CAM04
+  position: 90.0057deg -66.5627deg
+  priority: 100
+- 
+  name: TESS_SEC13_CAM01
+  position: 284.0498deg -40.8957deg
+  priority: 100
+- 
+  name: TESS_SEC13_CAM02
+  position: 289.5886deg -64.6822deg
+  priority: 100
+- 
+  name: TESS_SEC13_CAM03
+  position: 357.9380deg -85.4978deg
+  priority: 100
+- 
+  name: TESS_SEC13_CAM04
+  position: 90.0061deg -66.5638deg
+  priority: 100

--- a/resources/targets/tess_sectors_north.yaml
+++ b/resources/targets/tess_sectors_north.yaml
@@ -1,208 +1,224 @@
-- 
-  name: TESS_SEC01_CAM01
-  position: 324.5670deg -33.1730deg
+-
+  name: TESS_SEC14_CAM01
+  position: 297.7619deg, 29.1881deg
   priority: 100
-- 
-  name: TESS_SEC01_CAM02
-  position: 338.5766deg -55.0789deg
+-
+  name: TESS_SEC14_CAM02
+  position: 287.0536deg, 51.8282deg
   priority: 100
-- 
-  name: TESS_SEC01_CAM03
-  position: 19.4927deg -71.9781deg
+-
+  name: TESS_SEC14_CAM03
+  position: 256.1832deg, 71.5698deg
   priority: 100
-- 
-  name: TESS_SEC01_CAM04
-  position: 90.0042deg -66.5647deg
+-
+  name: TESS_SEC14_CAM04
+  position: 174.6436deg, 71.3012deg
   priority: 100
-- 
-  name: TESS_SEC02_CAM01
-  position: 352.0795deg -23.0645deg
+-
+  name: TESS_SEC15_CAM01
+  position: 316.9121deg, 35.5697deg
   priority: 100
-- 
-  name: TESS_SEC02_CAM02
-  position: 5.6956deg -44.3080deg
+-
+  name: TESS_SEC15_CAM02
+  position: 298.1783deg, 55.9001deg
   priority: 100
-- 
-  name: TESS_SEC02_CAM03
-  position: 33.3558deg -62.1878deg
+-
+  name: TESS_SEC15_CAM03
+  position: 252.3755deg, 68.6304deg
   priority: 100
-- 
-  name: TESS_SEC02_CAM04
-  position: 90.0022deg -66.5654deg
+-
+  name: TESS_SEC15_CAM04
+  position: 196.7468deg, 60.8581deg
   priority: 100
-- 
-  name: TESS_SEC03_CAM01
-  position: 17.1728deg -12.2229deg
+-
+  name: TESS_SEC16_CAM01
+  position: 353.4274deg, 16.8162deg
   priority: 100
-- 
-  name: TESS_SEC03_CAM02
-  position: 28.4640deg -33.9055deg
+-
+  name: TESS_SEC16_CAM02
+  position: 341.0108deg, 38.2030deg
   priority: 100
-- 
-  name: TESS_SEC03_CAM03
-  position: 47.3926deg -53.8504deg
+-
+  name: TESS_SEC16_CAM03
+  position: 318.6737deg, 57.2100deg
   priority: 100
-- 
-  name: TESS_SEC03_CAM04
-  position: 89.9996deg -66.5654deg
+-
+  name: TESS_SEC16_CAM04
+  position: 270.0004deg, 66.5654deg
   priority: 100
-- 
-  name: TESS_SEC04_CAM01
-  position: 41.8084deg -2.7600deg
+-
+  name: TESS_SEC16_CAM01
+  position: 336.0753deg, 44.1395deg
   priority: 100
-- 
-  name: TESS_SEC04_CAM02
-  position: 49.8806deg -25.4686deg
+-
+  name: TESS_SEC16_CAM02
+  position: 307.8459deg, 61.5441deg
   priority: 100
-- 
-  name: TESS_SEC04_CAM03
-  position: 61.8676deg -47.5211deg
+-
+  name: TESS_SEC16_CAM03
+  position: 252.9139deg, 65.4973deg
   priority: 100
-- 
-  name: TESS_SEC04_CAM04
-  position: 89.9973deg -66.5649deg
+-
+  name: TESS_SEC16_CAM04
+  position: 214.0535deg, 51.5694deg
   priority: 100
-- 
-  name: TESS_SEC05_CAM01
-  position: 67.0563deg 3.5339deg
+-
+  name: TESS_SEC17_CAM01
+  position: 17.3888deg, 26.8940deg
   priority: 100
-- 
-  name: TESS_SEC05_CAM02
-  position: 71.1053deg -20.1344deg
+-
+  name: TESS_SEC17_CAM02
+  position:  3.2857deg, 48.2318deg
   priority: 100
-- 
-  name: TESS_SEC05_CAM03
-  position: 76.6971deg -43.6751deg
+-
+  name: TESS_SEC17_CAM03
+  position: 331.6029deg, 65.5589deg
   priority: 100
-- 
-  name: TESS_SEC05_CAM04
-  position: 89.9956deg -66.5642deg
+-
+  name: TESS_SEC17_CAM04
+  position: 269.9980deg, 66.5652deg
   priority: 100
-- 
-  name: TESS_SEC06_CAM01
-  position: 92.8145deg 5.4079deg
-  priority: 500
-- 
-  name: TESS_SEC06_CAM02
-  position: 92.3086deg -18.5869deg
-  priority: 500
-- 
-  name: TESS_SEC06_CAM03
-  position: 91.6247deg -42.5799deg
-  priority: 500
-- 
-  name: TESS_SEC06_CAM04
-  position: 89.9947deg -66.5632deg
-  priority: 500
-- 
-  name: TESS_SEC07_CAM01
-  position: 118.1810deg 2.5749deg
+-
+  name: TESS_SEC18_CAM01
+  position: 44.1428deg, 35.6094deg
   priority: 100
-- 
-  name: TESS_SEC07_CAM02
-  position: 113.2461deg -20.9331deg
+-
+  name: TESS_SEC18_CAM02
+  position:  30.8552deg, 57.9255deg
   priority: 100
-- 
-  name: TESS_SEC07_CAM03
-  position: 106.3563deg -44.2432deg
+-
+  name: TESS_SEC18_CAM03
+  position:  344.6220deg, 75.0039deg
   priority: 100
-- 
-  name: TESS_SEC07_CAM04
-  position: 89.9954deg -66.5621deg
+-
+  name: TESS_SEC18_CAM04
+  position: 269.9962deg, 66.5646deg
   priority: 100
-- 
-  name: TESS_SEC08_CAM01
-  position: 142.3675deg -4.1754deg
+-
+  name: TESS_SEC19_CAM01
+  position: 75.3468deg, 40.8482deg
   priority: 100
-- 
-  name: TESS_SEC08_CAM02
-  position: 133.6943deg -26.6971deg
+-
+  name: TESS_SEC19_CAM02
+  position:  69.5876deg, 64.6165deg
   priority: 100
-- 
-  name: TESS_SEC08_CAM03
-  position: 120.5958deg -48.4220deg
+-
+  name: TESS_SEC19_CAM03
+  position:  1.5427deg, 85.3054deg
   priority: 100
-- 
-  name: TESS_SEC08_CAM04
-  position: 89.9978deg -66.5616deg
+-
+  name: TESS_SEC19_CAM04
+  position: 269.9958deg, 66.5636deg
   priority: 100
-- 
-  name: TESS_SEC09_CAM01
-  position: 165.7044deg -13.4558deg
+-
+  name: TESS_SEC20_CAM01
+  position: 110.0500deg, 40.3332deg
   priority: 100
-- 
-  name: TESS_SEC09_CAM02
-  position: 154.0889deg -35.0441deg
+-
+  name: TESS_SEC20_CAM02
+  position: 117.6724deg, 63.9125deg
   priority: 100
-- 
-  name: TESS_SEC09_CAM03
-  position: 134.2662deg -54.7292deg
+-
+  name: TESS_SEC20_CAM03
+  position: 182.3269deg, 83.5762deg
   priority: 100
-- 
-  name: TESS_SEC09_CAM04
-  position: 90.0001deg -66.5617deg
+-
+  name: TESS_SEC20_CAM04
+  position: 269.9962deg, 66.5628deg
   priority: 100
-- 
-  name: TESS_SEC10_CAM01
-  position: 189.9002deg -23.8878deg
+-
+  name: TESS_SEC21_CAM01
+  position: 143.6405deg, 33.4517deg
   priority: 100
-- 
-  name: TESS_SEC10_CAM02
-  position: 176.1577deg -45.1375deg
+-
+  name: TESS_SEC21_CAM02
+  position: 157.6002deg, 55.3973deg
   priority: 100
-- 
-  name: TESS_SEC10_CAM03
-  position: 147.6953deg -62.8858deg
+-
+  name: TESS_SEC21_CAM03
+  position: 199.0552deg, 72.3001deg
   priority: 100
-- 
-  name: TESS_SEC10_CAM04
-  position: 90.0019deg -66.5620deg
+-
+  name: TESS_SEC21_CAM04
+  position: 269.9969deg, 66.5619deg
   priority: 100
-- 
-  name: TESS_SEC11_CAM01
-  position: 217.3031deg -33.7306deg
+-
+  name: TESS_SEC22_CAM01
+  position: 172.7479deg, 22.7840deg
   priority: 100
-- 
-  name: TESS_SEC11_CAM02
-  position: 203.4026deg -55.7183deg
+-
+  name: TESS_SEC22_CAM02
+  position: 186.3215deg, 44.0256deg
   priority: 100
-- 
-  name: TESS_SEC11_CAM03
-  position: 161.3942deg -72.6301deg
+-
+  name: TESS_SEC22_CAM03
+  position: 213.7175deg, 61.9493deg
   priority: 100
-- 
-  name: TESS_SEC11_CAM04
-  position: 90.0037deg -66.5622deg
+-
+  name: TESS_SEC22_CAM04
+  position: 269.9989deg, 66.5613deg
   priority: 100
-- 
-  name: TESS_SEC12_CAM01
-  position: 249.3404deg -40.2646deg
+-
+  name: TESS_SEC23_CAM01
+  position: 198.4332deg, 11.6876deg
   priority: 100
-- 
-  name: TESS_SEC12_CAM02
-  position: 241.5203deg -63.8197deg
+-
+  name: TESS_SEC23_CAM02
+  position: 209.5809deg, 33.4130deg
   priority: 100
-- 
-  name: TESS_SEC12_CAM03
-  position: 177.2960deg -83.3792deg
+-
+  name: TESS_SEC23_CAM03
+  position: 228.1276deg, 53.4704deg
   priority: 100
-- 
-  name: TESS_SEC12_CAM04
-  position: 90.0057deg -66.5627deg
+-
+  name: TESS_SEC23_CAM04
+  position: 270.0013deg, 66.5614deg
   priority: 100
-- 
-  name: TESS_SEC13_CAM01
-  position: 284.0498deg -40.8957deg
+-
+  name: TESS_SEC24_CAM01
+  position: 222.7498deg, 2.4539deg
   priority: 100
-- 
-  name: TESS_SEC13_CAM02
-  position: 289.5886deg -64.6822deg
+-
+  name: TESS_SEC24_CAM02
+  position:  230.6858deg, 25.2037deg
   priority: 100
-- 
-  name: TESS_SEC13_CAM03
-  position: 357.9380deg -85.4978deg
+-
+  name: TESS_SEC24_CAM03
+  position: 242.4277deg, 47.3264deg
   priority: 100
-- 
-  name: TESS_SEC13_CAM04
-  position: 90.0061deg -66.5638deg
+-
+  name: TESS_SEC24_CAM04
+  position: 270.0033deg, 66.5618deg
+  priority: 100
+-
+  name: TESS_SEC25_CAM01
+  position: 246.7941deg, -3.4905deg
+  priority: 100
+-
+  name: TESS_SEC25_CAM02
+  position: 250.8897deg, 20.1702deg
+  priority: 100
+-
+  name: TESS_SEC25_CAM03
+  position: 256.5485deg, 43.6999deg
+  priority: 100
+-
+  name: TESS_SEC25_CAM04
+  position: 270.0048deg, 66.5625deg
+  priority: 100
+-
+  name: TESS_SEC26_CAM01
+  position: 270.6965deg, -5.4349deg
+  priority: 100
+-
+  name: TESS_SEC26_CAM02
+  position: 270.5726deg, 18.5648deg
+  priority: 100
+-
+  name: TESS_SEC26_CAM03
+  position: 270.4051deg, 42.5644deg
+  priority: 100
+-
+  name: TESS_SEC26_CAM04
+  position: 270.0058deg, 66.563deg
   priority: 100

--- a/resources/targets/tess_sectors_north.yaml
+++ b/resources/targets/tess_sectors_north.yaml
@@ -1,208 +1,208 @@
 -
   name: TESS_SEC14_CAM01
-  position: 297.7619deg, 29.1881deg
+  position: 297.7619deg +29.1881deg
   priority: 100
 -
   name: TESS_SEC14_CAM02
-  position: 287.0536deg, 51.8282deg
+  position: 287.0536deg +51.8282deg
   priority: 500
 -
   name: TESS_SEC14_CAM03
-  position: 256.1832deg, 71.5698deg
+  position: 256.1832deg +71.5698deg
   priority: 100
 -
   name: TESS_SEC14_CAM04
-  position: 174.6436deg, 71.3012deg
+  position: 174.6436deg +71.3012deg
   priority: 100
 -
   name: TESS_SEC15_CAM01
-  position: 316.9121deg, 35.5697deg
+  position: 316.9121deg +35.5697deg
   priority: 100
 -
   name: TESS_SEC15_CAM02
-  position: 298.1783deg, 55.9001deg
+  position: 298.1783deg +55.9001deg
   priority: 100
 -
   name: TESS_SEC15_CAM03
-  position: 252.3755deg, 68.6304deg
+  position: 252.3755deg +68.6304deg
   priority: 100
 -
   name: TESS_SEC15_CAM04
-  position: 196.7468deg, 60.8581deg
+  position: 196.7468deg +60.8581deg
   priority: 100
 -
   name: TESS_SEC16_CAM01
-  position: 353.4274deg, 16.8162deg
+  position: 353.4274deg +16.8162deg
   priority: 100
 -
   name: TESS_SEC16_CAM02
-  position: 341.0108deg, 38.2030deg
+  position: 341.0108deg +38.2030deg
   priority: 100
 -
   name: TESS_SEC16_CAM03
-  position: 318.6737deg, 57.2100deg
+  position: 318.6737deg +57.2100deg
   priority: 100
 -
   name: TESS_SEC16_CAM04
-  position: 270.0004deg, 66.5654deg
+  position: 270.0004deg +66.5654deg
   priority: 100
 -
   name: TESS_SEC17_CAM01
-  position: 17.3888deg, 26.8940deg
+  position: 17.3888deg +26.8940deg
   priority: 100
 -
   name: TESS_SEC17_CAM02
-  position:  3.2857deg, 48.2318deg
+  position:  3.2857deg +48.2318deg
   priority: 500
 -
   name: TESS_SEC17_CAM03
-  position: 331.6029deg, 65.5589deg
+  position: 331.6029deg +65.5589deg
   priority: 100
 -
   name: TESS_SEC17_CAM04
-  position: 269.9980deg, 66.5652deg
+  position: 269.9980deg +66.5652deg
   priority: 100
 -
   name: TESS_SEC18_CAM01
-  position: 44.1428deg, 35.6094deg
+  position: 44.1428deg +35.6094deg
   priority: 100
 -
   name: TESS_SEC18_CAM02
-  position:  30.8552deg, 57.9255deg
+  position:  30.8552deg +57.9255deg
   priority: 100
 -
   name: TESS_SEC18_CAM03
-  position:  344.6220deg, 75.0039deg
+  position:  344.6220deg +75.0039deg
   priority: 100
 -
   name: TESS_SEC18_CAM04
-  position: 269.9962deg, 66.5646deg
+  position: 269.9962deg +66.5646deg
   priority: 100
 -
   name: TESS_SEC19_CAM01
-  position: 75.3468deg, 40.8482deg
+  position: 75.3468deg +40.8482deg
   priority: 100
 -
   name: TESS_SEC19_CAM02
-  position:  69.5876deg, 64.6165deg
+  position:  69.5876deg +64.6165deg
   priority: 100
 -
   name: TESS_SEC19_CAM03
-  position:  1.5427deg, 85.3054deg
+  position:  1.5427deg +85.3054deg
   priority: 100
 -
   name: TESS_SEC19_CAM04
-  position: 269.9958deg, 66.5636deg
+  position: 269.9958deg +66.5636deg
   priority: 100
 -
   name: TESS_SEC20_CAM01
-  position: 110.0500deg, 40.3332deg
+  position: 110.0500deg +40.3332deg
   priority: 100
 -
   name: TESS_SEC20_CAM02
-  position: 117.6724deg, 63.9125deg
+  position: 117.6724deg +63.9125deg
   priority: 100
 -
   name: TESS_SEC20_CAM03
-  position: 182.3269deg, 83.5762deg
+  position: 182.3269deg +83.5762deg
   priority: 100
 -
   name: TESS_SEC20_CAM04
-  position: 269.9962deg, 66.5628deg
+  position: 269.9962deg +66.5628deg
   priority: 100
 -
   name: TESS_SEC21_CAM01
-  position: 143.6405deg, 33.4517deg
+  position: 143.6405deg +33.4517deg
   priority: 100
 -
   name: TESS_SEC21_CAM02
-  position: 157.6002deg, 55.3973deg
+  position: 157.6002deg +55.3973deg
   priority: 100
 -
   name: TESS_SEC21_CAM03
-  position: 199.0552deg, 72.3001deg
+  position: 199.0552deg +72.3001deg
   priority: 100
 -
   name: TESS_SEC21_CAM04
-  position: 269.9969deg, 66.5619deg
+  position: 269.9969deg +66.5619deg
   priority: 100
 -
   name: TESS_SEC22_CAM01
-  position: 172.7479deg, 22.7840deg
+  position: 172.7479deg +22.7840deg
   priority: 100
 -
   name: TESS_SEC22_CAM02
-  position: 186.3215deg, 44.0256deg
+  position: 186.3215deg +44.0256deg
   priority: 100
 -
   name: TESS_SEC22_CAM03
-  position: 213.7175deg, 61.9493deg
+  position: 213.7175deg +61.9493deg
   priority: 100
 -
   name: TESS_SEC22_CAM04
-  position: 269.9989deg, 66.5613deg
+  position: 269.9989deg +66.5613deg
   priority: 100
 -
   name: TESS_SEC23_CAM01
-  position: 198.4332deg, 11.6876deg
+  position: 198.4332deg +11.6876deg
   priority: 100
 -
   name: TESS_SEC23_CAM02
-  position: 209.5809deg, 33.4130deg
+  position: 209.5809deg +33.4130deg
   priority: 100
 -
   name: TESS_SEC23_CAM03
-  position: 228.1276deg, 53.4704deg
+  position: 228.1276deg +53.4704deg
   priority: 500
 -
   name: TESS_SEC23_CAM04
-  position: 270.0013deg, 66.5614deg
+  position: 270.0013deg +66.5614deg
   priority: 100
 -
   name: TESS_SEC24_CAM01
-  position: 222.7498deg, 2.4539deg
+  position: 222.7498deg +2.4539deg
   priority: 100
 -
   name: TESS_SEC24_CAM02
-  position:  230.6858deg, 25.2037deg
+  position:  230.6858deg +25.2037deg
   priority: 100
 -
   name: TESS_SEC24_CAM03
-  position: 242.4277deg, 47.3264deg
+  position: 242.4277deg +47.3264deg
   priority: 100
 -
   name: TESS_SEC24_CAM04
-  position: 270.0033deg, 66.5618deg
+  position: 270.0033deg +66.5618deg
   priority: 100
 -
   name: TESS_SEC25_CAM01
-  position: 246.7941deg, -3.4905deg
+  position: 246.7941deg -3.4905deg
   priority: 100
 -
   name: TESS_SEC25_CAM02
-  position: 250.8897deg, 20.1702deg
+  position: 250.8897deg +20.1702deg
   priority: 100
 -
   name: TESS_SEC25_CAM03
-  position: 256.5485deg, 43.6999deg
+  position: 256.5485deg +43.6999deg
   priority: 100
 -
   name: TESS_SEC25_CAM04
-  position: 270.0048deg, 66.5625deg
+  position: 270.0048deg +66.5625deg
   priority: 100
 -
   name: TESS_SEC26_CAM01
-  position: 270.6965deg, -5.4349deg
+  position: 270.6965deg -5.4349deg
   priority: 100
 -
   name: TESS_SEC26_CAM02
-  position: 270.5726deg, 18.5648deg
+  position: 270.5726deg +18.5648deg
   priority: 100
 -
   name: TESS_SEC26_CAM03
-  position: 270.4051deg, 42.5644deg
+  position: 270.4051deg +42.5644deg
   priority: 100
 -
   name: TESS_SEC26_CAM04
-  position: 270.0058deg, 66.563deg
+  position: 270.0058deg +66.563deg
   priority: 100

--- a/resources/targets/tess_sectors_north.yaml
+++ b/resources/targets/tess_sectors_north.yaml
@@ -47,22 +47,6 @@
   position: 270.0004deg, 66.5654deg
   priority: 100
 -
-  name: TESS_SEC16_CAM01
-  position: 336.0753deg, 44.1395deg
-  priority: 100
--
-  name: TESS_SEC16_CAM02
-  position: 307.8459deg, 61.5441deg
-  priority: 100
--
-  name: TESS_SEC16_CAM03
-  position: 252.9139deg, 65.4973deg
-  priority: 100
--
-  name: TESS_SEC16_CAM04
-  position: 214.0535deg, 51.5694deg
-  priority: 100
--
   name: TESS_SEC17_CAM01
   position: 17.3888deg, 26.8940deg
   priority: 100

--- a/resources/targets/tess_sectors_north.yaml
+++ b/resources/targets/tess_sectors_north.yaml
@@ -5,7 +5,7 @@
 -
   name: TESS_SEC14_CAM02
   position: 287.0536deg, 51.8282deg
-  priority: 100
+  priority: 500
 -
   name: TESS_SEC14_CAM03
   position: 256.1832deg, 71.5698deg
@@ -53,7 +53,7 @@
 -
   name: TESS_SEC17_CAM02
   position:  3.2857deg, 48.2318deg
-  priority: 100
+  priority: 500
 -
   name: TESS_SEC17_CAM03
   position: 331.6029deg, 65.5589deg
@@ -153,7 +153,7 @@
 -
   name: TESS_SEC23_CAM03
   position: 228.1276deg, 53.4704deg
-  priority: 100
+  priority: 500
 -
   name: TESS_SEC23_CAM04
   position: 270.0013deg, 66.5614deg


### PR DESCRIPTION
Adds a target file for the Northern Hemisphere based off https://tess.mit.edu/observations.

Gives a high priority to some random fields.