### PR TITLE
State Machine - State Tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,9 @@ install:
   - pip install -r requirements.txt
   - pip install -r docs/requirements.txt
   - pip install -e .
+  # Force creation of config file.
+  - python -c "import astroplan"
+  # Custom IERS urls in config file.
   - |
     echo "\
 
@@ -72,6 +75,7 @@ install:
     iers_auto_url = https://storage.googleapis.com/panoptes-resources/iers/ser7.dat
     iers_auto_url_mirror = https://storage.googleapis.com/panoptes-resources/iers/ser7.dat
     " >> $HOME/.astropy/config/astropy.cfg
+  # Download IERS and astroetry.net files.
   - python pocs/utils/data.py --folder $PANDIR/astrometry/data
 script:
   - export BOARD="arduino:avr:micro"

--- a/pocs/state/machine.py
+++ b/pocs/state/machine.py
@@ -232,7 +232,7 @@ class PanStateMachine(Machine):
             bool:   Latest safety flag
         """
 
-        self.logger.debug(f"Checking safety for {event_data!r}")
+        self.logger.debug(f"Checking safety for {event_data.transition}")
 
         if event_data is None:
             return self.is_safe()

--- a/pocs/state/machine.py
+++ b/pocs/state/machine.py
@@ -43,7 +43,7 @@ class PanStateMachine(Machine):
 
         # Add the tag
         states = [
-            self._load_state(state, state_info)
+            self._load_state(state, state_info=state_info)
             for state, state_info
             in state_machine_table.get('states', dict()).items()
         ]
@@ -378,7 +378,7 @@ class PanStateMachine(Machine):
         except Exception as e:
             self.logger.warning("Can't generate state graph: {}".format(e))
 
-    def _load_state(self, state, state_info):
+    def _load_state(self, state, state_info=None):
         self.logger.debug("Loading state: {}".format(state))
         s = None
         try:

--- a/pocs/state/machine.py
+++ b/pocs/state/machine.py
@@ -1,7 +1,7 @@
 import os
 import yaml
 
-from transitions import State
+from transitions.extensions.states import Tags as MachineState
 
 from pocs.utils import error
 from pocs.utils import listify
@@ -41,7 +41,12 @@ class PanStateMachine(Machine):
         _transitions = [self._load_transition(transition)
                         for transition in state_machine_table['transitions']]
 
-        states = [self._load_state(state) for state in state_machine_table.get('states', [])]
+        # Add the tag
+        states = [
+            self._load_state(state, state_info)
+            for state, state_info
+            in state_machine_table.get('states', dict()).items()
+        ]
 
         super(PanStateMachine, self).__init__(
             states=states,
@@ -227,13 +232,20 @@ class PanStateMachine(Machine):
             bool:   Latest safety flag
         """
 
-        self.logger.debug("Checking safety for {}".format(event_data.event.name))
+        self.logger.debug(f"Checking safety for {event_data!r}")
+
+        if event_data is None:
+            return self.is_safe()
+
+        dest_state_name = event_data.transition.dest
+        dest_state = self.get_state(dest_state_name)
 
         # It's always safe to be in some states
-        if event_data and event_data.event.name in [
-                'park', 'set_park', 'clean_up', 'goto_sleep', 'get_ready']:
-            self.logger.debug("Always safe to move to {}".format(event_data.event.name))
+        if dest_state.is_always_safe:
+            self.logger.debug(f"Always safe to move to {dest_state_name}")
             is_safe = True
+        elif dest_state.is_at_twilight:
+            is_safe = self.is_safe(horizon='flat')
         else:
             is_safe = self.is_safe()
 
@@ -366,7 +378,7 @@ class PanStateMachine(Machine):
         except Exception as e:
             self.logger.warning("Can't generate state graph: {}".format(e))
 
-    def _load_state(self, state):
+    def _load_state(self, state, state_info):
         self.logger.debug("Loading state: {}".format(state))
         s = None
         try:
@@ -385,8 +397,10 @@ class PanStateMachine(Machine):
                 "Added `on_enter` method from {} {}".format(
                     state_module, on_enter_method))
 
-            self.logger.debug("Created state")
-            s = State(name=state)
+            if state_info is None:
+                state_info = dict()
+            self.logger.debug(f"Creating state={state} with {state_info}")
+            s = MachineState(name=state, **state_info)
 
             s.add_callback('enter', '_update_status')
 

--- a/pocs/tests/test_state_machine.py
+++ b/pocs/tests/test_state_machine.py
@@ -4,28 +4,14 @@ import yaml
 
 from pocs.core import POCS
 from pocs.observatory import Observatory
-from pocs.camera import create_cameras_from_config
-from pocs.mount import create_mount_from_config
-from pocs.scheduler import create_scheduler_from_config
-from pocs.utils.location import create_location_from_config
 
 from pocs.utils import error
 
 
 @pytest.fixture
-def observatory(config_with_simulated_mount, images_dir):
+def observatory():
     """Return a valid Observatory instance with a specific config."""
-    config = config_with_simulated_mount
-    site_details = create_location_from_config(config)
-    scheduler = create_scheduler_from_config(config, observer=site_details['observer'])
-    mount = create_mount_from_config(config)
-    obs = Observatory(config=config,
-                      scheduler=scheduler,
-                      mount=mount,
-                      ignore_local_config=True)
-    cameras = create_cameras_from_config(config)
-    for cam_name, cam in cameras.items():
-        obs.add_camera(cam_name, cam)
+    obs = Observatory()
 
     return obs
 
@@ -46,8 +32,6 @@ def test_load_state_info(observatory):
     pocs = POCS(observatory)
 
     pocs._load_state('ready', state_info={'tags': ['at_twilight']})
-    pocs.next_state = 'ready'
-    pocs.goto_next_state()
 
 
 def test_state_machine_absolute(temp_file):

--- a/resources/state_table/simple_state_table.yaml
+++ b/resources/state_table/simple_state_table.yaml
@@ -2,17 +2,23 @@
 name: default
 initial: sleeping
 states:
-    - parked
-    - sleeping
-    - housekeeping
-    - ready
-    - scheduling
-    - slewing
-    - pointing
-    - tracking
-    - observing
-    - analyzing
-    - parking
+    parking:
+        tags: always_safe
+    parked:
+        tags: always_safe
+    sleeping:
+        tags: always_safe
+    housekeeping:
+        tags: always_safe
+    ready:
+        tags: always_safe
+    scheduling:
+        tags: always_safe
+    slewing:
+    pointing:
+    tracking:
+    observing:
+    analyzing:
 transitions:
     -
         source:
@@ -90,7 +96,7 @@ transitions:
     -
         source: observing
         dest: observing
-        trigger: observe        
+        trigger: observe
         conditions: mount_is_tracking
     -
         source: analyzing


### PR DESCRIPTION
* Add tags to the states
* Use the `always_safe` tag during the `check_safety` transition rather than using the transition name.
* Support the `horizon='flat'` attribute for the `at_twilight` tag, e.g. for a `calibrating` state.

## Description
This adds the ability to support `pytransitions` "tags" feature for states and then lets us use those tags for logic controller. Here we change the `check_safety` method so that it looks for an `always_safe` tag on the state name rather than relying on hard-coding the transition name. Also will call the `is_safe` with a `horizon='flat'` for `at_twilight` tags, with PANOPTES currently doesn't need but Huntsman will.

## Related Issue
https://github.com/AstroHuntsman/huntsman-pocs/issues/124

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
