### PR TITLE
Fix scaling of ZWO camera pixel values

### DIFF
--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -546,6 +546,8 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         header.set('CAM-ID', self.uid, 'Camera serial number')
         header.set('CAM-NAME', self.name, 'Camera name')
         header.set('CAM-MOD', self.model, 'Camera model')
+        with suppress(AttributeError):
+            header.set('BITDEPTH', self.bit_depth, 'ADC bit depth')
 
         if self.focuser:
             header = self.focuser._add_fits_keywords(header)

--- a/pocs/camera/zwo.py
+++ b/pocs/camera/zwo.py
@@ -2,6 +2,7 @@ import time
 import threading
 from contextlib import suppress
 
+import numpy as np
 from astropy import units as u
 from astropy.time import Time
 
@@ -71,6 +72,11 @@ class Camera(AbstractSDKCamera):
         roi_format = self._driver.get_roi_format(self._handle)
         roi_format['image_type'] = new_image_type
         Camera._driver.set_roi_format(self._handle, **roi_format)
+
+    @property
+    def bit_depth(self):
+        """ADC bit depth"""
+        return self.properties['bit_depth']
 
     @property
     def ccd_temp(self):
@@ -203,6 +209,13 @@ class Camera(AbstractSDKCamera):
         start_time = time.monotonic()
         good_frames = 0
         bad_frames = 0
+
+        # Calculate number of bits that have been used to pad the raw data to RAW16 format.
+        if self.image_type == 'RAW16':
+            pad_bits = 16 - int(get_quantity_value(self.bit_depth, u.bit))
+        else:
+            pad_bits = 0
+
         for frame_number in range(max_frames):
             if self._video_event.is_set():
                 break
@@ -216,6 +229,9 @@ class Camera(AbstractSDKCamera):
                 now = Time.now()
                 header.set('DATE-OBS', now.fits, 'End of exposure + readout')
                 filename = "{}_{:06d}.{}".format(filename_root, frame_number, file_extension)
+                # Fix 'raw' data scaling by changing from zero padding of LSBs
+                # to zero padding of MSBs.
+                video_data = np.right_shift(video_data, pad_bits)
                 fits_utils.write_fits(video_data, header, filename)
                 good_frames += 1
             else:
@@ -254,6 +270,12 @@ class Camera(AbstractSDKCamera):
             except RuntimeError as err:
                 raise error.PanError('Error getting image data from {}: {}'.format(self, err))
             else:
+                # Fix 'raw' data scaling by changing from zero padding of LSBs
+                # to zero padding of MSBs.
+                if self.image_type == 'RAW16':
+                    pad_bits = 16 - int(get_quantity_value(self.bit_depth, u.bit))
+                    image_data = np.right_shift(image_data, pad_bits)
+
                 fits_utils.write_fits(image_data,
                                       header,
                                       filename,

--- a/pocs/tests/test_camera.py
+++ b/pocs/tests/test_camera.py
@@ -400,6 +400,7 @@ def test_exposure_scaling(camera, tmpdir):
         fits_path = str(tmpdir.join('test_exposure_scaling.fits'))
         camera.take_exposure(filename=fits_path, dark=True, blocking=True)
         image_data, image_header = fits.getdata(fits_path, header=True)
+        assert bit_depth == image_header['BITDEPTH'] * u.bit
         pad_bits = image_header['BITPIX'] - image_header['BITDEPTH']
         assert (image_data % 2**pad_bits).any()
 

--- a/pocs/tests/test_camera.py
+++ b/pocs/tests/test_camera.py
@@ -400,7 +400,7 @@ def test_exposure_scaling(camera, tmpdir):
         fits_path = str(tmpdir.join('test_exposure_scaling.fits'))
         camera.take_exposure(filename=fits_path, dark=True, blocking=True)
         image_data, image_header = fits.getdata(fits_path, header=True)
-        pad_bits = image_header['BITPIX'] = bit_depth
+        pad_bits = image_header['BITPIX'] - image_header['BITDEPTH']
         assert (image_data % 2**pad_bits).any()
 
 


### PR DESCRIPTION
Fixes the incorrect scaling of pixel values in image data from ZWO ASI cameras.

## Description
Adds rescaling when reading image data from the camera driver in RAW16 format. The raw image data is shifted by the appropriate number of bits to the right to remove the zero padding that ZWO ASI cameras incorrectly apply to the least significant bits instead of the most significant bits.

## Related Issue
#899 

## How Has This Been Tested?
A regression test has been added to the unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
