### PR TITLE
ensure exptime Quantity doesn't impact the Huntsamn-pocs pyro client serialiser

### DIFF
--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -700,7 +700,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         }
         metadata.update(headers)
 
-        exptime = kwargs.pop('exptime', observation.exptime.value)
+        exptime = kwargs.get('exptime', observation.exptime.value)
         # The exptime header data is set as part of observation but can
         # be override by passed parameter so update here.
         metadata['exptime'] = exptime

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -300,6 +300,8 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
                                                                          filename,
                                                                          **kwargs)
 
+        # pop exptime from kwarg as its now in exptime
+        exptime = kwargs.pop('exptime', observation.exptime.value)
         exposure_event = self.take_exposure(seconds=exptime, filename=file_path, **kwargs)
 
         # Add most recent exposure to list

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -700,7 +700,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         }
         metadata.update(headers)
 
-        exptime = kwargs.get('exptime', observation.exptime.value)
+        exptime = kwargs.pop('exptime', observation.exptime.value)
         # The exptime header data is set as part of observation but can
         # be override by passed parameter so update here.
         metadata['exptime'] = exptime


### PR DESCRIPTION
A tiny fix to bug found from Huntsman-POCS and pyro 

## Description
Details are given here, including a fix discussion with @AnthonyHorton : 
https://github.com/AstroHuntsman/huntsman-pocs/issues/105#issuecomment-565915906
This PR prompted another solution as this one didn't work. See below.

## Related Issue
https://github.com/AstroHuntsman/huntsman-pocs/issues/105

## How Has This Been Tested?
On live control computer.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
