### PR TITLE
Use real serial numbers for ZWO ASI cameras

### DIFF
--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -119,6 +119,16 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         return self._file_extension
 
     @property
+    def egain(self):
+        """Image sensor gain in e-/ADU as reported by the camera."""
+        raise NotImplementedError  # pragma: no cover
+
+    @property
+    def bit_depth(self):
+        """ADC bit depth."""
+        raise NotImplementedError  # pragma: no cover
+
+    @property
     def ccd_temp(self):
         """
         Get current temperature of the camera's image sensor.
@@ -537,17 +547,21 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
                 header.set('IMAGETYP', 'Light Frame')
         header.set('FILTER', self.filter_type)
         with suppress(NotImplementedError):
-            header.set('CCD-TEMP', get_quantity_value(self.ccd_temp, u.Celsius), 'Degrees C')
-        with suppress(NotImplementedError):
-            header.set('SET-TEMP', get_quantity_value(self.ccd_set_point, u.Celsius), 'Degrees C')
-        with suppress(NotImplementedError):
-            header.set('COOL-POW', get_quantity_value(self.ccd_cooling_power, u.percent),
+            # SBIG & ZWO cameras report their gain.
+            header.set('EGAIN', get_quantity_value(self.egain, u.electron/u.adu), 'Electrons/ADU')
+            # ZWO cameras have ADC bit depths with differ from BITPIX
+            header.set('BITDEPTH', int(get_quantity_value(self.bit_depth, u.bit)), 'ADC bit depth')
+            # Some non cooled cameras can still report the image sensor temperature
+            header.set('CCD-TEMP', get_quantity_value(self.temperature, u.Celsius), 'Degrees C')
+        if self.is_cooled_camera:
+            header.set('SET-TEMP', get_quantity_value(self.target_temperature, u.Celsius),
+                       'Degrees C')
+            header.set('COOL-POW', get_quantity_value(self.cooling_power, u.percent),
                        'Percentage')
         header.set('CAM-ID', self.uid, 'Camera serial number')
         header.set('CAM-NAME', self.name, 'Camera name')
         header.set('CAM-MOD', self.model, 'Camera model')
-        with suppress(AttributeError):
-            header.set('BITDEPTH', get_quantity_value(self.bit_depth, u.bit), 'ADC bit depth')
+
 
         if self.focuser:
             header = self.focuser._add_fits_keywords(header)

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -548,7 +548,8 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         header.set('FILTER', self.filter_type)
         with suppress(NotImplementedError):
             # SBIG & ZWO cameras report their gain.
-            header.set('EGAIN', get_quantity_value(self.egain, u.electron/u.adu), 'Electrons/ADU')
+            header.set('EGAIN', get_quantity_value(self.egain, u.electron / u.adu),
+                       'Electrons/ADU')
             # ZWO cameras have ADC bit depths with differ from BITPIX
             header.set('BITDEPTH', int(get_quantity_value(self.bit_depth, u.bit)), 'ADC bit depth')
             # Some non cooled cameras can still report the image sensor temperature
@@ -561,7 +562,6 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         header.set('CAM-ID', self.uid, 'Camera serial number')
         header.set('CAM-NAME', self.name, 'Camera name')
         header.set('CAM-MOD', self.model, 'Camera model')
-
 
         if self.focuser:
             header = self.focuser._add_fits_keywords(header)

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -550,14 +550,16 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
             # SBIG & ZWO cameras report their gain.
             header.set('EGAIN', get_quantity_value(self.egain, u.electron / u.adu),
                        'Electrons/ADU')
+        with suppress(NotImplementedError):
             # ZWO cameras have ADC bit depths with differ from BITPIX
             header.set('BITDEPTH', int(get_quantity_value(self.bit_depth, u.bit)), 'ADC bit depth')
+        with suppress(NotImplementedError):
             # Some non cooled cameras can still report the image sensor temperature
-            header.set('CCD-TEMP', get_quantity_value(self.temperature, u.Celsius), 'Degrees C')
-        if self.is_cooled_camera:
-            header.set('SET-TEMP', get_quantity_value(self.target_temperature, u.Celsius),
+            header.set('CCD-TEMP', get_quantity_value(self.ccd_temp, u.Celsius), 'Degrees C')
+        with suppress(NotImplementedError):
+            header.set('SET-TEMP', get_quantity_value(self.ccd_set_point, u.Celsius),
                        'Degrees C')
-            header.set('COOL-POW', get_quantity_value(self.cooling_power, u.percent),
+            header.set('COOL-POW', get_quantity_value(self.ccd_cooling_power, u.percent),
                        'Percentage')
         header.set('CAM-ID', self.uid, 'Camera serial number')
         header.set('CAM-NAME', self.name, 'Camera name')

--- a/pocs/camera/fli.py
+++ b/pocs/camera/fli.py
@@ -100,7 +100,7 @@ class Camera(AbstractSDKCamera):
             message = 'Could not connect to {} on {}!'.format(self.name, self._camera_address)
             raise error.PanError(message)
         self._get_camera_info()
-        self.model = self._info['camera model']
+        self.model = self.properties['camera model']
         self._connected = True
 
 # Private Methods
@@ -117,8 +117,8 @@ class Camera(AbstractSDKCamera):
         # For now set to 'visible' (i.e. light sensitive) area of image sensor.
         # Can later use this for windowed exposures.
         self._driver.FLISetImageArea(self._handle,
-                                     self._info['visible corners'][0],
-                                     self._info['visible corners'][1])
+                                     self.properties['visible corners'][0],
+                                     self.properties['visible corners'][1])
 
         # No on chip binning for now.
         self._driver.FLISetHBin(self._handle, bin_factor=1)
@@ -133,8 +133,8 @@ class Camera(AbstractSDKCamera):
         self._driver.FLIExposeFrame(self._handle)
 
         readout_args = (filename,
-                        self._info['visible width'],
-                        self._info['visible height'],
+                        self.properties['visible width'],
+                        self.properties['visible height'],
                         header)
         return readout_args
 
@@ -157,10 +157,10 @@ class Camera(AbstractSDKCamera):
     def _create_fits_header(self, seconds, dark):
         header = super()._create_fits_header(seconds, dark)
 
-        header.set('CAM-HW', self._info['hardware version'], 'Camera hardware version')
-        header.set('CAM-FW', self._info['firmware version'], 'Camera firmware version')
-        header.set('XPIXSZ', self._info['pixel width'].value, 'Microns')
-        header.set('YPIXSZ', self._info['pixel height'].value, 'Microns')
+        header.set('CAM-HW', self.properties['hardware version'], 'Camera hardware version')
+        header.set('CAM-FW', self.properties['firmware version'], 'Camera firmware version')
+        header.set('XPIXSZ', self.properties['pixel width'].value, 'Microns')
+        header.set('YPIXSZ', self.properties['pixel height'].value, 'Microns')
 
         return header
 

--- a/pocs/camera/libasi.py
+++ b/pocs/camera/libasi.py
@@ -430,7 +430,7 @@ class ASIDriver(AbstractSDKDriver):
                             ctypes.bytef(pin_high),
                             ctypes.byref(delay),
                             ctypes.byref(duration))
-        self.logger.debug("Got trigger config from camera {}".format(camera_IF))
+        self.logger.debug("Got trigger config from camera {}".format(camera_ID))
         return TrigOutput(pin).name, bool(pin_high), int(delay), int(duration)
 
     def set_trigger_ouput_io_conf(self, camera_ID, pin, pin_high, delay, duration):

--- a/pocs/camera/libasi.py
+++ b/pocs/camera/libasi.py
@@ -337,7 +337,7 @@ class ASIDriver(AbstractSDKDriver):
                             GuideDirection[direction])
         dname = GuideDirection[direction].name
         msg = f"PulseGuide on camera {camera_ID} on in direction {dname}."
-        self.logger.debug(msg}
+        self.logger.debug(msg)
 
     def pulse_guide_off(self, camera_ID, direction):
         """Turn off PulseGuide on ST4 port of given camera in given direction."""
@@ -346,7 +346,7 @@ class ASIDriver(AbstractSDKDriver):
                             GuideDirection[direction])
         dname = GuideDirection[direction].name
         msg = f"PulseGuide on camera {camera_ID} off in direction {dname}."
-        self.logger.debug(msg}
+        self.logger.debug(msg)
 
     def get_gain_offset(self, camera_ID):
         """Get pre-setting parameters."""
@@ -371,7 +371,7 @@ class ASIDriver(AbstractSDKDriver):
                             ctypes.byref(modes_struct.modes))
         supported_modes = []
         for mode_int in modes_struct.modes:
-            if mode_int = CameraMode.END:
+            if mode_int == CameraMode.END:
                 break
             supported_modes.append(CameraMode(mode_int).name)
 
@@ -402,7 +402,7 @@ class ASIDriver(AbstractSDKDriver):
         self._call_function('ASISendSoftTrigger',
                             camera_ID,
                             int(bool(start_stop_signal)))
-        self.logger.debug('Soft trigger sent to camera {}.'format(camera_ID))
+        self.logger.debug('Soft trigger sent to camera {}.'.format(camera_ID))
 
     def get_serial_number(self, camera_ID):
         """Get serial number of the camera with given integer ID.
@@ -687,6 +687,7 @@ class TrigOutput(enum.IntEnum):
     PINA = 0  # Only Pin A output
     PINB = enum.auto()  # Only Pin B outoput
     NONE = -1
+
 
 @enum.unique
 class ErrorCode(enum.IntEnum):

--- a/pocs/camera/libasi.py
+++ b/pocs/camera/libasi.py
@@ -391,7 +391,7 @@ class ASIDriver(AbstractSDKDriver):
 
     def set_camera_mode(self, camera_ID, mode_name):
         """Set trigger mode for camera with given integer ID."""
-        mode = CamerMode[mode_name]
+        mode = CameraMode[mode_name]
         self._call_function('ASISetCameraMode',
                             camera_ID,
                             mode)

--- a/pocs/camera/libasi.py
+++ b/pocs/camera/libasi.py
@@ -74,7 +74,7 @@ class ASIDriver(AbstractSDKDriver):
             camera_ID = info['camera_ID']
             self.open_camera(camera_ID)
             try:
-                serial_number = self.get_serial_number()
+                serial_number = self.get_serial_number(camera_ID)
             except RuntimeError as err:
                 # If at first you don't succeed, try, except, else, finally again.
                 self.logger.error(f"Error getting serial number: {err}")

--- a/pocs/camera/libasi.py
+++ b/pocs/camera/libasi.py
@@ -77,13 +77,13 @@ class ASIDriver(AbstractSDKDriver):
                 serial_number = self.get_serial_number(camera_ID)
             except RuntimeError as err:
                 # If at first you don't succeed, try, except, else, finally again.
-                self.logger.error(f"Error getting serial number: {err}")
+                self.logger.warning(f"Error getting serial number: {err}")
                 try:
                     string_ID = self.get_ID(camera_ID)
                 except RuntimeError as err:
-                    self.logger.error(f"Error getting string ID: {err}")
+                    self.logger.warning(f"Error getting string ID: {err}")
                     msg = f"Skipping ZWO ASI camera {camera_ID} with no serial number or string ID."
-                    self.logger.warning(msg)
+                    self.logger.error(msg)
                     break
                 else:
                     msg = f"Using string ID '{string_ID}' in place of serial number."
@@ -127,8 +127,7 @@ class ASIDriver(AbstractSDKDriver):
             raise RuntimeError(msg)
 
         pythonic_info = self._parse_info(camera_info)
-        self.logger.debug("Got info from camera {}, {}".format(pythonic_info['camera_ID'],
-                                                               pythonic_info['name']))
+        self.logger.debug("Got info from camera {camera_ID}, {name}".format(**pythonic_info))
         return pythonic_info
 
     def get_camera_property_by_id(self, camera_ID):
@@ -139,8 +138,7 @@ class ASIDriver(AbstractSDKDriver):
                             ctypes.byref(camera_info))
 
         pythonic_info = self._parse_info(camera_info)
-        self.logger.debug("Got info from camera {}, {}".format(pythonic_info['camera_ID'],
-                                                               pythonic_info['name']))
+        self.logger.debug("Got info from camera {camera_ID}, {name}".format(**pythonic_info))
         return pythonic_info
 
     def open_camera(self, camera_ID):

--- a/pocs/camera/sbig.py
+++ b/pocs/camera/sbig.py
@@ -35,7 +35,7 @@ class Camera(AbstractSDKCamera):
     @property
     def egain(self):
         """Image sensor gain in e-/ADU as reported by the camera."""
-        return self._info['readout modes']['RM_1X1']['gain']
+        return self.properties['readout modes']['RM_1X1']['gain']
 
     @property
     def ccd_temp(self):
@@ -197,10 +197,10 @@ class Camera(AbstractSDKCamera):
         # Unbinned. Need to chance if binning gets implemented.
         readout_mode = 'RM_1X1'
 
-        header.set('CAM-FW', self._info['firmware version'], 'Camera firmware version')
-        header.set('XPIXSZ', self._info['readout modes'][readout_mode]['pixel width'].value,
+        header.set('CAM-FW', self.properties['firmware version'], 'Camera firmware version')
+        header.set('XPIXSZ', self.properties['readout modes'][readout_mode]['pixel width'].value,
                    'Microns')
-        header.set('YPIXSZ', self._info['readout modes'][readout_mode]['pixel height'].value,
+        header.set('YPIXSZ', self.properties['readout modes'][readout_mode]['pixel height'].value,
                    'Microns')
 
         return header

--- a/pocs/camera/sbig.py
+++ b/pocs/camera/sbig.py
@@ -33,6 +33,11 @@ class Camera(AbstractSDKCamera):
 # Properties
 
     @property
+    def egain(self):
+        """Image sensor gain in e-/ADU as reported by the camera."""
+        return self._info['readout modes']['RM_1X1']['gain']
+
+    @property
     def ccd_temp(self):
         """
         Current temperature of the camera's image sensor.
@@ -197,7 +202,5 @@ class Camera(AbstractSDKCamera):
                    'Microns')
         header.set('YPIXSZ', self._info['readout modes'][readout_mode]['pixel height'].value,
                    'Microns')
-        header.set('EGAIN', self._info['readout modes'][readout_mode]['gain'].value,
-                   'Electrons/ADU')
 
         return header

--- a/pocs/camera/sdk.py
+++ b/pocs/camera/sdk.py
@@ -139,8 +139,8 @@ class AbstractSDKCamera(AbstractCamera):
     # Methods
 
     def _create_fits_header(self, seconds, dark):
-        header = super()._create__fits_header(seconds, dark)
-        header.set('CAM-SDK', self._Driver.version, 'Camera SDK version')
+        header = super()._create_fits_header(seconds, dark)
+        header.set('CAM-SDK', type(self)._driver.version, 'Camera SDK version')
         return header
 
     def __str__(self):

--- a/pocs/camera/sdk.py
+++ b/pocs/camera/sdk.py
@@ -138,6 +138,11 @@ class AbstractSDKCamera(AbstractCamera):
 
     # Methods
 
+    def _create_fits_header(self, seconds, dark):
+        header = super()._create__fits_header(seconds, dark)
+        header.set('CAM-SDK', self._Driver.version, 'Camera SDK version')
+        return header
+
     def __str__(self):
         # SDK cameras don't have a port so just include the serial number in the string
         # representation.

--- a/pocs/camera/zwo.py
+++ b/pocs/camera/zwo.py
@@ -24,10 +24,25 @@ class Camera(AbstractSDKCamera):
                  gain=None,
                  image_type=None,
                  *args, **kwargs):
-        # ZWO ASI cameras don't have a 'port', they only have a non-deterministic integer
-        # camera_ID and, optionally, an 8 byte ID that can be written to the camera firmware
-        # by the user (using ASICap, or pocs.camera.libasi.ASIDriver.set_ID()). We will use
-        # the latter as a serial number string.
+        """
+        ZWO ASI Camera class
+
+        Args:
+            serial_number (str): camera serial number or user set ID (up to 8 bytes). See notes.
+            gain (int, optional): gain setting, using camera's internal units. If not given
+                the camera will use its current or default setting.
+            image_type (str, optional): image format to use (one of 'RAW8', 'RAW16', 'RGB24'
+                or 'Y8'). Default is to use 'RAW16' if supported by the camera, otherwise
+                the camera's own default will be used.
+            *args, **kwargs: additional arguments to be passed to the parent classes.
+
+        Notes:
+            ZWO ASI cameras don't have a 'port', they only have a non-deterministic integer
+            camera_ID and, probably, an 8 byte serial number. Optionally they also have an
+            8 byte ID that can be written to the camera firmware by the user (using ASICap,
+            or pocs.camera.libasi.ASIDriver.set_ID()). The camera should be identified by
+            its serial number or, if it doesn't have one, by the user set ID.
+        """
         kwargs['readout_time'] = kwargs.get('readout_time', 0.1)
         kwargs['timeout'] = kwargs.get('timeout', 0.5)
 

--- a/pocs/tests/test_camera.py
+++ b/pocs/tests/test_camera.py
@@ -394,7 +394,7 @@ def test_exposure_scaling(camera, tmpdir):
     """
     try:
         bit_depth = camera.bit_depth
-    except AttributeError:
+    except NotImplementedError:
         pytest.skip("Camera does not have bit_depth attribute")
     else:
         fits_path = str(tmpdir.join('test_exposure_scaling.fits'))


### PR DESCRIPTION
Taking advantage of the function added to the ZWO SDK in order to use the camera's real serial number as its UID instead of the user set 'string ID'.

## Description
This PR adds to the methods of the `pocs.camera.libasi.ASIDriver` class so that there are methods corresponding to all functions of the ZWO ASI camera SDK API as of version v1.14.0715. All but one of these methods are implemented. Most of the new methods are of niche interest except `.get_serial_number()`, which calls the new `ASIGetSerialNumber` function.

Now that real camera serial numbers are accessible via the camera driver the `get_cameras()` function has been modified to return these serial numbers instead of the user set string ID as before, if possible. This brings the ZWO ASI cameras in line with the other SDK cameras (SBIG, FLI) in using serial numbers for their UID.

## Related Issue
Addresses #900.

## How Has This Been Tested?
Most of these changes are hardware dependent and cannot be tested without real ZWO cameras. Most of the new methods relate to trigger or guiding functionality that is only supported by a subset of ZWO cameras (which we don't have). I will test what I can next week and update this PR with details of the confirmed functionality.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
Breaking only to the extent that any existing config files for ZWO cameras would need to be changed to specify the camera serial numbers instead of string IDs.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
