### PR TITLE
Config file updates and better user warnings in the pocs-shell

### DIFF
--- a/conf_files/pocs.yaml
+++ b/conf_files/pocs.yaml
@@ -91,14 +91,14 @@ observations:
 # By default all images are stored on googlecloud servers and we also
 # use a few google services to store metadata, communicate with servers, etc.
 #
-# See $POCS/pocs/utils/google/README.md for details about authentication.
+# See $PANDIR/panoptes/utils/google/README.md for details about authentication.
 #
 # Options to change:
 #   image_storage: If images should be uploaded to Google Cloud Storage.
 #   service_account_key: Location of the JSON service account key.
 ################################################################################
 panoptes_network:
-    image_storage: True
+    image_storage: False
     service_account_key: # Location of JSON account key
     project_id: panoptes-survey
     buckets:

--- a/conf_files/pocs.yaml
+++ b/conf_files/pocs.yaml
@@ -15,13 +15,13 @@ pan_id: PAN000
 
 location:
     name: Mauna Loa Observatory
-    latitude: 19.54 deg
-    longitude: -155.58 deg
-    elevation: 3400.0 m
-    horizon: 30 deg # targets must be above this to be considered valid.
-    flat_horizon: -6 deg # Flats when sun between this and focus horizon.
-    focus_horizon: -12 deg # Dark enough to focus on stars.
-    observe_horizon: -18 deg # Sun below this limit to observe.
+    latitude: 19.54 deg # Degrees
+    longitude: -155.58 deg # Degrees
+    elevation: 3400.0 m # Meters
+    horizon: 30 deg # Degrees; targets must be above this to be considered valid.
+    flat_horizon: -6 deg # Degrees - Flats when sun between this and focus horizon.
+    focus_horizon: -12 deg # Degrees - Dark enough to focus on stars.
+    observe_horizon: -18 deg # Degrees - Sun below this limit to observe.
     timezone: US/Hawaii
     gmt_offset: -600 # Offset in minutes from GMT during.
                      # standard time (not daylight saving).
@@ -91,14 +91,14 @@ observations:
 # By default all images are stored on googlecloud servers and we also
 # use a few google services to store metadata, communicate with servers, etc.
 #
-# See $PANDIR/panoptes/utils/google/README.md for details about authentication.
+# See $POCS/pocs/utils/google/README.md for details about authentication.
 #
 # Options to change:
 #   image_storage: If images should be uploaded to Google Cloud Storage.
 #   service_account_key: Location of the JSON service account key.
 ################################################################################
 panoptes_network:
-    image_storage: False
+    image_storage: True
     service_account_key: # Location of JSON account key
     project_id: panoptes-survey
     buckets:
@@ -115,19 +115,16 @@ panoptes_network:
 #         webhook_url: [your_webhook_url]
 #         output_timestamp: False
 
+
 ######################### Environmental Sensors ################################
 # Configure the environmental sensors that are attached.
-# 
+#
 # Use `auto_detect: True` for most options. Or use a manual configuration:
 #
 #   camera_board:
 #       serial_port: /dev/ttyACM0
 #   control_board:
 #       serial_port: /dev/ttyACM1
-#
-# With the aag-weather repo cloned to the $PANDIR directory, a url can be 
-# specified to allow the PEAS shell to use AAG CloudWatcher data.
-#
 ################################################################################
 environment:
     auto_detect: False
@@ -136,16 +133,14 @@ environment:
     control_board:
         serial_port: /dev/ttyACM1
     weather:
-        url: http://127.0.0.1:5000/latest.json
-        
+     url: http://127.0.0.1:5000/latest.json
+
 ######################### Weather Station ######################################
 # Weather station options.
 #
 # Configure the serial_port as necessary.
 #
 # Default thresholds should be okay for most locations.
-# If using the AAG repository, be sure to configure the weather station according
-# to the README.MD file in the aag-weather-repository.
 ################################################################################
 weather:
     aag_cloud:

--- a/conf_files/pocs.yaml
+++ b/conf_files/pocs.yaml
@@ -18,7 +18,7 @@ location:
     latitude: 19.54 deg # Degrees
     longitude: -155.58 deg # Degrees
     elevation: 3400.0 m # Meters
-    horizon: 30 deg # Degrees; targets must be above this to be considered valid.
+    horizon: 30 deg # Degrees - targets must be above this to be considered valid.
     flat_horizon: -6 deg # Degrees - Flats when sun between this and focus horizon.
     focus_horizon: -12 deg # Degrees - Dark enough to focus on stars.
     observe_horizon: -18 deg # Degrees - Sun below this limit to observe.

--- a/conf_files/pocs.yaml
+++ b/conf_files/pocs.yaml
@@ -117,13 +117,17 @@ panoptes_network:
 
 ######################### Environmental Sensors ################################
 # Configure the environmental sensors that are attached.
-#
+# 
 # Use `auto_detect: True` for most options. Or use a manual configuration:
 #
 #   camera_board:
 #       serial_port: /dev/ttyACM0
 #   control_board:
 #       serial_port: /dev/ttyACM1
+#
+# With the aag-weather repo cloned to the $PANDIR directory, a url can be 
+# specified to allow the PEAS shell to use AAG CloudWatcher data.
+#
 ################################################################################
 environment:
     auto_detect: False
@@ -131,13 +135,17 @@ environment:
         serial_port: /dev/ttyACM0
     control_board:
         serial_port: /dev/ttyACM1
-
+    weather:
+        url: http://127.0.0.1:5000/latest.json
+        
 ######################### Weather Station ######################################
 # Weather station options.
 #
 # Configure the serial_port as necessary.
 #
 # Default thresholds should be okay for most locations.
+# If using the AAG repository, be sure to configure the weather station according
+# to the README.MD file in the aag-weather-repository.
 ################################################################################
 weather:
     aag_cloud:

--- a/scripts/pocs-shell.py
+++ b/scripts/pocs-shell.py
@@ -191,7 +191,7 @@ Hardware names: {}   (or all for all hardware)'''.format(
         Does NOT park the mount, nor execute power_down.
         """
         if self.pocs.observatory.mount.is_parked is False:
-            print("ATTENTION: The mount is not in the parked position and reset_pocs will not move the mount to park position!")
+            print_warning("ATTENTION: The mount is not in the parked position and reset_pocs will not move the mount to park position!")
             response = input("The unit could be damaged if it is not parked before sunrise. Execute reset_pocs anyway?[y/n]")
             if response == "y" or response == "yes":
                 self.pocs = None

--- a/scripts/pocs-shell.py
+++ b/scripts/pocs-shell.py
@@ -196,7 +196,7 @@ Hardware names: {}   (or all for all hardware)'''.format(
             if response.lower().startswith('y'):
                 self.pocs = None
                 print_info("POCS instance discarded. Remember to park the mount later.")
-            elif response == "n" or response == "no":
+            elif response.lower().startswith('n'):
                 print("Keeping POCS instance.")
             else:
                 print("A 'yes' or 'no' response is required")

--- a/scripts/pocs-shell.py
+++ b/scripts/pocs-shell.py
@@ -190,17 +190,24 @@ Hardware names: {}   (or all for all hardware)'''.format(
 
         Does NOT park the mount, nor execute power_down.
         """
-        if self.pocs.observatory.mount.is_parked is False:
+        if self.pocs is None:
+            print_info("POCS does not have an instance. Create one using 'setup_pocs'.")
+            return
+        elif self.pocs.observatory.mount.is_parked is True:
+            self.pocs = None
+        elif self.pocs.observatory.mount.is_parked is False:
             print_warning("ATTENTION: The mount is not in the parked position and reset_pocs will not move the mount to park position!")
-            response = input("The unit could be damaged if it is not parked before sunrise. Execute reset_pocs anyway?[y/n]")
-            if response.lower().startswith('y'):
-                self.pocs = None
-                print_info("POCS instance discarded. Remember to park the mount later.")
-            elif response.lower().startswith('n'):
-                print("Keeping POCS instance.")
-            else:
-                print("A 'yes' or 'no' response is required")
-                self.do_reset_pocs()
+            while True:
+                response = input("The unit could be damaged if it is not parked before sunrise. Execute reset_pocs anyway[y/n]?")
+                if response.lower().startswith('y'):
+                    self.pocs = None
+                    print_info("POCS instance discarded. Remember to park the mount later.")
+                    break
+                elif response.lower().startswith('n'):
+                    print_info("Keeping POCS instance.")
+                    break
+                else:
+                    print("A 'yes' or 'no' response is required")
 
     def do_run_pocs(self, *arg):
         """Make POCS `run` the state machine.

--- a/scripts/pocs-shell.py
+++ b/scripts/pocs-shell.py
@@ -193,7 +193,7 @@ Hardware names: {}   (or all for all hardware)'''.format(
         if self.pocs.observatory.mount.is_parked is False:
             print_warning("ATTENTION: The mount is not in the parked position and reset_pocs will not move the mount to park position!")
             response = input("The unit could be damaged if it is not parked before sunrise. Execute reset_pocs anyway?[y/n]")
-            if response == "y" or response == "yes":
+            if response.lower().startswith('y'):
                 self.pocs = None
                 print("POCS instance discarded. Remember to park the mount later.")
             elif response == "n" or response == "no":

--- a/scripts/pocs-shell.py
+++ b/scripts/pocs-shell.py
@@ -193,9 +193,7 @@ Hardware names: {}   (or all for all hardware)'''.format(
         if self.pocs is None:
             print_info("POCS does not have an instance. Create one using 'setup_pocs'.")
             return
-        elif self.pocs.observatory.mount.is_parked is True:
-            self.pocs = None
-        elif self.pocs.observatory.mount.is_parked is False:
+        elif self.pocs.observatory.mount and not self.pocs.observatory.mount.is_parked:
             print_warning("ATTENTION: The mount is not in the parked position and reset_pocs will not move the mount to park position!")
             while True:
                 response = input("The unit could be damaged if it is not parked before sunrise. Execute reset_pocs anyway[y/n]?")
@@ -208,6 +206,7 @@ Hardware names: {}   (or all for all hardware)'''.format(
                     break
                 else:
                     print("A 'yes' or 'no' response is required")
+        self.pocs = None
 
     def do_run_pocs(self, *arg):
         """Make POCS `run` the state machine.

--- a/scripts/pocs-shell.py
+++ b/scripts/pocs-shell.py
@@ -190,7 +190,17 @@ Hardware names: {}   (or all for all hardware)'''.format(
 
         Does NOT park the mount, nor execute power_down.
         """
-        self.pocs = None
+        if self.pocs.observatory.mount.is_parked is False:
+            print("ATTENTION: The mount is not in the parked position and reset_pocs will not move the mount to park position!")
+            response = input("The unit could be damaged if it is not parked before sunrise. Execute reset_pocs anyway?[y/n]")
+            if response == "y" or response == "yes":
+                self.pocs = None
+                print("POCS instance discarded. Remember to park the mount later.")
+            elif response == "n" or response == "no":
+                print("Keeping POCS instance.")
+            else:
+                print("A 'yes' or 'no' response is required")
+                self.do_reset_pocs()
 
     def do_run_pocs(self, *arg):
         """Make POCS `run` the state machine.

--- a/scripts/pocs-shell.py
+++ b/scripts/pocs-shell.py
@@ -195,7 +195,7 @@ Hardware names: {}   (or all for all hardware)'''.format(
             response = input("The unit could be damaged if it is not parked before sunrise. Execute reset_pocs anyway?[y/n]")
             if response.lower().startswith('y'):
                 self.pocs = None
-                print("POCS instance discarded. Remember to park the mount later.")
+                print_info("POCS instance discarded. Remember to park the mount later.")
             elif response == "n" or response == "no":
                 print("Keeping POCS instance.")
             else:


### PR DESCRIPTION
## Description
Added endpoint URL for AGG weather reader in pocs.yaml.

Added if statements and an input prompt to pocs-shell.py so that users don't discard a POCS instance with `reset_pocs` while the mount is in the home position without knowing they have to manually park it after discarding the instance.

## Related Issue
[933](https://github.com/panoptes/POCS/issues/933)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Config file changes that added the AAG weather sensor endpoint URL are working on PAN015. 

The `pocs-shell` changes in `reset_pocs` have been tested on PAN015. When parked, `reset_pocs` behavior does not changed. When not parked, the user is warned about leaving the unit in the home position and is prompted if they would like to run `reset_pocs` with a yes/no response.  If input is not a yes/no response the `reset_pocs` method is called again and the users is prompted with the same question. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
