### PR TITLE
Fixing power entry

### DIFF
--- a/peas/sensors.py
+++ b/peas/sensors.py
@@ -143,7 +143,7 @@ class ArduinoSerialMonitor(object):
                     self.db.insert_current(sensor_name, data)
 
                     # Make a separate power entry
-                    if 'power' in sensor_data:
+                    if 'power' in data:
                         self.db.insert_current('power', data['power'])
 
             except Exception as e:


### PR DESCRIPTION
Fixes the power entry for reading during PEAS shell.

## Description
Was reading the wrong data dictionary so new `power` entries were not being updated.

## How Has This Been Tested?
Discovered via testing on PAN010.

