### PR TITLE
Mount updates - slew_to_target timeout

### DIFF
--- a/pocs/mount/mount.py
+++ b/pocs/mount/mount.py
@@ -436,7 +436,7 @@ class AbstractMount(PanBase):
 # Movement methods
 ##################################################################################################
 
-    def slew_to_coordinates(self, coords, ra_rate=15.0, dec_rate=0.0):
+    def slew_to_coordinates(self, coords, ra_rate=15.0, dec_rate=0.0, *args, **kwargs):
         """ Slews to given coordinates.
 
         Note:
@@ -460,7 +460,7 @@ class AbstractMount(PanBase):
         if not self.is_parked:
             # Set the coordinates
             if self.set_target_coordinates(coords):
-                response = self.slew_to_target()
+                response = self.slew_to_target(*args, **kwargs)
             else:
                 self.logger.warning("Could not set target_coordinates")
 

--- a/pocs/mount/mount.py
+++ b/pocs/mount/mount.py
@@ -518,6 +518,7 @@ class AbstractMount(PanBase):
             if success:
                 if blocking:
                     # Set up the timeout timer
+                    self.logger.debug(f'Setting slew timeout timer for {timeout} sec')
                     timeout_timer = CountdownTimer(timeout)
                     block_time = 3  # seconds
 
@@ -528,6 +529,8 @@ class AbstractMount(PanBase):
 
                         self.logger.debug(f'Slewing to target, sleeping for {block_time} seconds')
                         timeout_timer.sleep(max_sleep=block_time)
+
+                    self.logger.debug(f'Done wtih slew_to_target block')
             else:
                 self.logger.warning('Problem with slew_to_target')
 

--- a/pocs/mount/mount.py
+++ b/pocs/mount/mount.py
@@ -530,7 +530,7 @@ class AbstractMount(PanBase):
                         self.logger.debug(f'Slewing to target, sleeping for {block_time} seconds')
                         timeout_timer.sleep(max_sleep=block_time)
 
-                    self.logger.debug(f'Done wtih slew_to_target block')
+                    self.logger.debug(f'Done with slew_to_target block')
             else:
                 self.logger.warning('Problem with slew_to_target')
 

--- a/pocs/mount/mount.py
+++ b/pocs/mount/mount.py
@@ -484,12 +484,22 @@ class AbstractMount(PanBase):
 
         self.logger.debug("Mount parked")
 
-    def slew_to_target(self):
-        """ Slews to the current _target_coordinates
+    def slew_to_target(self, blocking=False, timeout=180):
+        """ Slews to the currently assigned target coordinates.
+
+        Slews the mount to the coordinates that have been assigned by `~set_target_coordinates`.
+        If no coordinates have been set, do nothing and return `False`, otherwise
+        return response from the mount.
+
+        If `blocking=True` then wait for up to `timeout` seconds for the mount
+        to reach the `is_tracking` state. If a timeout occurs, raise a `pocs.error.Timeout`
+        exception.
 
         Args:
-            on_finish(method):  A callback method to be executed when mount has
-            arrived at destination
+            blocking (bool, optional): If command should block while slewing to
+                home, default False.
+            timeout (int, optional): Maximum time spent slewing to home, default
+                180 seconds.
 
         Returns:
             bool: indicating success
@@ -501,12 +511,23 @@ class AbstractMount(PanBase):
         elif not self.has_target:
             self.logger.info("Target Coordinates not set")
         else:
+            self.logger.debug('Slewing to target')
             success = self.query('slew_to_target')
 
             self.logger.debug("Mount response: {}".format(success))
             if success:
-                self.logger.debug('Slewing to target')
+                if blocking:
+                    # Set up the timeout timer
+                    timeout_timer = CountdownTimer(timeout)
+                    block_time = 3  # seconds
 
+                    while self.is_tracking is False:
+                        if timeout_timer.expired():
+                            self.logger.warning(f'slew_to_target timout: {timeout} seconds')
+                            raise error.Timeout('Problem slewing to target')
+
+                        self.logger.debug(f'Slewing to target, sleeping for {block_time} seconds')
+                        timeout_timer.sleep(max_sleep=block_time)
             else:
                 self.logger.warning('Problem with slew_to_target')
 

--- a/pocs/mount/simulator.py
+++ b/pocs/mount/simulator.py
@@ -167,6 +167,7 @@ class Mount(AbstractMount):
         self.logger.debug("Query: {} {}".format(cmd, params))
         if cmd == 'slew_to_target':
             time.sleep(self._loop_delay)
+            self._is_tracking = True
 
         return True
 

--- a/pocs/mount/simulator.py
+++ b/pocs/mount/simulator.py
@@ -107,26 +107,9 @@ class Mount(AbstractMount):
 
         return super().get_ms_offset(offset, axis=axis)
 
-    def slew_to_target(self):
-        success = False
-
-        if self.is_parked:
-            self.logger.warning("Mount is parked")
-        elif not self.has_target:
-            self.logger.warning("Target Coordinates not set")
-        else:
-
-            self._is_slewing = True
-            self._is_tracking = False
-            self._is_home = False
-
-            time.sleep(self._loop_delay)
-
-            self.stop_slew()
-            self._state = 'Tracking'
-
-            self._current_coordinates = self.get_target_coordinates()
-            success = True
+    def slew_to_target(self, loop_delay=0.01, *args, **kwargs):
+        success = super().slew_to_target(*args, **kwargs)
+        self._current_coordinates = self.get_target_coordinates()
 
         return success
 
@@ -182,6 +165,10 @@ class Mount(AbstractMount):
 
     def query(self, cmd, params=None):
         self.logger.debug("Query: {} {}".format(cmd, params))
+        if cmd == 'slew_to_target':
+            time.sleep(self._loop_delay)
+
+        return True
 
     def write(self, cmd):
         self.logger.debug("Write: {}".format(cmd))

--- a/pocs/mount/simulator.py
+++ b/pocs/mount/simulator.py
@@ -116,7 +116,6 @@ class Mount(AbstractMount):
         def trigger_tracking():
             self.logger.debug('Triggering mount simulator tracking')
             self._is_tracking = True
-            self._current_coordinates = self.get_target_coordinates()
 
         timer = Timer(slew_delay, trigger_tracking)
         timer.start()
@@ -127,6 +126,8 @@ class Mount(AbstractMount):
             # Cancel the timer and re-throw exception
             timer.cancel()
             raise error.Timeout
+
+        self._current_coordinates = self.get_target_coordinates()
 
         return success
 

--- a/pocs/state/states/default/pointing.py
+++ b/pocs/state/states/default/pointing.py
@@ -94,7 +94,7 @@ def on_enter(event_data):
                         if observation.field is not None:
                             pocs.logger.debug("Slewing back to target")
                             pocs.observatory.mount.set_target_coordinates(observation.field)
-                            pocs.observatory.mount.slew_to_target()
+                            pocs.observatory.mount.slew_to_target(blocking=True)
                 else:
                     pocs.logger.info("Separation is within pointing threshold, starting tracking.")
                     break

--- a/pocs/state/states/default/pointing.py
+++ b/pocs/state/states/default/pointing.py
@@ -35,8 +35,8 @@ def on_enter(event_data):
 
         # Loop over maximum number of pointing iterations
         for img_num in range(num_pointing_images):
-            pocs.logger.debug("Taking pointing image {}/{} on: {}",
-                              img_num, num_pointing_images, primary_camera)
+            pocs.logger.info(
+                f"Taking pointing image {img_num+1}/{num_pointing_images} on: {primary_camera}")
 
             # Start the exposure
             camera_event = primary_camera.take_observation(
@@ -95,6 +95,10 @@ def on_enter(event_data):
                             pocs.logger.debug("Slewing back to target")
                             pocs.observatory.mount.set_target_coordinates(observation.field)
                             pocs.observatory.mount.slew_to_target(blocking=True)
+
+                    if img_num == (num_pointing_images - 1):
+                        pocs.logger.info(f'Separation outside threshold but at max corrections. ' +
+                                         'Will proceed to observations.')
                 else:
                     pocs.logger.info("Separation is within pointing threshold, starting tracking.")
                     break

--- a/pocs/state/states/default/slewing.py
+++ b/pocs/state/states/default/slewing.py
@@ -4,15 +4,11 @@ def on_enter(event_data):
     try:
         pocs.logger.debug("Inside slew state")
 
-        # Start the mount slewing
-        pocs.observatory.mount.slew_to_target()
-
         # Wait until mount is_tracking, then transition to track state
         pocs.say("I'm slewing over to the coordinates to track the target.")
 
-        while not pocs.observatory.mount.is_tracking:
-            pocs.logger.debug("Slewing to target")
-            pocs.sleep()
+        # Start the mount slewing
+        pocs.observatory.mount.slew_to_target(blocking=True)
 
         pocs.say("I'm at the target, checking pointing.")
         pocs.next_state = 'pointing'

--- a/pocs/tests/test_mount_simulator.py
+++ b/pocs/tests/test_mount_simulator.py
@@ -7,6 +7,7 @@ from astropy.coordinates import SkyCoord
 
 from pocs.mount.simulator import Mount
 from pocs.utils import altaz_to_radec
+from pocs.utils import error
 
 
 @pytest.fixture
@@ -163,6 +164,16 @@ def test_slew_to_target(mount, target):
     mount.park()
     assert mount.is_parked is True
     mount.get_current_coordinates() == parked_coords
+
+
+def test_slew_to_target_timeout(mount, target):
+    os.environ['POCSTIME'] = '2016-08-13 20:03:01'
+
+    mount.initialize(unpark=True)
+
+    assert mount.set_target_coordinates(target) is True
+    with pytest.raises(error.Timeout):
+        assert mount.slew_to_target(blocking=True, timeout=1, loop_delay=30)
 
 
 def test_slew_to_home(mount):

--- a/pocs/tests/test_mount_simulator.py
+++ b/pocs/tests/test_mount_simulator.py
@@ -173,7 +173,7 @@ def test_slew_to_target_timeout(mount, target):
 
     assert mount.set_target_coordinates(target) is True
     with pytest.raises(error.Timeout):
-        assert mount.slew_to_target(blocking=True, timeout=1, loop_delay=30)
+        assert mount.slew_to_target(blocking=True, timeout=3, slew_delay=30)
 
 
 def test_slew_to_home(mount):


### PR DESCRIPTION
## Description
* `slew_to_target` has an optional `blocking` parameter to match #887.
* Mount simulator
    * Update simulate `slew_to_target` to actually use the `AbstractMount` code.

What's not entirely clear here is what should be done if the `Timeout` is actually raised but this at least adds the mechanism for it.

## Related Issue
#887 

