### PR TITLE
Finite readout time for simulated cameras

### DIFF
--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -76,7 +76,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
 
         self._filter_type = kwargs.get('filter_type', 'RGGB')
         self._serial_number = kwargs.get('serial_number', 'XXXXXX')
-        self._readout_time = kwargs.get('readout_time', 5.0)
+        self._readout_time = get_quantity_value(kwargs.get('readout_time', 5.0), unit=u.second)
         self._file_extension = kwargs.get('file_extension', 'fits')
         self._timeout = get_quantity_value(kwargs.get('timeout', 10), unit=u.second)
         # Default is uncooled camera. Should be set to True if appropriate in camera connect()

--- a/pocs/camera/simulator/dslr.py
+++ b/pocs/camera/simulator/dslr.py
@@ -1,5 +1,6 @@
 import os
 import random
+import time
 
 from threading import Timer
 
@@ -17,6 +18,7 @@ class Camera(AbstractCamera):
 
     def __init__(self, name='Simulated Camera', *args, **kwargs):
         kwargs['timeout'] = kwargs.get('timeout', 0.5 * u.second)
+        kwargs['readout_time'] = kwargs.get('readout_time', 1.0 * u.second)
         super().__init__(name, *args, **kwargs)
         self.connect()
         self.logger.info("{} initialised".format(self))
@@ -71,6 +73,7 @@ class Camera(AbstractCamera):
             fake_data = np.random.randint(low=975, high=1026,
                                           size=fake_data.shape,
                                           dtype=fake_data.dtype)
+        time.sleep(self.readout_time)
         fits_utils.write_fits(fake_data, header, filename, self.logger)
 
     def _process_fits(self, file_path, info):

--- a/pocs/tests/test_camera.py
+++ b/pocs/tests/test_camera.py
@@ -202,7 +202,7 @@ def test_sim_file_extension():
 
 def test_sim_readout_time():
     sim_camera = SimCamera()
-    assert sim_camera.readout_time == 5.0
+    assert sim_camera.readout_time == 1.0
     sim_camera = SimCamera(readout_time=2.0)
     assert sim_camera.readout_time == 2.0
 


### PR DESCRIPTION
Make simulated cameras use the `Camera.readout_time` property to simulated a finite readout time.

## Description
Simulated cameras `._readout()` method will wait for the duration of `.readout_time` before writing the FITS file to disc. As before the `readout_time` property can be set with keyword arguments to the constructor, and has now been set to default to 1 second for simulated cameras. This change resolves some issues with test distributed cameras in huntsman-pocs.

## How Has This Been Tested?
Usual unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
