### PR TITLE
Fix target temperature in simulator

### DIFF
--- a/pocs/camera/sdk.py
+++ b/pocs/camera/sdk.py
@@ -119,11 +119,11 @@ class AbstractSDKCamera(AbstractCamera):
             self._filter_type = filter_type
 
         if target_temperature is not None:
+            self.target_temperature = target_temperature
             if self.is_cooled_camera:
-                self.target_temperature = target_temperature
                 self.cooling_enabled = True
             else:
-                msg = "Attempt to set target temperature on uncooled camera {}".format(self)
+                msg = "Setting a target temperature on uncooled camera {}".format(self)
                 self.logger.warning(msg)
 
     def __del__(self):

--- a/pocs/camera/simulator_sdk/ccd.py
+++ b/pocs/camera/simulator_sdk/ccd.py
@@ -29,12 +29,12 @@ class Camera(AbstractSDKCamera, Camera):
                  driver=SDKDriver,
                  target_temperature=0 * u.Celsius,
                  *args, **kwargs):
-        kwargs['target_temperature'] = target_temperature
         super().__init__(name, driver, *args, **kwargs)
 
         self._is_cooled_camera = True
         self._cooling_enabled = False
         self._temperature = 25 * u.Celsius
+        self._target_temperature = target_temperature
         self._max_temp = 25 * u.Celsius
         self._min_temp = -15 * u.Celsius
         self._temp_var = 0.2 * u.Celsius

--- a/pocs/camera/simulator_sdk/ccd.py
+++ b/pocs/camera/simulator_sdk/ccd.py
@@ -29,6 +29,7 @@ class Camera(AbstractSDKCamera, Camera):
                  driver=SDKDriver,
                  target_temperature=0 * u.Celsius,
                  *args, **kwargs):
+        kwargs['_target_temperature'] = target_temperature
         super().__init__(name, driver, *args, **kwargs)
 
         self._is_cooled_camera = True

--- a/pocs/camera/simulator_sdk/ccd.py
+++ b/pocs/camera/simulator_sdk/ccd.py
@@ -2,6 +2,7 @@ import math
 import random
 import time
 
+from contextlib import suppress
 import astropy.units as u
 
 from pocs.camera.simulator import Camera
@@ -29,12 +30,12 @@ class Camera(AbstractSDKCamera, Camera):
                  driver=SDKDriver,
                  target_temperature=0 * u.Celsius,
                  *args, **kwargs):
+        kwargs.update({'target_temperature': target_temperature})
         super().__init__(name, driver, *args, **kwargs)
 
         self._is_cooled_camera = True
         self._cooling_enabled = False
         self._temperature = 25 * u.Celsius
-        self._target_temperature = target_temperature
         self._max_temp = 25 * u.Celsius
         self._min_temp = -15 * u.Celsius
         self._temp_var = 0.2 * u.Celsius
@@ -58,7 +59,9 @@ class Camera(AbstractSDKCamera, Camera):
 
     @target_temperature.setter
     def target_temperature(self, target):
-        self._last_temp = self.temperature
+        # Upon init the camera won't have an existing temperature.
+        with suppress(AttributeError):
+            self._last_temp = self.temperature
         self._last_time = time.monotonic()
         if not isinstance(target, u.Quantity):
             target = target * u.Celsius

--- a/pocs/camera/simulator_sdk/ccd.py
+++ b/pocs/camera/simulator_sdk/ccd.py
@@ -29,7 +29,7 @@ class Camera(AbstractSDKCamera, Camera):
                  driver=SDKDriver,
                  target_temperature=0 * u.Celsius,
                  *args, **kwargs):
-        kwargs['_target_temperature'] = target_temperature
+        kwargs['target_temperature'] = target_temperature
         super().__init__(name, driver, *args, **kwargs)
 
         self._is_cooled_camera = True

--- a/pocs/tests/test_camera.py
+++ b/pocs/tests/test_camera.py
@@ -347,7 +347,7 @@ def test_exposure(camera, tmpdir):
     fits_path = str(tmpdir.join('test_exposure.fits'))
     if camera.is_cooled_camera and camera.cooling_enabled is False:
         camera.cooling_enabled = True
-        time.sleep(4)
+        time.sleep(5)  # Give camera time to cool
     assert camera.is_ready
     assert not camera.is_exposing
     # A one second normal exposure.

--- a/pocs/tests/test_camera.py
+++ b/pocs/tests/test_camera.py
@@ -345,6 +345,10 @@ def test_exposure(camera, tmpdir):
     Tests basic take_exposure functionality
     """
     fits_path = str(tmpdir.join('test_exposure.fits'))
+    if camera.is_cooled_camera and camera.cooling_enabled is False:
+        camera.cooling_enabled = True
+        time.sleep(4)
+    assert camera.is_ready
     assert not camera.is_exposing
     # A one second normal exposure.
     exp_event = camera.take_exposure(filename=fits_path)


### PR DESCRIPTION
## Description
The `target_temperature` was not properly being set in the `ccd` simulator.

This will set the `target_temperature` even if `is_cooled_camera=False` but will provide a warning.

On current `develop` running the following will fail because it relies on a previous test and the `module` level scope for the camera object.:

```bash
pytest -xvrs pocs/tests/test_camera.py -k 'test_exposure'
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
