### PR TITLE
Add UTC timezone to current_time if datetime=True

### DIFF
--- a/pocs/utils/__init__.py
+++ b/pocs/utils/__init__.py
@@ -4,6 +4,7 @@ import shutil
 import signal
 import time
 
+from pytz import utc
 from astropy import units as u
 from astropy.coordinates import AltAz
 from astropy.coordinates import ICRS
@@ -77,8 +78,7 @@ def current_time(flatten=False, datetime=False, pretty=False):
         _time = _time.isot.split('.')[0].replace('T', ' ')
 
     if datetime:
-        # Add UTC timezone
-        _time = _time.to_datetime()
+        _time = _time.to_datetime(timezone=utc)
 
     return _time
 


### PR DESCRIPTION
The conversion to a `datetime.datetime` object from an `astropy.Time` object in `current_time` was missing a timezone. This means that calling `datetime.astimezone(utc)` on the returned `datetime` object leads to an incorrect time.

## How Has This Been Tested?
Tested out the changes in the python console.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
