### PR TITLE
Custom IERS url

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ install:
   - pip install -r requirements.txt
   - pip install -r docs/requirements.txt
   - pip install -e .
-  - python pocs/utils/data.py --folder="$PANDIR/astrometry/data" --iers-url="https://storage.googleapis.com/panoptes-resources/iers/ser7.dat"
+  - python pocs/utils/data.py --folder="$PANDIR/astrometry/data" --iers-url="${IERS_URL}"
 script:
   - export BOARD="arduino:avr:micro"
   - arduino --verify --board $BOARD resources/arduino_files/camera_board/camera_board.ino

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,9 @@ install:
   - pip install -r requirements.txt
   - pip install -r docs/requirements.txt
   - pip install -e .
-  - python pocs/utils/data.py --folder $PANDIR/astrometry/data
+  - python pocs/utils/data.py \
+    --folder $PANDIR/astrometry/data \
+    --iers-url "https://storage.googleapis.com/panoptes-resources/iers/ser7.dat"
 script:
   - export BOARD="arduino:avr:micro"
   - arduino --verify --board $BOARD resources/arduino_files/camera_board/camera_board.ino

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,9 +65,7 @@ install:
   - pip install -r requirements.txt
   - pip install -r docs/requirements.txt
   - pip install -e .
-  - python pocs/utils/data.py \
-    --folder="$PANDIR/astrometry/data" \
-    --iers-url="https://storage.googleapis.com/panoptes-resources/iers/ser7.dat"
+  - python pocs/utils/data.py --folder="$PANDIR/astrometry/data" --iers-url="https://storage.googleapis.com/panoptes-resources/iers/ser7.dat"
 script:
   - export BOARD="arduino:avr:micro"
   - arduino --verify --board $BOARD resources/arduino_files/camera_board/camera_board.ino

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,8 +66,8 @@ install:
   - pip install -r docs/requirements.txt
   - pip install -e .
   - python pocs/utils/data.py \
-    --folder $PANDIR/astrometry/data \
-    --iers-url "https://storage.googleapis.com/panoptes-resources/iers/ser7.dat"
+    --folder="$PANDIR/astrometry/data" \
+    --iers-url="https://storage.googleapis.com/panoptes-resources/iers/ser7.dat"
 script:
   - export BOARD="arduino:avr:micro"
   - arduino --verify --board $BOARD resources/arduino_files/camera_board/camera_board.ino

--- a/pocs/utils/data.py
+++ b/pocs/utils/data.py
@@ -7,6 +7,8 @@ import shutil
 import sys
 import warnings
 
+from pocs.utils import listify
+
 # Importing download_IERS_A can emit a scary warnings, so we suppress it.
 with warnings.catch_warnings():
     warnings.filterwarnings('ignore', message='Your version of the IERS Bulletin A')
@@ -100,6 +102,7 @@ def main():
         '--folder',
         help='Destination folder for astrometry indices. Default: {}'.format(DEFAULT_DATA_FOLDER),
         default=DEFAULT_DATA_FOLDER)
+    parser.add_argument('--iers-url', default=None, help='List of IERS url')
 
     group = parser.add_mutually_exclusive_group()
     group.add_argument(
@@ -134,7 +137,7 @@ def main():
         keep_going=args.keep_going or not args.no_keep_going,
         narrow_field=args.narrow_field,
         wide_field=args.wide_field or not args.no_wide_field)
-    return dl.download_all_files()
+    return dl.download_all_files(iers_urls=listify(args.iers_url))
 
 
 if __name__ == '__main__':

--- a/pocs/utils/data.py
+++ b/pocs/utils/data.py
@@ -42,11 +42,11 @@ class Downloader:
         self.narrow_field = narrow_field
         self.keep_going = keep_going
 
-    def download_all_files(self):
+    def download_all_files(self, iers_urls=None):
         """Downloads the files according to the attributes of this object."""
         result = True
         try:
-            download_IERS_A()
+            download_IERS_A(urls=iers_urls)
         except Exception as e:
             if not self.keep_going:
                 raise e

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-astroplan
+-e git+git://github.com/wtgee/astroplan@add-iers-conf#egg=astroplan
 astropy
 dateparser
 Flask

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements.in
 #
-astroplan==0.5
+-e git+git://github.com/wtgee/astroplan@add-iers-conf#egg=astroplan
 astropy==3.2.2
 atomicwrites==1.3.0       # via pytest
 attrs==19.2.0             # via jsonschema, pytest
@@ -86,7 +86,7 @@ pysocks==1.7.1            # via tweepy
 pytest==5.2.1
 python-dateutil==2.8.0
 python-magic==0.4.15      # via mocket
-pytz==2019.3              # via astroplan, dateparser, google-api-core, pandas, panoptes-utils, tzlocal
+pytz==2019.3              # via dateparser, google-api-core, pandas, panoptes-utils, tzlocal
 pywavelets==1.0.3         # via scikit-image
 pyyaml==5.1.2
 pyzmq==17.1.3


### PR DESCRIPTION
To deal with IERS url, allow a custom url to be passed through at most levels.

## Description
This PR passes a custom IERS url through to `download_IERS_A`, which has been added in my fork of astroplan ([here](https://github.com/wtgee/astroplan/commit/ca8aadd2cdbc830f56cc3815a6ff55afecd6e628)).  The idea is to circumvent the astropy config by passing a mirror url.

## Related Issue
https://github.com/wtgee/astroplan/tree/add-iers-conf

