### PR TITLE
ZWO camera serial number parsing

### DIFF
--- a/pocs/camera/libasi.py
+++ b/pocs/camera/libasi.py
@@ -405,14 +405,17 @@ class ASIDriver(AbstractSDKDriver):
     def get_serial_number(self, camera_ID):
         """Get serial number of the camera with given integer ID.
 
-        The serial number is an array of 8 unsigned chars, the same as string ID.
+        The serial number is an array of 8 unsigned chars, the same as string ID,
+        but it is interpreted differently. It is displayed in ASICAP as a 16 digit
+        hexadecimal number, so we will convert it the same 16 character string
+        representation.
         """
         struct_SN = ID()  # Same structure as string ID.
         self._call_function('ASIGetSerialNumber',
                             camera_ID,
                             ctypes.byref(struct_SN))
         bytes_SN = bytes(struct_SN.id)
-        serial_number = bytes_SN.decode()
+        serial_number = "".join(f"{b:02x}" for b in bytes_SN)
         self.logger.debug("Got serial number '{}' from camera {}".format(serial_number, camera_ID))
         return serial_number
 


### PR DESCRIPTION
Convert array of 8 unsigned chars returned by `ASIGetSerialNumber()` to the string representation of a 16 digit hexadecimal number.

## Description
<!--- Describe your changes in detail -->
When asked for the camera serial number the ZWO ASI camera driver library returns an array of 8 unsigned char's, the same data structure as used for the user set camera ID ('string ID'). However _unlike_ the camera ID the byte values are not an 8 character ASCII (or UTF-8) string, they are a 64 bit integer in disguise. This PR changes the parsing of the serial number to convert the array of chars to the string representation of the 16 digit hexadecimal number, instead of trying to convert them to a UTF-8 string (which fails due to illegal byte values).

## How Has This Been Tested?
Manually tested with an ASI183MM Pro.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
