### PR TITLE
Increase default temperature_tolerance for ZWO cameras

### DIFF
--- a/pocs/camera/zwo.py
+++ b/pocs/camera/zwo.py
@@ -50,6 +50,9 @@ class Camera(AbstractSDKCamera):
 
         super().__init__(name, ASIDriver, *args, **kwargs)
 
+        # Increase default temperature_tolerance for ZWO cameras
+        self.temperature_tolerance = kwargs.get('temperature_tolerance', 0.6 * u.Celsius)
+
         if gain:
             self.gain = gain
 

--- a/pocs/camera/zwo.py
+++ b/pocs/camera/zwo.py
@@ -50,7 +50,8 @@ class Camera(AbstractSDKCamera):
 
         super().__init__(name, ASIDriver, *args, **kwargs)
 
-        # Increase default temperature_tolerance for ZWO cameras
+        # Increase default temperature_tolerance for ZWO cameras because the
+        # default value is too low for their temperature resolution.
         self.temperature_tolerance = kwargs.get('temperature_tolerance', 0.6 * u.Celsius)
 
         if gain:


### PR DESCRIPTION
## Description
The temperature resolution for ZWO cameras is 0.5 deg, meaning that the current default of  `temperature_tolerance=0.5` can cause `camera.is_temperature_stable` to undesirably return `False`. Increasing the default to `temperature_tolerance=0.6` for the ZWO cameras solves this problem.

## How Has This Been Tested?
Tested running POCS on actual hardware with default value overridden.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
