### PR TITLE
Fix bit depth FITS header bug

### DIFF
--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -547,7 +547,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         header.set('CAM-NAME', self.name, 'Camera name')
         header.set('CAM-MOD', self.model, 'Camera model')
         with suppress(AttributeError):
-            header.set('BITDEPTH', self.bit_depth, 'ADC bit depth')
+            header.set('BITDEPTH', get_quantity_value(self.bit_depth, u.bit), 'ADC bit depth')
 
         if self.focuser:
             header = self.focuser._add_fits_keywords(header)


### PR DESCRIPTION
Strip units from `bit_depth` when adding to FITS headers.

## Description
#902 introduced a `bit_depth` property for ZWO cameras, and added a `BITDEPTH` keyword to the FITS headers of images taken with these cameras. The `bit_depth` property is an `astropy.units.Quantity` however, and the `astropy.io.fits` library rejects `Quantity` header values with a `ValueError`.  It is necessary to extract the value of the `Quantity` first before adding to the FITS header but this had not been done, resulting in an exception when trying to take an exposure.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
