### PR TITLE
Horizon ranges

### DIFF
--- a/pocs/core.py
+++ b/pocs/core.py
@@ -291,6 +291,8 @@ class POCS(PanStateMachine, PanBase):
                 defaults to False.
             horizon (str, optional): For night time check use given horizon,
                 default 'observe'.
+            horizon_bright (str, optional): Horizon spcifying minimum brightness,
+                default None.
         Returns:
             bool: Latest safety flag
 

--- a/pocs/core.py
+++ b/pocs/core.py
@@ -276,7 +276,8 @@ class POCS(PanStateMachine, PanBase):
 # Safety Methods
 ##################################################################################################
 
-    def is_safe(self, no_warning=False, horizon='observe', **kwargs):
+    def is_safe(self, no_warning=False, horizon='observe', horizon_bright=None,
+                **kwargs):
         """Checks the safety flag of the system to determine if safe.
 
         This will check the weather station as well as various other environmental
@@ -308,6 +309,10 @@ class POCS(PanStateMachine, PanBase):
 
         # Check if night time
         is_safe_values['is_dark'] = self.is_dark(horizon=horizon)
+
+        # Check if its bright enough (e.g. for twilight flats)
+        if horizon_bright is not None:
+            is_safe_values['is_bright'] = not self.is_dark(horizon=horizon_bright)
 
         # Check weather
         is_safe_values['good_weather'] = self.is_weather_safe()

--- a/pocs/utils/__init__.py
+++ b/pocs/utils/__init__.py
@@ -4,6 +4,7 @@ import shutil
 import signal
 import time
 
+from pytz import utc
 from astropy import units as u
 from astropy.coordinates import AltAz
 from astropy.coordinates import ICRS
@@ -77,8 +78,7 @@ def current_time(flatten=False, datetime=False, pretty=False):
         _time = _time.isot.split('.')[0].replace('T', ' ')
 
     if datetime:
-        # Add UTC timezone
-        _time = _time.to_datetime()
+        _time = _time.to_datetime(timezone=utc)
 
     return _time
 

--- a/pocs/utils/__init__.py
+++ b/pocs/utils/__init__.py
@@ -77,6 +77,7 @@ def current_time(flatten=False, datetime=False, pretty=False):
         _time = _time.isot.split('.')[0].replace('T', ' ')
 
     if datetime:
+        # Add UTC timezone
         _time = _time.to_datetime()
 
     return _time

--- a/pocs/utils/__init__.py
+++ b/pocs/utils/__init__.py
@@ -4,7 +4,6 @@ import shutil
 import signal
 import time
 
-from pytz import utc
 from astropy import units as u
 from astropy.coordinates import AltAz
 from astropy.coordinates import ICRS
@@ -78,7 +77,7 @@ def current_time(flatten=False, datetime=False, pretty=False):
         _time = _time.isot.split('.')[0].replace('T', ' ')
 
     if datetime:
-        _time = _time.to_datetime(timezone=utc)
+        _time = _time.to_datetime()
 
     return _time
 


### PR DESCRIPTION
Add support for a state to specify a "bright horizon", meaning that `pocs.is_safe()=True` only when the Sun is between `horizon` and `horizon_bright`. Useful for e.g. taking twilight flat fields before it gets too dark.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
