### PR TITLE
Slew to home blocking

### DIFF
--- a/bin/pocs_shell
+++ b/bin/pocs_shell
@@ -287,7 +287,7 @@ Hardware names: {}   (or all for all hardware)'''.format(
             return
 
         try:
-            self.pocs.observatory.mount.slew_to_home()
+            self.pocs.observatory.mount.slew_to_home(blocking=True)
         except Exception as e:
             print_warning('Problem slewing to home: {}'.format(e))
 
@@ -350,7 +350,7 @@ Hardware names: {}   (or all for all hardware)'''.format(
 
         print_info("Moving to home position")
         self.pocs.say("Moving to home position")
-        mount.slew_to_home()
+        mount.slew_to_home(blocking=True)
 
         # Polar Rotation
         pole_fn = polar_rotation(self.pocs, base_dir=base_dir)
@@ -362,7 +362,7 @@ Hardware names: {}   (or all for all hardware)'''.format(
 
         print_info("Moving back to home")
         self.pocs.say("Moving back to home")
-        mount.slew_to_home()
+        mount.slew_to_home(blocking=True)
 
         print_info("Solving celestial pole image")
         self.pocs.say("Solving celestial pole image")
@@ -488,10 +488,7 @@ def polar_rotation(pocs, exptime=30, base_dir=None, **kwargs):
 
     print_info('Performing polar rotation test')
     pocs.say('Performing polar rotation test')
-    mount.slew_to_home()
-
-    while not mount.is_home:
-        time.sleep(2)
+    mount.slew_to_home(blocking=True)
 
     analyze_fn = None
 
@@ -537,7 +534,7 @@ def mount_rotation(pocs, base_dir=None, include_west=False, **kwargs):
 
     print_info("Doing rotation test")
     pocs.say("Doing rotation test")
-    mount.slew_to_home()
+    mount.slew_to_home(blocking=True)
     exptime = 25
     mount.move_direction(direction='west', seconds=11)
 
@@ -719,7 +716,7 @@ class DriftShell(Cmd):
             return
 
         try:
-            self.pocs.observatory.mount.slew_to_home()
+            self.pocs.observatory.mount.slew_to_home(blocking=True)
         except Exception as e:
             print_warning('Problem slewing to home: {}'.format(e))
 

--- a/pocs/mount/bisque.py
+++ b/pocs/mount/bisque.py
@@ -203,11 +203,15 @@ class Mount(AbstractMount):
 
         return success
 
-    def slew_to_home(self):
+    def slew_to_home(self, blocking=False):
         """ Slews the mount to the home position.
 
         Note:
             Home position and Park position are not the same thing
+
+        Args:
+            blocking (bool, optional): If command should block while slewing to
+                home, default False.
 
         Returns:
             bool: indicating success
@@ -222,9 +226,9 @@ class Mount(AbstractMount):
 
         return response
 
-    def slew_to_zero(self):
+    def slew_to_zero(self, blocking=False):
         """ Calls `slew_to_home` in base class. Can be overridden.  """
-        self.slew_to_home()
+        self.slew_to_home(blocking=blocking)
 
     def park(self):
         """ Slews to the park position and parks the mount.

--- a/pocs/mount/mount.py
+++ b/pocs/mount/mount.py
@@ -514,20 +514,30 @@ class AbstractMount(PanBase):
 
         return success
 
-    def slew_to_home(self):
+    def slew_to_home(self, blocking=False):
         """ Slews the mount to the home position.
 
         Note:
             Home position and Park position are not the same thing
+
+        Args:
+            blocking (bool, optional): If command should block while slewing to
+                home, default False.
 
         Returns:
             bool: indicating success
         """
         response = 0
 
+        block_time = 2  # seconds
+
         if not self.is_parked:
             self._target_coordinates = None
             response = self.query('slew_to_home')
+            if response and blocking:
+                while self.is_home is False:
+                    time.sleep(block_time)
+                    self.logger.debug(f'Slewing to home, sleeping for {block_time} seconds')
         else:
             self.logger.info('Mount is parked')
 

--- a/pocs/mount/mount.py
+++ b/pocs/mount/mount.py
@@ -469,10 +469,7 @@ class AbstractMount(PanBase):
         """ Convenience method to first slew to the home position and then park.
         """
         if not self.is_parked:
-            self.slew_to_home()
-            while self.is_slewing:
-                time.sleep(5)
-                self.logger.debug("Slewing to home, sleeping for 5 seconds")
+            self.slew_to_home(blocking=True)
 
             # Reinitialize from home seems to always do the trick of getting us to
             # correct side of pier for parking

--- a/pocs/mount/mount.py
+++ b/pocs/mount/mount.py
@@ -543,9 +543,9 @@ class AbstractMount(PanBase):
 
         return response
 
-    def slew_to_zero(self):
+    def slew_to_zero(self, blocking=False):
         """ Calls `slew_to_home` in base class. Can be overridden.  """
-        self.slew_to_home()
+        self.slew_to_home(blocking=blocking)
 
     def park(self):
         """ Slews to the park position and parks the mount.

--- a/pocs/mount/simulator.py
+++ b/pocs/mount/simulator.py
@@ -148,7 +148,7 @@ class Mount(AbstractMount):
             self.logger.debug("Setting next position to {}".format(next_position))
             setattr(self, next_position, True)
 
-    def slew_to_home(self):
+    def slew_to_home(self, blocking=False):
         """ Slews the mount to the home position.
 
         Note:


### PR DESCRIPTION
Provides a parameter that allows the `slew_to_home` command to block until home is reached. Defaults to `False` for backwards compatibility.

Replaces some custom blocking in various places with new parameter.

Pulled from #859.