### PR TITLE
horizon=flat

### DIFF
--- a/pocs/core.py
+++ b/pocs/core.py
@@ -587,13 +587,13 @@ class POCS(PanStateMachine, PanBase):
             # Sleep for a little bit.
             time.sleep(sleep_delay)
 
-    def wait_until_safe(self):
+    def wait_until_safe(self, **kwargs):
         """ Waits until weather is safe.
 
         This will wait until a True value is returned from the safety check,
         blocking until then.
         """
-        while not self.is_safe(no_warning=True):
+        while not self.is_safe(no_warning=True, **kwargs):
             self.sleep(delay=self._safe_delay)
 
 ##################################################################################################

--- a/pocs/state/machine.py
+++ b/pocs/state/machine.py
@@ -129,8 +129,8 @@ class PanStateMachine(Machine):
 
                 # If sleeping, wait until safe (or interrupt)
                 if self.state == 'sleeping':
-                    if self.is_safe() is not True:
-                        self.wait_until_safe()
+                    if self.is_safe(horizon='flat') is not True:
+                        self.wait_until_safe(horizon='flat')
 
                 try:
                     state_changed = self.goto_next_state()

--- a/pocs/utils/theskyx.py
+++ b/pocs/utils/theskyx.py
@@ -50,12 +50,14 @@ class TheSkyX(object):
 
     def read(self, timeout=5):
         try:
-            self.socket.settimeout(timeout)
+            #self.socket.settimeout(timeout)
             response = None
             err = None
 
             try:
-                response = self.socket.recv(2048).decode()
+                #response = self.socket.recv(2048).decode()
+                msg, ancdata, flags, addr = self.socket.recvmsg(1024)
+                response = msg.decode()
                 if '|' in response:
                     response, err = response.split('|')
 
@@ -67,7 +69,8 @@ class TheSkyX(object):
                         raise error.TheSkyXKeyError("Invalid TheSkyX key")
 
                     raise error.TheSkyXError(err)
-            except socket.timeout:  # pragma: no cover
+            except socket.timeout as e:  # pragma: no cover
+                self.logger.warning(f'Error on read: {e!r}')
                 raise error.TheSkyXTimeout()
 
             return response

--- a/pocs/utils/theskyx.py
+++ b/pocs/utils/theskyx.py
@@ -50,14 +50,12 @@ class TheSkyX(object):
 
     def read(self, timeout=5):
         try:
-            #self.socket.settimeout(timeout)
+            self.socket.settimeout(timeout)
             response = None
             err = None
 
             try:
-                #response = self.socket.recv(2048).decode()
-                msg, ancdata, flags, addr = self.socket.recvmsg(1024)
-                response = msg.decode()
+                response = self.socket.recv(2048).decode()
                 if '|' in response:
                     response, err = response.split('|')
 
@@ -69,8 +67,7 @@ class TheSkyX(object):
                         raise error.TheSkyXKeyError("Invalid TheSkyX key")
 
                     raise error.TheSkyXError(err)
-            except socket.timeout as e:  # pragma: no cover
-                self.logger.warning(f'Error on read: {e!r}')
+            except socket.timeout:  # pragma: no cover
                 raise error.TheSkyXTimeout()
 
             return response


### PR DESCRIPTION
-Allow kwargs to be passed to wait_until_safe so we can pass the horizon argument

-Passed horizon='flat' to wait_until_safe and is_safe in machine.run. I am not sure about this, as maybe the horizon used should depend on the next state?