### PR TITLE
Fix SDK Camera simulator initialisation

### DIFF
--- a/pocs/camera/sdk.py
+++ b/pocs/camera/sdk.py
@@ -119,9 +119,11 @@ class AbstractSDKCamera(AbstractCamera):
             self._filter_type = filter_type
 
         if target_temperature is not None:
-            self.target_temperature = target_temperature
             if self.is_cooled_camera:
+                self.target_temperature = target_temperature
                 self.cooling_enabled = True
+                msg = f"Set target temperature {target_temperature} & enabled cooling on {self}."
+                self.logger.debug(msg)
             else:
                 msg = "Setting a target temperature on uncooled camera {}".format(self)
                 self.logger.warning(msg)

--- a/pocs/camera/simulator_sdk/ccd.py
+++ b/pocs/camera/simulator_sdk/ccd.py
@@ -32,7 +32,6 @@ class Camera(AbstractSDKCamera, Camera):
                  *args, **kwargs):
         kwargs.update({'target_temperature': target_temperature})
         super().__init__(name, driver, *args, **kwargs)
-        self.connect()
 
     @property
     def cooling_enabled(self):
@@ -92,3 +91,4 @@ class Camera(AbstractSDKCamera, Camera):
         self._last_temp = 25 * u.Celsius
         self._last_time = time.monotonic()
         self._time_constant = 1.0
+        self._connected = True

--- a/pocs/camera/simulator_sdk/ccd.py
+++ b/pocs/camera/simulator_sdk/ccd.py
@@ -32,16 +32,7 @@ class Camera(AbstractSDKCamera, Camera):
                  *args, **kwargs):
         kwargs.update({'target_temperature': target_temperature})
         super().__init__(name, driver, *args, **kwargs)
-
-        self._is_cooled_camera = True
-        self._cooling_enabled = False
-        self._temperature = 25 * u.Celsius
-        self._max_temp = 25 * u.Celsius
-        self._min_temp = -15 * u.Celsius
-        self._temp_var = 0.2 * u.Celsius
-        self._last_temp = 25 * u.Celsius
-        self._last_time = time.monotonic()
-        self._time_constant = 1.0
+        self.connect()
 
     @property
     def cooling_enabled(self):
@@ -90,3 +81,14 @@ class Camera(AbstractSDKCamera, Camera):
                                  (self._max_temp - self._min_temp))
         else:
             return 0.0
+
+    def connect(self):
+        self._is_cooled_camera = True
+        self._cooling_enabled = False
+        self._temperature = 25 * u.Celsius
+        self._max_temp = 25 * u.Celsius
+        self._min_temp = -15 * u.Celsius
+        self._temp_var = 0.2 * u.Celsius
+        self._last_temp = 25 * u.Celsius
+        self._last_time = time.monotonic()
+        self._time_constant = 1.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Moves class specific initialisation from `.__init__()` to `.connect()`.

## Description
The SDK Camera simulator class `pocs.camera.simulator_sdk.Camera` was setting all its attributes in its `.__init__()` method, unlike the real SDK cameras where several attributes are set in the `.connect()` method instead, based on information received from the camera driver.

The effect of this was to prevent cooling from starting on camera initialisation. The `pocs.camera.sdk.AbstractSDKCamea` base class `.__init__()` calls `.connect()`, then, if a target temperature has been passed to it and the camera has a cooler, it sets the target temperature and enable cooling. Before the changes in this PR the SDK Camera simulator wasn't setting `._is_cooled_camera` to `True` until after the base class `.__init__()` had been called, causing the simulated camera to appear to be an uncooled camera at the point at which cooling would otherwise be enabled.

## How Has This Been Tested?
Usual unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
