### PR TITLE
Fix skyx timeout

### DIFF
--- a/pocs/mount/bisque.py
+++ b/pocs/mount/bisque.py
@@ -157,7 +157,7 @@ class Mount(AbstractMount):
 # Movement methods
 ##########################################################################
 
-    def slew_to_target(self):
+    def slew_to_target(self, timeout=60):
         """ Slews to the current _target_coordinates
 
         Args:
@@ -182,7 +182,7 @@ class Mount(AbstractMount):
                 response = self.query('slew_to_coordinates', {
                     'ra': mount_coords[0],
                     'dec': mount_coords[1],
-                })
+                }, timeout=timeout)
                 success = response['success']
                 if success:
                     self.status()
@@ -203,7 +203,7 @@ class Mount(AbstractMount):
 
         return success
 
-    def slew_to_home(self, blocking=False):
+    def slew_to_home(self, blocking=False, timeout=60):
         """ Slews the mount to the home position.
 
         Note:
@@ -220,7 +220,7 @@ class Mount(AbstractMount):
 
         if not self.is_parked:
             self._target_coordinates = None
-            response = self.query('goto_home')
+            response = self.query('goto_home', timeout=timeout)
         else:
             self.logger.info('Mount is parked')
 
@@ -230,7 +230,7 @@ class Mount(AbstractMount):
         """ Calls `slew_to_home` in base class. Can be overridden.  """
         self.slew_to_home(blocking=blocking)
 
-    def park(self):
+    def park(self, timeout=60):
         """ Slews to the park position and parks the mount.
 
         Note:
@@ -240,7 +240,7 @@ class Mount(AbstractMount):
             bool: indicating success
         """
         self.logger.debug('Parking mount')
-        response = self.query('park')
+        response = self.query('park', timeout=timeout)
 
         self._is_parked = response['success']
 
@@ -281,7 +281,8 @@ class Mount(AbstractMount):
 
         try:
             self.logger.debug("Moving {} for {} arcmins. ".format(direction, arcmin))
-            self.query(move_command, params={'direction': direction.upper()[0], 'arcmin': arcmin})
+            self.query(move_command, params={'direction': direction.upper()[0], 'arcmin': arcmin},
+                       timeout=seconds + 10)
         except KeyboardInterrupt:
             self.logger.warning("Keyboard interrupt, stopping movement.")
         except Exception as e:
@@ -301,14 +302,14 @@ class Mount(AbstractMount):
         return self.theskyx.write(value)
 
     def read(self, timeout=5):
+
         response_obj = {'success': False}
-        while True:
-            response = self.theskyx.read()
-            if response is not None or timeout == 0:
-                break
-            else:
-                time.sleep(1)
-                timeout -= 1
+
+        try:
+            response = self.theskyx.read(timeout=timeout)
+        except Exception as err:
+            self.logger.error(err)
+            response = None
 
         if response is None:
             return response_obj
@@ -318,17 +319,9 @@ class Mount(AbstractMount):
         except TypeError as e:
             self.logger.warning("Error: {}".format(e, response))
         except json.JSONDecodeError as e:
-            # self.logger.warning("Can't decode JSON response from mount")
-            # self.logger.warning(e)
-            # self.logger.warning(response)
-            response_obj = {
-                "response": response,
-                "success": False,
-                "error": e,
-            }
+            response_obj = {"response": response, "success": False, "error": e}
 
         return response_obj
-
 
 ##########################################################################
 # Private Methods

--- a/pocs/mount/bisque.py
+++ b/pocs/mount/bisque.py
@@ -157,7 +157,7 @@ class Mount(AbstractMount):
 # Movement methods
 ##########################################################################
 
-    def slew_to_target(self, timeout=60):
+    def slew_to_target(self, timeout=120):
         """ Slews to the current _target_coordinates
 
         Args:
@@ -203,7 +203,7 @@ class Mount(AbstractMount):
 
         return success
 
-    def slew_to_home(self, blocking=False, timeout=60):
+    def slew_to_home(self, blocking=False, timeout=120):
         """ Slews the mount to the home position.
 
         Note:
@@ -230,7 +230,7 @@ class Mount(AbstractMount):
         """ Calls `slew_to_home` in base class. Can be overridden.  """
         self.slew_to_home(blocking=blocking)
 
-    def park(self, timeout=60):
+    def park(self, timeout=120):
         """ Slews to the park position and parks the mount.
 
         Note:

--- a/pocs/mount/bisque.py
+++ b/pocs/mount/bisque.py
@@ -305,12 +305,7 @@ class Mount(AbstractMount):
 
         response_obj = {'success': False}
 
-        try:
-            response = self.theskyx.read(timeout=timeout)
-        except Exception as err:
-            self.logger.error(err)
-            response = None
-
+        response = self.theskyx.read(timeout=timeout)
         if response is None:
             return response_obj
 

--- a/pocs/mount/mount.py
+++ b/pocs/mount/mount.py
@@ -698,7 +698,7 @@ class AbstractMount(PanBase):
 
         return (offset / (self.sidereal_rate * guide_rate)).to(u.ms)
 
-    def query(self, cmd, params=None):
+    def query(self, cmd, params=None, **kwargs):
         """Sends a query to the mount and returns response.
 
         Performs a send and then returns response. Will do a translate on cmd first. This should
@@ -727,7 +727,7 @@ class AbstractMount(PanBase):
         full_command = self._get_command(cmd, params=params)
         self.write(full_command)
 
-        response = self.read()
+        response = self.read(**kwargs)
 
         # expected_response = self._get_expected_response(cmd)
         # if str(response) != str(expected_response):

--- a/pocs/utils/__init__.py
+++ b/pocs/utils/__init__.py
@@ -4,6 +4,7 @@ import shutil
 import signal
 import time
 
+from pytz import utc
 from astropy import units as u
 from astropy.coordinates import AltAz
 from astropy.coordinates import ICRS
@@ -77,8 +78,7 @@ def current_time(flatten=False, datetime=False, pretty=False):
         _time = _time.isot.split('.')[0].replace('T', ' ')
 
     if datetime:
-        # Add UTC timezone
-        _time = _time.to_datetime()
+        _time = _time.to_datetime(timezone=utc)
 
     return _time
 

--- a/pocs/utils/__init__.py
+++ b/pocs/utils/__init__.py
@@ -4,7 +4,6 @@ import shutil
 import signal
 import time
 
-from pytz import utc
 from astropy import units as u
 from astropy.coordinates import AltAz
 from astropy.coordinates import ICRS
@@ -78,7 +77,8 @@ def current_time(flatten=False, datetime=False, pretty=False):
         _time = _time.isot.split('.')[0].replace('T', ' ')
 
     if datetime:
-        _time = _time.to_datetime(timezone=utc)
+        # Add UTC timezone
+        _time = _time.to_datetime()
 
     return _time
 


### PR DESCRIPTION
## Description
This PR removes the redundant timeout functionality in `pocs.mount.bisque.read` to instead rely on the equivalent funtionality in `pocs.utils.theskyx.read`. It also adds functionality to pass the `timeout` key word argument to `pocs.utils.theskyx.read` via `pocs.mount.mount.query`, and increases the default timeout for movements in `pocs.mount.bisque`.

This fixes TheSkyXTimeout errors encountered after running:
```
from pocs.mount import create_mount_from_config 
from huntsman.utils import load_config 
config = load_config()  
mount = create_mount_from_config(config)   
mount.initialize() 
mount.unpark()
mount.home_and_park() 
```

I think the problem is twofold:
a) in `pocs.mount.bisque.read` there is a timeout countdown. This calls `theskyx.read` at each time step, without catching any errors. It incorrectly expects `theskyx.read` to return None if there is no response, but instead it implicitly raises a TheSkyXTimeout error , causing the timeout functionality in `pocs.mount.bisque.read` to be ignored.
b) The default timeout in `pocs.mount.bisque.read` is 5s, which is too short for typical slewings.

## How Has This Been Tested?
Tested on hardware (Huntsman telscope).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
