### PR TITLE
Allow override of initialisation of Focuser autofocus parameters

### DIFF
--- a/pocs/focuser/focuser.py
+++ b/pocs/focuser/focuser.py
@@ -76,23 +76,15 @@ class AbstractFocuser(PanBase, metaclass=ABCMeta):
         else:
             self._position = int(initial_position)
 
-        if autofocus_range:
-            self.autofocus_range = (int(autofocus_range[0]), int(autofocus_range[1]))
-        else:
-            self.autofocus_range = None
-
-        if autofocus_step:
-            self.autofocus_step = (int(autofocus_step[0]), int(autofocus_step[1]))
-        else:
-            self.autofocus_step = None
-
-        self.autofocus_seconds = autofocus_seconds
-        self.autofocus_size = autofocus_size
-        self.autofocus_keep_files = autofocus_keep_files
-        self.autofocus_take_dark = autofocus_take_dark
-        self.autofocus_merit_function = autofocus_merit_function
-        self.autofocus_merit_function_kwargs = autofocus_merit_function_kwargs
-        self.autofocus_mask_dilations = autofocus_mask_dilations
+        self._set_autofocus_parameters(autofocus_range,
+                                       autofocus_step,
+                                       autofocus_seconds,
+                                       autofocus_size,
+                                       autofocus_keep_files,
+                                       autofocus_take_dark,
+                                       autofocus_merit_function,
+                                       autofocus_merit_function_kwargs,
+                                       autofocus_mask_dilations)
 
         self._camera = camera
 
@@ -542,6 +534,35 @@ class AbstractFocuser(PanBase, metaclass=ABCMeta):
             focus_event.set()
 
         return initial_focus, final_focus
+
+    def _set_autofocus_parameters(self,
+                                  autofocus_range,
+                                  autofocus_step,
+                                  autofocus_seconds,
+                                  autofocus_size,
+                                  autofocus_keep_files,
+                                  autofocus_take_dark,
+                                  autofocus_merit_function,
+                                  autofocus_merit_function_kwargs,
+                                  autofocus_mask_dilations):
+        # Moved to a separate private method to make it possible to override.
+        if autofocus_range:
+            self.autofocus_range = (int(autofocus_range[0]), int(autofocus_range[1]))
+        else:
+            self.autofocus_range = None
+
+        if autofocus_step:
+            self.autofocus_step = (int(autofocus_step[0]), int(autofocus_step[1]))
+        else:
+            self.autofocus_step = None
+
+        self.autofocus_seconds = autofocus_seconds
+        self.autofocus_size = autofocus_size
+        self.autofocus_keep_files = autofocus_keep_files
+        self.autofocus_take_dark = autofocus_take_dark
+        self.autofocus_merit_function = autofocus_merit_function
+        self.autofocus_merit_function_kwargs = autofocus_merit_function_kwargs
+        self.autofocus_mask_dilations = autofocus_mask_dilations
 
     def _add_fits_keywords(self, header):
         header.set('FOC-NAME', self.name, 'Focuser name')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Makes it possible for derived Focuser classes to override the initialisation of the autofocus parameters.

## Description

These changes move the initialisation of the autofocus parameters in the `pocs.focuser.AbstractFocuser`'s `.__init__()` method to a new private method `._set_autofocus_parameters()`, which is called from `.__init__()`.  The purpose of this change is to allow derived classes to override the `._set_autofocus_parameters()` method in order to change how these parameters are initialised.

This is motivated by the client side distributed focuser class in huntsman-pocs. This has a set of properties to allow the autofocus parameters of a remote focuser to be read or changed. The initial values of these come from a remote configuration file, but on connecting to the remote focuser the base class `__init__` overwrites all the values. This PR enables that class to prevent this.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Usual unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
