### PR TITLE
More detailed logging & exception message for camera readiness

### DIFF
--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -394,7 +394,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
                 problems.append("exposure in progress")
 
             problems_string = ", ".join(problems)
-            msg = f"Attempt to start exposure on {self} while not ready: {problem_string}."
+            msg = f"Attempt to start exposure on {self} while not ready: {problems_string}."
             raise error.PanError(msg)
 
         if not isinstance(seconds, u.Quantity):

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -263,7 +263,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         # Check all the subcomponents too, e.g. make sure filterwheel/focuser aren't moving.
         for sub_name in self._subcomponent_names:
             if getattr(self, sub_name):
-                current_readiness['sub_name'] = getattr(self.subname).is_ready
+                current_readiness['sub_name'] = getattr(self, sub_name).is_ready
         # Make sure there isn't an exposure already in progress.
         current_readiness['not_exposing'] = not self.is_exposing
 

--- a/pocs/camera/camera.py
+++ b/pocs/camera/camera.py
@@ -239,7 +239,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
                     self.logger.warning(f"Image sensor temperature {self.temperature} " +
                                         f"deviating from target ({self.target_temperature}) " +
                                         f"by more than tolerance ({self.temperature_tolerance})" +
-                                        f"in {self}".)
+                                        f"in {self}.")
                 if self.cooling_power == 100 * u.percent:
                     self.logger.warning(f"Image sensor cooling power at 100% in {self}.")
                 return False

--- a/pocs/utils/images/__init__.py
+++ b/pocs/utils/images/__init__.py
@@ -285,7 +285,7 @@ def make_timelapse(
     """
     if fn_out is None:
         head, tail = os.path.split(directory)
-        if tail is '':
+        if tail == '':
             head, tail = os.path.split(head)
 
         field_name = head.split('/')[-2]


### PR DESCRIPTION
Increases the level of detail in both the log and exception messages related to camera readiness.

## Description

- Increased logging detail for `pocs.camera.AbstractCamera.is_temperature_stable` property, now included actual temperature, target temperature and temperature tolerance if image sensor temperature is deviating, & mentions if cooling power is at 100 percent.
-  New `pocs.camera.AbstractCamera.readiness` property that returns a dictionary with the different aspects of camera readiness (temperature stability, subcomponent readiness, not currently exposing).
- Increased logging by `pocs.camera.AbstractCamera.is_ready`, will now log warnings about aspects of the camera that are not ready.
- Increased detail of exception message raised by `pocs.camera.AbstractCamera.take_exposure()` if called when the camera is not ready, now uses `Camera.readiness` to include a list of problems in the exception and log message.

## Related Issue
#969 

## How Has This Been Tested?
Usual unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
