### PR TITLE
Bug Fix - Start Docker Containers

### DIFF
--- a/bin/pocs
+++ b/bin/pocs
@@ -25,6 +25,12 @@ usage() {
 
     # Run the software tests (no hardware)
     $POCS/scripts/pocs-docker.sh up
+    
+    #Start specific docker containers in the back ground with
+    $POCS/scripts/pocs-docker.sh up --no-deps -d <container name> 
+    
+    #Manually stop docker containers in the with
+    docker stop <container name> 
 "
 }
 
@@ -34,16 +40,24 @@ if [ "${START}" = 'help' ] || [ "${START}" = '-h' ] || [ "${START}" = '--help' ]
 	exit 1
 fi
 
-if [ "$(docker ps -q -f name="pocs-shell")" ] || [ "$(docker ps -q -f name="peas-shell")" ] || [ "$(docker ps -q -f name="messaging-hub")" ] || [ "$(docker ps -q -f name="config-server")" ] || [ "$(docker ps -q -f name="aag-weather-reader")" ] || [ "$(docker ps -q -f name="aag-weather-server")" ]; then
-	echo "At least one PANOPTES docker container is already running! Manually stop docker containers with docker stop <container name> if needed."
-	echo "If an single docker container needs to be started do so with bin/pocs up --no-deps <container name>."
-        exit 1
-fi
-
+PARAMS="$@"   
+    
 cd "$PANDIR"
-docker-compose \
-   --project-directory "${PANDIR}" \
-        -f panoptes-utils/docker/docker-compose.yaml \
-        -f PAWS/docker/docker-compose.yaml \
-        -f POCS/docker/docker-compose.yaml \
-                -p panoptes "$@"
+CMD="docker-compose \
+    --project-directory ${PANDIR} \
+    -f panoptes-utils/docker/docker-compose.yaml \
+    -f PAWS/docker/docker-compose.yaml \
+    -f POCS/docker/docker-compose.yaml \
+    -p panoptes"
+    
+# If user only asked to start, check if already running and if so use "-d" option.
+if [[ "$PARAMS" == "up" ]]; then
+    if [[ ! -z $(eval "${CMD} ps -q") ]]; then
+        echo "Some containers already running, using -d to only start non-running containers."
+	echo "For more info on managing docker containers manually, run bin/pocs."
+        PARAMS="up -d"    
+    fi    
+fi    
+    
+# Run the docker-compose command with user params.
+eval "${CMD} ${PARAMS}"

--- a/bin/pocs
+++ b/bin/pocs
@@ -34,31 +34,15 @@ if [ "${START}" = 'help' ] || [ "${START}" = '-h' ] || [ "${START}" = '--help' ]
 	exit 1
 fi
 
-#Array storing container names
-docker_names=("pocs-shell" "peas-shell" "messaging-hub" "config-server" "aag-weather-reader" "aag-weather-server")
+if [ "$(docker ps -q -f name="pocs-shell")" ] || [ "$(docker ps -q -f name="peas-shell")" ] || [ "$(docker ps -q -f name="messaging-hub")" ] || [ "$(docker ps -q -f name="config-server")" ] || [ "$(docker ps -q -f name="aag-weather-reader")" ] || [ "$(docker ps -q -f name="aag-weather-server")" ]; then
+	echo "At least one PANOPTES docker container is already running! Manually kill docker containers with docker kill <container name> if needed."
+        exit 1
+fi
 
-let counter=6
-#While loop that checks to see if any docker containers are running
-while [ "${counter}" > 0 ]
-do
-        element=$(($counter - 1))
-        DOCKER_NAME=${docker_names[$element]}
-	#If running
-        if [ "$(docker ps -q -f name=${DOCKER_NAME})" ]; then
-                echo "At least one docker container is already running! Manually kill docker containers with docker kill <container name> if needed."
-                exit 1
-	#if not running
-        else
-	#I placed this in an else statement instead of keeping it outside the while loop since I was running into an 
-	#error where the while loop exits the bash script and stops the containers from stopping.
-                cd /var/panoptes
-                docker-compose \
-                   --project-directory "${PANDIR}" \
-                        -f panoptes-utils/docker/docker-compose.yaml \
-                        -f PAWS/docker/docker-compose.yaml \
-                        -f POCS/docker/docker-compose.yaml \
-                        -p panoptes "$@"
-                exit
-        fi
-        let counter=$counter-1
-done
+cd "$PANDIR"
+docker-compose \
+   --project-directory "${PANDIR}" \
+        -f panoptes-utils/docker/docker-compose.yaml \
+        -f PAWS/docker/docker-compose.yaml \
+        -f POCS/docker/docker-compose.yaml \
+                -p panoptes "$@"

--- a/bin/pocs
+++ b/bin/pocs
@@ -52,7 +52,7 @@ CMD="docker-compose \
     
 # If user only asked to start, check if already running and if so use "-d" option.
 if [[ "$PARAMS" == "up" ]]; then
-    if [[ ! -z $(eval "${CMD} ps -q") ]]; then
+    if [[ ! -z $(eval "${CMD} top") ]]; then
         echo "Some containers already running, using -d to only start non-running containers."
 	 echo "For more info on managing docker containers manually, run bin/pocs --help".
         PARAMS="up -d"    

--- a/bin/pocs
+++ b/bin/pocs
@@ -34,6 +34,17 @@ if [ "${START}" = 'help' ] || [ "${START}" = '-h' ] || [ "${START}" = '--help' ]
 	exit 1
 fi
 
+#Patch could be improved by using for loops to test for all docker containers
+#in case the user manually kills pocs-shell. Also the if statement should be true
+#if the string doesn't have characters
+
+#exit script before trying to start containers if containers are running
+docker_ps=$(docker ps -q -f name=pocs-shell)
+if [ "$docker_ps" = "87d6fde2a139" ]; then 
+	echo "Docker containers are already running! Manually kill docker containers with docker kill <container name> if needed."
+	exit 1
+fi
+
 cd "$PANDIR"
 docker-compose \
     --project-directory "${PANDIR}" \

--- a/bin/pocs
+++ b/bin/pocs
@@ -35,7 +35,8 @@ if [ "${START}" = 'help' ] || [ "${START}" = '-h' ] || [ "${START}" = '--help' ]
 fi
 
 if [ "$(docker ps -q -f name="pocs-shell")" ] || [ "$(docker ps -q -f name="peas-shell")" ] || [ "$(docker ps -q -f name="messaging-hub")" ] || [ "$(docker ps -q -f name="config-server")" ] || [ "$(docker ps -q -f name="aag-weather-reader")" ] || [ "$(docker ps -q -f name="aag-weather-server")" ]; then
-	echo "At least one PANOPTES docker container is already running! Manually kill docker containers with docker kill <container name> if needed."
+	echo "At least one PANOPTES docker container is already running! Manually stop docker containers with docker stop <container name> if needed."
+	echo "If an single docker container needs to be started do so with bin/pocs up --no-deps <container name>."
         exit 1
 fi
 

--- a/bin/pocs
+++ b/bin/pocs
@@ -54,7 +54,7 @@ CMD="docker-compose \
 if [[ "$PARAMS" == "up" ]]; then
     if [[ ! -z $(eval "${CMD} ps -q") ]]; then
         echo "Some containers already running, using -d to only start non-running containers."
-	echo "For more info on managing docker containers manually, run bin/pocs."
+	 echo "For more info on managing docker containers manually, run bin/pocs --help".
         PARAMS="up -d"    
     fi    
 fi    

--- a/bin/pocs
+++ b/bin/pocs
@@ -15,19 +15,19 @@ usage() {
  Examples:
 
 	# Start all services in the foreground.
-	$POCS/scripts/pocs-docker.sh up
+	$POCS/bin/pocs up
 
  	# Start config-server and messaging-hub serivces in the background.
-	$POCS/scripts/pocs-docker.sh up --no-deps -d config-server messaging-hub
+	$POCS/bin/pocs up --no-deps -d config-server messaging-hub
 
  	# Read the logs from the config-server
-	$POCS/scripts/pocs-docker.sh logs config-server
+	$POCS/bin/pocs logs config-server
 
     # Run the software tests (no hardware)
-    $POCS/scripts/pocs-docker.sh up
+    $POCS/bin/pocs up
     
-    #Start specific docker containers in the back ground with
-    $POCS/scripts/pocs-docker.sh up --no-deps -d <container name> 
+    #Start specific docker containers in the background with
+    $POCS/bin/pocs up --no-deps -d <container name> 
     
     #Manually stop docker containers in the with
     docker stop <container name> 

--- a/bin/pocs
+++ b/bin/pocs
@@ -34,22 +34,31 @@ if [ "${START}" = 'help' ] || [ "${START}" = '-h' ] || [ "${START}" = '--help' ]
 	exit 1
 fi
 
-#Patch could be improved by using for loops to test for all docker containers
-#in case the user manually kills pocs-shell. Also the if statement should be true
-#if the string doesn't have characters
+#Array storing container names
+docker_names=("pocs-shell" "peas-shell" "messaging-hub" "config-server" "aag-weather-reader" "aag-weather-server")
 
-#exit script before trying to start containers if containers are running
-docker_ps=$(docker ps -q -f name=pocs-shell)
-if [ "$docker_ps" = "87d6fde2a139" ]; then 
-	echo "Docker containers are already running! Manually kill docker containers with docker kill <container name> if needed."
-	exit 1
-fi
-
-cd "$PANDIR"
-docker-compose \
-    --project-directory "${PANDIR}" \
-	-f panoptes-utils/docker/docker-compose.yaml \
-	-f PAWS/docker/docker-compose.yaml \
-	-f POCS/docker/docker-compose.yaml \
-	-p panoptes "$@"
-
+let counter=6
+#While loop that checks to see if any docker containers are running
+while [ "${counter}" > 0 ]
+do
+        element=$(($counter - 1))
+        DOCKER_NAME=${docker_names[$element]}
+	#If running
+        if [ "$(docker ps -q -f name=${DOCKER_NAME})" ]; then
+                echo "At least one docker container is already running! Manually kill docker containers with docker kill <container name> if needed."
+                exit 1
+	#if not running
+        else
+	#I placed this in an else statement instead of keeping it outside the while loop since I was running into an 
+	#error where the while loop exits the bash script and stops the containers from stopping.
+                cd /var/panoptes
+                docker-compose \
+                   --project-directory "${PANDIR}" \
+                        -f panoptes-utils/docker/docker-compose.yaml \
+                        -f PAWS/docker/docker-compose.yaml \
+                        -f POCS/docker/docker-compose.yaml \
+                        -p panoptes "$@"
+                exit
+        fi
+        let counter=$counter-1
+done


### PR DESCRIPTION
$POCS/bin/pocs tries to start docker containers when they are already running. Added an if statement that exits the code if docker containers are already running.  

## Description
Compares the docker ps command output with the pocs-shell container ID to see if the pocs-shell container is running. If it finds that the container is running it exits the script before attempting to start the docker containers and outputs an error with information on how to manually kill docker containers in case a single docker container failed.

## Related Issue
[926](https://github.com/panoptes/POCS/issues/926)

## How Has This Been Tested?
Killed all docker containers, then ran ```bin/pocs up -d``` from the ```$POCS``` directory to make sure containers still start, and then ran ```bin/pocs up -d``` again which behaved as expected and in the way described in the description section.
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
