### PR TITLE
Don't require a `config` for the mount creation but load default.

### DIFF
--- a/pocs/mount/__init__.py
+++ b/pocs/mount/__init__.py
@@ -1,6 +1,7 @@
 from glob import glob
 
 from pocs.mount.mount import AbstractMount  # pragma: no flakes
+from pocs.utils.config import load_config
 from pocs.utils import error
 from pocs.utils import load_module
 from pocs.utils.location import create_location_from_config
@@ -40,6 +41,9 @@ def create_mount_from_config(config,
     """
     if logger is None:
         logger = get_root_logger()
+
+    if not config:
+        config = load_config(**kwargs)
 
     # If mount_info was not passed as a paramter, check config.
     if mount_info is None:

--- a/pocs/mount/__init__.py
+++ b/pocs/mount/__init__.py
@@ -8,7 +8,7 @@ from pocs.utils.location import create_location_from_config
 from pocs.utils.logger import get_root_logger
 
 
-def create_mount_from_config(config,
+def create_mount_from_config(config=None,
                              mount_info=None,
                              earth_location=None,
                              logger=None,

--- a/pocs/mount/__init__.py
+++ b/pocs/mount/__init__.py
@@ -78,7 +78,7 @@ def create_mount_from_config(config,
                 raise error.MountNotFound(msg=msg)
         except KeyError:
             # Note: see Issue #866
-            if model == 'bisque':
+            if driver == 'bisque':
                 logger.debug(f'Driver specifies a bisque mount type, no serial port needed.')
             else:
                 msg = 'Mount port not specified in config file. Use simulator=mount for simulator.'

--- a/pocs/scheduler/__init__.py
+++ b/pocs/scheduler/__init__.py
@@ -6,6 +6,7 @@ from pocs.scheduler.constraint import Altitude
 from pocs.scheduler.constraint import Duration
 from pocs.scheduler.constraint import MoonAvoidance
 from pocs.scheduler.scheduler import BaseScheduler  # pragma: no flakes
+from pocs.utils.config import load_config
 from pocs.utils import error
 from pocs.utils import horizon as horizon_utils
 from pocs.utils import load_module
@@ -13,10 +14,13 @@ from pocs.utils.location import create_location_from_config
 from pocs.utils.logger import get_root_logger
 
 
-def create_scheduler_from_config(config, observer=None):
+def create_scheduler_from_config(config=None, observer=None, *args, **kwargs):
     """ Sets up the scheduler that will be used by the observatory """
 
     logger = get_root_logger()
+
+    if not config:
+        config = load_config(**kwargs)
 
     if 'scheduler' not in config:
         logger.info("No scheduler in config")

--- a/pocs/tests/test_mount.py
+++ b/pocs/tests/test_mount.py
@@ -20,6 +20,11 @@ def test_mount_not_in_config(config):
         create_mount_from_config(conf)
 
 
+def test_mount_no_config_param():
+    mount = create_mount_from_config()
+    assert mount
+
+
 def test_bad_mount_port(config):
     conf = config.copy()
     conf['mount']['serial']['port'] = 'foobar'

--- a/pocs/tests/test_mount.py
+++ b/pocs/tests/test_mount.py
@@ -20,9 +20,11 @@ def test_mount_not_in_config(config):
         create_mount_from_config(conf)
 
 
+@pytest.mark.without_mount
 def test_mount_no_config_param():
-    mount = create_mount_from_config()
-    assert mount
+    # Will fail because it's not a simulator and no real mount attached
+    with pytest.raises(MountNotFound):
+        create_mount_from_config()
 
 
 def test_bad_mount_port(config):

--- a/pocs/tests/test_scheduler.py
+++ b/pocs/tests/test_scheduler.py
@@ -13,6 +13,12 @@ def test_bad_scheduler_type(config):
         create_scheduler_from_config(conf, observer=site_details['observer'])
 
 
+def test_mount_no_config_param():
+    # Will fail because it's not a simulator and no real mount attached
+    scheduler = create_scheduler_from_config()
+    assert scheduler
+
+
 def test_bad_scheduler_fields_file(config):
     conf = config.copy()
     conf['scheduler']['fields_file'] = 'foobar'


### PR DESCRIPTION
The `create_mount_from_config` should not require a config to be passed.

