### PR TITLE
Fix import of ctypes.util

### DIFF
--- a/pocs/tests/utils/test_utils.py
+++ b/pocs/tests/utils/test_utils.py
@@ -12,7 +12,7 @@ from pocs.utils import load_module
 from pocs.utils import CountdownTimer
 from pocs.utils import error
 from pocs.camera import list_connected_cameras
-from pocs.utils.library import load_library
+from pocs.utils.library import load_library as load_c_library
 
 
 def test_error(capsys):

--- a/pocs/tests/utils/test_utils.py
+++ b/pocs/tests/utils/test_utils.py
@@ -12,6 +12,7 @@ from pocs.utils import load_module
 from pocs.utils import CountdownTimer
 from pocs.utils import error
 from pocs.camera import list_connected_cameras
+from pocs.utils.library import load_library
 
 
 def test_error(capsys):
@@ -39,6 +40,12 @@ def test_error(capsys):
 def test_bad_load_module():
     with pytest.raises(error.NotFound):
         load_module('FOOBAR')
+
+
+def test_load_c_library():
+    # Called without a `path` this will use find_library to locate libc.
+    libc = load_c_library('c')
+    assert libc._name[:4] == 'libc'
 
 
 def test_listify():

--- a/pocs/utils/library.py
+++ b/pocs/utils/library.py
@@ -1,4 +1,5 @@
 import ctypes
+import ctypes.util
 
 from pocs.utils import error
 


### PR DESCRIPTION
## Description

The `pocs.utils.library.load_library()` function was calling the `ctypes.util.find_library` function but `ctypes.util` was not being imported in `pocs/utils/library.py` so this call was failing. This was causing SDK `Camera` classes (e.g. SBIG, FLI, ZWO) to fail on initialisation unless the full path to their driver library was explicitly specified, which avoids the call to `ctypes.util.find_library()`.

The changes here are a duplicate of changes made to fix the same bug in `panoptes-utils`, in https://github.com/panoptes/panoptes-utils/pull/72. Because of the impact of this bug on Huntsman operations it seems worthwhile to fix it here too, rather than waiting for POCS to transition to using `panoptes-utils` for this function.

## How Has This Been Tested?

Test added to `pocs/tests/utils/test_utils.py` to ensure call to `ctypes.util.find_library` now works.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
