### PR TITLE
Revert "Use our own mirror for the IERS data."

### DIFF
--- a/pocs/utils/data.py
+++ b/pocs/utils/data.py
@@ -7,9 +7,6 @@ import shutil
 import sys
 import warnings
 
-from astropy.utils import iers
-iers.IERS_A_URL = 'https://storage.googleapis.com/panoptes-resources/iers/ser7.dat'
-
 # Importing download_IERS_A can emit a scary warnings, so we suppress it.
 with warnings.catch_warnings():
     warnings.filterwarnings('ignore', message='Your version of the IERS Bulletin A')


### PR DESCRIPTION
This reverts commit 8be8f1e78e6abdf7df9a6e4e17a756d9407486b6.

We should deal with this via the astropy configuration settings instead of here. 