### PR TITLE
Add filter selection to observations

### DIFF
--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -353,7 +353,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
 
         assert filename is not None, self.logger.error("Must pass filename for take_exposure")
 
-        # Check that the filterwheel is not moving
+        # Check that the camera (and subcomponents) is ready
         if not self.is_ready:
             msg = f"Attempt to start exposure on {self} while not ready, ignoring!"
             raise error.PanError(msg)

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -659,7 +659,8 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
 
             else:
                 self.logger.info(f'Filter {observation.filter_name} requested by'
-                    ' observation but {self} has no filterwheel, using {self.filter_type}.')
+                                 ' observation but {self} has no filterwheel, using'
+                                 ' {self.filter_type}.')
 
         start_time = headers.get('start_time', current_time(flatten=True))
 

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -354,14 +354,6 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         assert filename is not None, self.logger.error("Must pass filename for take_exposure")
 
         # Check that the filterwheel is not moving
-        """
-        if self.filterwheel is not None:
-            if self.filterwheel.is_moving:
-                msg = f'Attempt to prepare observation on {self} while' \
-                        ' filterwheel is moving, ignoring.'
-                self.logger.error(msg)
-                raise error.PanError(msg)
-        """
         if not self.is_ready:
             msg = f"Attempt to start exposure on {self} while not ready, ignoring!"
             raise error.PanError(msg)

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -715,7 +715,11 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         if (self.filterwheel is not None) and (observation.filter_name is not None):
 
             # Move filterwheel if necessary
-            self.filterwheel.move_to(observation.filter_name, blocking=True)
+            try:
+                self.filterwheel.move_to(observation.filter_name, blocking=True)
+            except Exception as e:
+                self.logger.error(f'Error moving filterwheel to {observation.filter_name}: {e}')
+                raise(e)
 
             # Store the filter name in metadata
             metadata['filter_name'] = observation.filter_name

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -645,14 +645,21 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
             headers = {}
 
         # Move the filterwheel if necessary
-        if (self.filterwheel is not None) and (observation.filter_name is not None):
+        if self.filterwheel is not None:
 
-            try:
-                self.filterwheel.move_to(observation.filter_name, blocking=True)
-            except Exception as e:
-                self.logger.error(f'Error moving filterwheel on {self} to'
-                                  f' {observation.filter_name}: {e}')
-                raise(e)
+            if observation.filter_name is not None:
+
+                try:
+                    # Move the filterwheel
+                    self.filterwheel.move_to(observation.filter_name, blocking=True)
+                except Exception as e:
+                    self.logger.error(f'Error moving filterwheel on {self} to'
+                                      f' {observation.filter_name}: {e}')
+                    raise(e)
+
+            else:
+                self.logger.info(f'Filter {observation.filter_name} requested by'
+                    ' observation but {self} has no filterwheel, using {self.filter_type}.')
 
         start_time = headers.get('start_time', current_time(flatten=True))
 
@@ -719,7 +726,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
             'exptime': exptime
         }
         if observation.filter_name is not None:
-            metadata['filter_name'] = observation.filter_name
+            metadata['filter_request'] = observation.filter_name
         metadata.update(headers)
 
         return exptime, file_path, image_id, metadata

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -705,6 +705,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         # be override by passed parameter so update here.
         metadata['exptime'] = exptime
 
+        # Prepare the filterwheel
         if self.filterwheel is not None:
 
             # Check that the filterwheel is ready

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -705,7 +705,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         # be override by passed parameter so update here.
         metadata['exptime'] = exptime
 
-        if (self.filterwheel is not None):
+        if self.filterwheel is not None:
 
             # Check that the filterwheel is ready
             if self.filterwheel.is_moving:

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -712,7 +712,6 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         # be override by passed parameter so update here.
         metadata['exptime'] = exptime
 
-
         if (self.filterwheel is not None) and (observation.filter_name is not None):
 
             # Move filterwheel if necessary

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -303,7 +303,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         # pop exptime from kwarg as its now in exptime
         exptime = kwargs.pop('exptime', observation.exptime.value)
         
-        # Now move the filerwheel into position
+        # Move the filerwheel into position
         if (self.filterwheel is not None) & (observation.filter_name is not None):
             self.filterwheel.move_to(observation.filter_name)
         

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -305,8 +305,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         exptime = kwargs.pop('exptime', observation.exptime.value)
 
         # start the exposure
-        exposure_event = self.take_exposure(seconds=exptime, filename=file_path,
-                                            **kwargs)
+        exposure_event = self.take_exposure(seconds=exptime, filename=file_path, **kwargs)
 
         # Add most recent exposure to list
         if self.is_primary:

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -304,7 +304,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         exptime = kwargs.pop('exptime', observation.exptime.value)
 
         # Move the filerwheel into position
-        if (self.filterwheel is not None) & (observation.filter_name is not None):
+        if (self.filterwheel is not None) and (observation.filter_name is not None):
             self.filterwheel.move_to(observation.filter_name)
 
         exposure_event = self.take_exposure(seconds=exptime, filename=file_path,

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -303,8 +303,11 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         # pop exptime from kwarg as its now in exptime
         exptime = kwargs.pop('exptime', observation.exptime.value)
         
+        # Now move the filerwheel into position
+        if (self.filterwheel is not None) & (observation.filter_name is not None):
+            self.filterwheel.move_to(observation.filter_name)
+        
         exposure_event = self.take_exposure(seconds=exptime, filename=file_path,
-                                            filter_name=observation.filter_name,
                                             **kwargs)
 
         # Add most recent exposure to list
@@ -329,7 +332,6 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
                       filename=None,
                       dark=False,
                       blocking=False,
-                      filter_name=None,
                       *args,
                       **kwargs):
         """Take an exposure for given number of seconds and saves to provided filename.
@@ -354,9 +356,15 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
 
         assert filename is not None, self.logger.error("Must pass filename for take_exposure")
 
+        # Check that the filterwheel is ready
+        if self.filterwheel and self.filterwheel.is_moving:
+            msg = "Attempt to start exposure on {} while filterwheel is moving, ignoring.".format(
+                self)
+            raise error.PanError(msg)
+            
         if not isinstance(seconds, u.Quantity):
             seconds = seconds * u.second
-
+            
         self.logger.debug('Taking {} exposure on {}: {}'.format(seconds, self.name, filename))
 
         header = self._create_fits_header(seconds, dark)
@@ -367,17 +375,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
 
         # Clear event now to prevent any other exposures starting before this one is finished.
         self._exposure_event.clear()
-           
-        # Check that the filterwheel is ready
-        if self.filterwheel and self.filterwheel.is_moving:
-            msg = "Attempt to start exposure on {} while filterwheel is moving, ignoring.".format(
-                self)
-            raise error.PanError(msg)
-            
-        # Now move the filerwheel into position
-        if (self.filterwheel is not None) & (filter_name is not None):
-            self.filterwheel.move_to(filter_name)
-            
+                                   
         try:
             # Camera type specific exposure set up and start
             readout_args = self._start_exposure(seconds, filename, dark, header, *args, *kwargs)

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -726,8 +726,8 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
                                       f' {observation.filter_name}: {e}')
                     raise(e)
 
-            # Store the filter name in metadata
-            metadata['filter_name'] = observation.filter_name
+                # Store the filter name in metadata
+                metadata['filter_name'] = observation.filter_name
 
         return exptime, file_path, image_id, metadata
 

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -302,11 +302,11 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
 
         # pop exptime from kwarg as its now in exptime
         exptime = kwargs.pop('exptime', observation.exptime.value)
-        
+
         # Move the filerwheel into position
         if (self.filterwheel is not None) & (observation.filter_name is not None):
             self.filterwheel.move_to(observation.filter_name)
-        
+
         exposure_event = self.take_exposure(seconds=exptime, filename=file_path,
                                             **kwargs)
 
@@ -361,10 +361,10 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
             msg = "Attempt to start exposure on {} while filterwheel is moving, ignoring.".format(
                 self)
             raise error.PanError(msg)
-            
+
         if not isinstance(seconds, u.Quantity):
             seconds = seconds * u.second
-            
+
         self.logger.debug('Taking {} exposure on {}: {}'.format(seconds, self.name, filename))
 
         header = self._create_fits_header(seconds, dark)
@@ -375,7 +375,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
 
         # Clear event now to prevent any other exposures starting before this one is finished.
         self._exposure_event.clear()
-                                   
+
         try:
             # Camera type specific exposure set up and start
             readout_args = self._start_exposure(seconds, filename, dark, header, *args, *kwargs)

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -295,6 +295,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         # To be used for marking when exposure is complete (see `process_exposure`)
         observation_event = threading.Event()
 
+        # Setup the observation
         exptime, file_path, image_id, metadata = self._setup_observation(observation,
                                                                          headers,
                                                                          filename,
@@ -303,10 +304,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         # pop exptime from kwarg as its now in exptime
         exptime = kwargs.pop('exptime', observation.exptime.value)
 
-        # Move the filerwheel into position
-        if (self.filterwheel is not None) and (observation.filter_name is not None):
-            self.filterwheel.move_to(observation.filter_name)
-
+        # start the exposure
         exposure_event = self.take_exposure(seconds=exptime, filename=file_path,
                                             **kwargs)
 
@@ -713,6 +711,15 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         # The exptime header data is set as part of observation but can
         # be override by passed parameter so update here.
         metadata['exptime'] = exptime
+
+
+        if (self.filterwheel is not None) and (observation.filter_name is not None):
+
+            # Move filterwheel if necessary
+            self.filterwheel.move_to(observation.filter_name, blocking=True)
+
+            # Store the filter name in metadata
+            metadata['filter_name'] = observation.filter_name
 
         return exptime, file_path, image_id, metadata
 

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -708,7 +708,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         # Prepare the filterwheel
         if self.filterwheel is not None:
 
-            # Check that the filterwheel is ready
+            # Check that the filterwheel is not moving
             if self.filterwheel.is_moving:
 
                 msg = f'Attempt to prepare observation on {self} while' \

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -650,7 +650,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
             try:
                 self.filterwheel.move_to(observation.filter_name, blocking=True)
             except Exception as e:
-                self.logger.error(f'Error moving filterwheel on {self} to' \
+                self.logger.error(f'Error moving filterwheel on {self} to'
                                   f' {observation.filter_name}: {e}')
                 raise(e)
 
@@ -716,7 +716,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
             'is_primary': self.is_primary,
             'sequence_id': sequence_id,
             'start_time': start_time,
-            'exptime':exptime
+            'exptime': exptime
         }
         if observation.filter_name is not None:
             metadata['filter_name'] = observation.filter_name

--- a/pocs/scheduler/observation.py
+++ b/pocs/scheduler/observation.py
@@ -10,7 +10,7 @@ class Observation(PanBase):
 
     @u.quantity_input(exptime=u.second)
     def __init__(self, field, exptime=120 * u.second, min_nexp=60,
-                 exp_set_size=10, priority=100, **kwargs):
+                 exp_set_size=10, priority=100, filter_name=None, **kwargs):
         """ An observation of a given `~pocs.scheduler.field.Field`.
 
         An observation consists of a minimum number of exposures (`min_nexp`) that
@@ -38,6 +38,8 @@ class Observation(PanBase):
                 (default: {10})
             priority {int} -- Overall priority for field, with 1.0 being highest
                 (default: {100})
+            filter_name {str} -- Name of the filter to be used. If specified,
+            will override the default filter name (default: {None}).
 
         """
         PanBase.__init__(self)
@@ -63,6 +65,8 @@ class Observation(PanBase):
         self.pointing_images = OrderedDict()
 
         self.priority = float(priority)
+        
+        self.filter_name = filter_name
 
         self._min_duration = self.exptime * self.min_nexp
         self._set_duration = self.exptime * self.exp_set_size

--- a/pocs/scheduler/observation.py
+++ b/pocs/scheduler/observation.py
@@ -77,7 +77,7 @@ class Observation(PanBase):
         self.merit = 0.0
 
         self.reset()
-
+        
         self.logger.debug("Observation created: {}".format(self))
 
 

--- a/pocs/scheduler/observation.py
+++ b/pocs/scheduler/observation.py
@@ -39,7 +39,7 @@ class Observation(PanBase):
             priority {int} -- Overall priority for field, with 1.0 being highest
                 (default: {100})
             filter_name {str} -- Name of the filter to be used. If specified,
-            will override the default filter name (default: {None}).
+                will override the default filter name (default: {None}).
 
         """
         PanBase.__init__(self)

--- a/pocs/scheduler/observation.py
+++ b/pocs/scheduler/observation.py
@@ -65,7 +65,7 @@ class Observation(PanBase):
         self.pointing_images = OrderedDict()
 
         self.priority = float(priority)
-        
+
         self.filter_name = filter_name
 
         self._min_duration = self.exptime * self.min_nexp
@@ -77,7 +77,7 @@ class Observation(PanBase):
         self.merit = 0.0
 
         self.reset()
-        
+
         self.logger.debug("Observation created: {}".format(self))
 
 

--- a/pocs/tests/test_camera.py
+++ b/pocs/tests/test_camera.py
@@ -496,7 +496,7 @@ def test_observation(camera, images_dir):
     Tests functionality of take_observation()
     """
     field = Field('Test Observation', '20h00m43.7135s +22d42m39.0645s')
-    observation = Observation(field, exptime=1.5*u.second, filter_name='deux')
+    observation = Observation(field, exptime=1.5 * u.second, filter_name='deux')
     observation.seq_time = '19991231T235959'
     camera.take_observation(observation, headers={})
     time.sleep(7)

--- a/pocs/tests/test_camera.py
+++ b/pocs/tests/test_camera.py
@@ -496,9 +496,9 @@ def test_observation(camera, images_dir):
     Tests functionality of take_observation()
     """
     field = Field('Test Observation', '20h00m43.7135s +22d42m39.0645s')
-    observation = Observation(field, exptime=1.5 * u.second)
+    observation = Observation(field, exptime=1.5*u.second, filter_name='deux')
     observation.seq_time = '19991231T235959'
-    camera.take_observation(observation, headers={}, filter_name='deux')
+    camera.take_observation(observation, headers={})
     time.sleep(7)
     observation_pattern = os.path.join(images_dir, 'fields', 'TestObservation',
                                        camera.uid, observation.seq_time, '*.fits*')

--- a/pocs/tests/test_camera.py
+++ b/pocs/tests/test_camera.py
@@ -467,6 +467,14 @@ def test_exposure_moving(camera, tmpdir):
     assert not os.path.exists(fits_path_2)
 
 
+def test_move_filterwheel(camera, images_dir):
+    field = Field('Test Observation', '20h00m43.7135s +22d42m39.0645s')
+    observation = Observation(field, exptime=1.5*u.second, filter_name='deux')
+    observation.seq_time = '19991231T235959'
+    camera.take_observation(observation, headers={})
+    time.sleep(7)
+
+
 def test_exposure_timeout(camera, tmpdir, caplog):
     """
     Tests response to an exposure timeout

--- a/pocs/tests/test_camera.py
+++ b/pocs/tests/test_camera.py
@@ -507,6 +507,22 @@ def test_observation(camera, images_dir):
         os.remove(_)
 
 
+def test_observation_nofilter(camera, images_dir):
+    """
+    Tests functionality of take_observation()
+    """
+    field = Field('Test Observation', '20h00m43.7135s +22d42m39.0645s')
+    observation = Observation(field, exptime=1.5 * u.second, filter_name=None)
+    observation.seq_time = '19991231T235959'
+    camera.take_observation(observation, headers={})
+    time.sleep(7)
+    observation_pattern = os.path.join(images_dir, 'fields', 'TestObservation',
+                                       camera.uid, observation.seq_time, '*.fits*')
+    assert len(glob.glob(observation_pattern)) == 1
+    for _ in glob.glob(observation_pattern):
+        os.remove(_)
+
+
 def test_autofocus_coarse(camera, patterns, counter):
     if not camera.focuser:
         pytest.skip("Camera does not have a focuser")

--- a/pocs/tests/test_camera.py
+++ b/pocs/tests/test_camera.py
@@ -467,14 +467,6 @@ def test_exposure_moving(camera, tmpdir):
     assert not os.path.exists(fits_path_2)
 
 
-def test_move_filterwheel(camera, images_dir):
-    field = Field('Test Observation', '20h00m43.7135s +22d42m39.0645s')
-    observation = Observation(field, exptime=1.5*u.second, filter_name='deux')
-    observation.seq_time = '19991231T235959'
-    camera.take_observation(observation, headers={})
-    time.sleep(7)
-
-
 def test_exposure_timeout(camera, tmpdir, caplog):
     """
     Tests response to an exposure timeout
@@ -506,11 +498,13 @@ def test_observation(camera, images_dir):
     field = Field('Test Observation', '20h00m43.7135s +22d42m39.0645s')
     observation = Observation(field, exptime=1.5 * u.second)
     observation.seq_time = '19991231T235959'
-    camera.take_observation(observation, headers={})
+    camera.take_observation(observation, headers={}, filter_name='deux')
     time.sleep(7)
     observation_pattern = os.path.join(images_dir, 'fields', 'TestObservation',
                                        camera.uid, observation.seq_time, '*.fits*')
     assert len(glob.glob(observation_pattern)) == 1
+    for _ in glob.glob(observation_pattern):
+        os.remove(_)
 
 
 def test_autofocus_coarse(camera, patterns, counter):


### PR DESCRIPTION
## Description
Add's an optional argument to `pocs.scheduler.observation.Observation` called `filter_name` that can be used to specify the filter for that observation, provided a filter wheel is found. Added a call to `filterwheel.move_to` in `AbstractCamera.take_observation` to facilitate this.

## Related Issue
#941 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
