### PR TITLE
Scheduler updates

### DIFF
--- a/pocs/scheduler/__init__.py
+++ b/pocs/scheduler/__init__.py
@@ -54,7 +54,7 @@ def create_scheduler_from_config(config, observer=None):
             constraints = [
                 Altitude(horizon=horizon_line),
                 MoonAvoidance(),
-                Duration(default_horizon)
+                Duration(default_horizon, weight=5.0)
             ]
 
             # Create the Scheduler instance

--- a/pocs/scheduler/constraint.py
+++ b/pocs/scheduler/constraint.py
@@ -61,7 +61,7 @@ class Altitude(BaseConstraint):
             self.logger.debug("\t\tBelow minimum altitude: {:.02f} < {:.02f}", target_alt, min_alt)
             veto = True
         else:
-            score = 100
+            score = 1
         return veto, score * self.weight
 
     def __str__(self):
@@ -164,6 +164,7 @@ class AlreadyVisited(BaseConstraint):
     has already been visited before. If given `observation` has already been
     visited then it will not be considered for a call to become the `current observation`.
     """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/pocs/scheduler/dispatch.py
+++ b/pocs/scheduler/dispatch.py
@@ -39,7 +39,7 @@ class Scheduler(BaseScheduler):
         if time is None:
             time = current_time()
 
-        valid_obs = {obs: 1.0 for obs in self.observations}
+        valid_obs = {obs: 0.0 for obs in self.observations}
         best_obs = []
 
         self.set_common_properties(time)
@@ -48,28 +48,37 @@ class Scheduler(BaseScheduler):
             self.logger.info("Checking Constraint: {}".format(constraint))
             for obs_name, observation in self.observations.items():
                 if obs_name in valid_obs:
-                    self.logger.debug("\tObservation: {}".format(obs_name))
+                    current_score = valid_obs[obs_name]
+                    self.logger.debug(f"\t{obs_name}\tCurrent score: {current_score:.03f}")
 
-                    veto, score = constraint.get_score(
-                        time, self.observer, observation, **self.common_properties)
+                    veto, score = constraint.get_score(time,
+                                                       self.observer,
+                                                       observation,
+                                                       **self.common_properties)
 
-                    self.logger.debug("\t\tScore: {:.05f}\tVeto: {}".format(score, veto))
+                    self.logger.debug(f"\t\tConstraint Score: {score:.03f}\tVeto: {veto}")
 
                     if veto:
-                        self.logger.debug("\t\t{} vetoed by {}".format(obs_name, constraint))
+                        self.logger.debug(f"\t\tVetoed by {constraint}")
                         del valid_obs[obs_name]
                         continue
 
                     valid_obs[obs_name] += score
+                    self.logger.debug(f"\t\tTotal score: {valid_obs[obs_name]:.03f}")
 
+        self.logger.debug(f'Multiplying final scores by priority')
         for obs_name, score in valid_obs.items():
-            valid_obs[obs_name] += self.observations[obs_name].priority
+            priority = self.observations[obs_name].priority
+            new_score = score * priority
+            self.logger.debug(f'{obs_name}: {priority:7.2f} *{score:7.2f} = {new_score:7.2f}')
+            valid_obs[obs_name] = new_score
 
         if len(valid_obs) > 0:
             # Sort the list by highest score (reverse puts in correct order)
             best_obs = sorted(valid_obs.items(), key=lambda x: x[1])[::-1]
 
-            top_obs_name, top_obs_merit = best_obs[0]
+            top_obs_name, top_obs_score = best_obs[0]
+            self.logger.info(f'Best observation: {top_obs_name}\tScore: {top_obs_score:.02f}')
 
             # Check new best against current_observation
             if self.current_observation is not None \
@@ -80,13 +89,13 @@ class Scheduler(BaseScheduler):
                 if self.observation_available(self.current_observation, end_of_next_set):
 
                     # If current is better or equal to top, use it
-                    if self.current_observation.merit >= top_obs_merit:
+                    if self.current_observation.merit >= top_obs_score:
                         best_obs.insert(0, (self.current_observation,
                                             self.current_observation.merit))
 
             # Set the current
             self.current_observation = self.observations[top_obs_name]
-            self.current_observation.merit = top_obs_merit
+            self.current_observation.merit = top_obs_score
         else:
             if self.current_observation is not None:
                 # Favor the current observation if still available


### PR DESCRIPTION
* Duration constraint has a higher default weight (randomly picked)
* Altitude constraint has a score normalized to 1. instead of 100.
* Dispatch scheduler:
    * **Final score is multipled by priority instead of added to**
    * Base score is 0.0 instead of 1.0
    * More logging output showing scoring

@joshwalawender I can't remember why we have been adding the priority instead of mulitiplying it although I do remember that was a conscious choice. The Denny paper is not explicit about this (in my quick re-scanning of the paper).

Note: These were some changes I had made on various nights to both PAN001 and PAN008 for testing some scheduling and I wanted to get the code into a PR rather than have the changes hanging out on those units.