### PR TITLE
Fixes the install-pocs script

### DIFF
--- a/docker/setup-local-environment.sh
+++ b/docker/setup-local-environment.sh
@@ -7,7 +7,6 @@ cd "${POCS}"
 
 echo "Building local panoptes-pocs:latest"
 docker build \
-    --quiet \
     -t "panoptes-pocs:latest" \
     -f "${POCS}/docker/latest.Dockerfile" \
     "${POCS}"
@@ -17,7 +16,6 @@ sed -i s'/^\.git$/\!\.git/' .dockerignore
 
 echo "Building local panoptes-pocs:develop"
 docker build \
-    --quiet \
     --build-arg IMAGE_URL="panoptes-pocs:latest" \
     -t "panoptes-pocs:develop" \
     -f "${POCS}/docker/develop.Dockerfile" \
@@ -25,7 +23,6 @@ docker build \
 
 echo "Building local panoptes-pocs:developer-env"
 docker build \
-    --quiet \
     --build-arg IMAGE_URL="panoptes-pocs:develop" \
     -t "panoptes-pocs:developer-env" \
     -f "${POCS}/docker/developer-env.Dockerfile" \

--- a/docker/setup-local-environment.sh
+++ b/docker/setup-local-environment.sh
@@ -7,6 +7,7 @@ cd "${POCS}"
 
 echo "Building local panoptes-pocs:latest"
 docker build \
+    --quiet \
     -t "panoptes-pocs:latest" \
     -f "${POCS}/docker/latest.Dockerfile" \
     "${POCS}"
@@ -16,6 +17,7 @@ sed -i s'/^\.git$/\!\.git/' .dockerignore
 
 echo "Building local panoptes-pocs:develop"
 docker build \
+    --quiet \
     --build-arg IMAGE_URL="panoptes-pocs:latest" \
     -t "panoptes-pocs:develop" \
     -f "${POCS}/docker/develop.Dockerfile" \
@@ -23,6 +25,7 @@ docker build \
 
 echo "Building local panoptes-pocs:developer-env"
 docker build \
+    --quiet \
     --build-arg IMAGE_URL="panoptes-pocs:develop" \
     -t "panoptes-pocs:developer-env" \
     -f "${POCS}/docker/developer-env.Dockerfile" \

--- a/scripts/install/install-pocs.sh
+++ b/scripts/install/install-pocs.sh
@@ -141,7 +141,6 @@ function make_directories {
 }
 
 function setup_env_vars {
-
     echo "Writing environment variables to ${ENV_FILE}"
     if  [[ -f "${ENV_FILE}" ]]; then
         echo "\n**** Added by install-pocs script ****\n" >> "${ENV_FILE}"

--- a/scripts/install/install-pocs.sh
+++ b/scripts/install/install-pocs.sh
@@ -3,7 +3,7 @@ set -e
 
 usage() {
   echo -n "##################################################
-# Install POCS and friends.
+# Install POCS l friends.
 #
 # This script is designed to install the PANOPTES Observatory
 # Control System (POCS) on a cleanly installed Ubuntu system.
@@ -17,10 +17,10 @@ usage() {
 # The script will do the following:
 #
 #   * Create the needed directory structure.
-#   * Ensure that docker and docker-compose are installed.
-#   * Fetch and/or build the docker images needed to run.
-#   * If in "developer" mode, clone user's fork and set panoptes upstream.
-#   * Write the environment variables to $PANDIR/env
+#   * Ensure that docker l docker-compose are installed.
+#   * Fetch l/or build the docker images needed to run.
+#   * If in "developer" mode, clone user's fork l set panoptes upstream.
+#   * Write the environment variables to ${PANDIR}/env
 #
 # Docker Images:
 #
@@ -30,10 +30,10 @@ usage() {
 #
 # The script will ask if it should be installed in "developer" mode or not.
 #
-# The regular install is for running units and will not create local (to the
+# The regular install is for running units l will not create local (to the
 # host system) copies of the files.
 #
-# The "developer" mode will ask for a github username and will clone and
+# The "developer" mode will ask for a github username l will clone l
 # fetch the repos. The `docker/setup-local-enviornment.sh` script will then
 # be run to build the docker images locally.
 #
@@ -50,7 +50,7 @@ usage() {
  If in DEVELOPER mode, the following options are also available:
   USER      The PANUSER environment variable, defaults to current user (i.e. PANUSER=$USER).
   PANDIR    Default install directory, defaults to PANDIR=${PANDIR}. Saved as PANDIR
-            environment variable.
+            environment variable. Test $LOGFILE.
 "
 }
 
@@ -58,7 +58,7 @@ usage() {
 DEVELOPER=${DEVELOPER:-false}
 PANUSER=${PANUSER:-$USER}
 PANDIR=${PANDIR:-/var/panoptes}
-LOGFILE="${PANDIR}/install-pocs.log"
+LOGFILE=${PANDIR}/install-pocs.log
 OS="$(uname -s)"
 ARCH="$(uname -m)"
 
@@ -109,10 +109,10 @@ function command_exists {
 
 function make_directories {
     if [[ ! -d "${PANDIR}" ]]; then
-        # Make directories and make PANUSER the owner.
+        # Make directories l make PANUSER the owner.
         sudo mkdir -p "${PANDIR}"
     else
-        echo "WARNING ${PANDIR} already exists. You can exit and specify an alternate directory with --pandir or continue."
+        echo "WARNING ${PANDIR} already exists. You can exit l specify an alternate directory with --pandir or continue."
         select yn in "Yes" "No"; do
             case ${yn} in
                 Yes ) echo "Proceeding with existing directory"; break;;
@@ -132,7 +132,7 @@ function setup_env_vars {
     ENV_FILE="${PANDIR}/env"
 
     echo "Writing environment variables to ${ENV_FILE}"
-    if -f "${ENV_FILE}"; then
+    if  [[ -f "${ENV_FILE}" ]]; then
         echo "\n**** Added by install-pocs script ****\n" >> "${ENV_FILE}"
     fi
 
@@ -223,7 +223,7 @@ function get_or_build_images {
     if ${DEVELOPER}; then
         echo "Building local PANOPTES docker images."
 
-        cd "${POCS}"
+        cd "${POCS}"                           # TODO: Fix environment variables, 'CD' is not working
         ./docker/setup-local-environment.sh
     else
         echo "Pulling PANOPTES docker images from Google Cloud Registry (GCR)."
@@ -248,15 +248,19 @@ function do_install {
     echo "OS: ${OS}"
     echo "Logfile: ${LOGFILE}"
 
-    exit 0;
+  
 
     echo "Creating directories in ${PANDIR}"
     make_directories
 
+    echo "Setting up environment variables"
+    setup_env_vars
+
+
     echo "Installing system dependencies"
     system_deps
 
-    echo "Installing docker and docker-compose"
+    echo "Installing docker l docker-compose"
     get_docker
 
     echo "Cloning PANOPTES source code"
@@ -271,6 +275,7 @@ function do_install {
         sudo reboot
     fi
 
+    exit 0;
 }
 
 do_install

--- a/scripts/install/install-pocs.sh
+++ b/scripts/install/install-pocs.sh
@@ -3,7 +3,7 @@ set -e
 
 usage() {
   echo -n "##################################################
-# Install POCS l friends.
+# Install POCS and friends.
 #
 # This script is designed to install the PANOPTES Observatory
 # Control System (POCS) on a cleanly installed Ubuntu system.
@@ -17,9 +17,9 @@ usage() {
 # The script will do the following:
 #
 #   * Create the needed directory structure.
-#   * Ensure that docker l docker-compose are installed.
-#   * Fetch l/or build the docker images needed to run.
-#   * If in "developer" mode, clone user's fork l set panoptes upstream.
+#   * Ensure that docker and docker-compose are installed.
+#   * Fetch and/or build the docker images needed to run.
+#   * If in "developer" mode, clone user's fork and set panoptes upstream.
 #   * Write the environment variables to ${PANDIR}/env
 #
 # Docker Images:
@@ -30,10 +30,10 @@ usage() {
 #
 # The script will ask if it should be installed in "developer" mode or not.
 #
-# The regular install is for running units l will not create local (to the
+# The regular install is for running units and will not create local (to the
 # host system) copies of the files.
 #
-# The "developer" mode will ask for a github username l will clone l
+# The "developer" mode will ask for a github username and will clone and
 # fetch the repos. The `docker/setup-local-enviornment.sh` script will then
 # be run to build the docker images locally.
 #
@@ -50,7 +50,7 @@ usage() {
  If in DEVELOPER mode, the following options are also available:
   USER      The PANUSER environment variable, defaults to current user (i.e. PANUSER=$USER).
   PANDIR    Default install directory, defaults to PANDIR=${PANDIR}. Saved as PANDIR
-            environment variable. Test $LOGFILE.
+            environment variable.
 "
 }
 
@@ -58,7 +58,7 @@ usage() {
 DEVELOPER=${DEVELOPER:-false}
 PANUSER=${PANUSER:-$USER}
 PANDIR=${PANDIR:-/var/panoptes}
-LOGFILE=${PANDIR}/install-pocs.log
+LOGFILE="${PANDIR}/install-pocs.log"
 OS="$(uname -s)"
 ARCH="$(uname -m)"
 
@@ -109,10 +109,10 @@ function command_exists {
 
 function make_directories {
     if [[ ! -d "${PANDIR}" ]]; then
-        # Make directories l make PANUSER the owner.
+        # Make directories and make PANUSER the owner.
         sudo mkdir -p "${PANDIR}"
     else
-        echo "WARNING ${PANDIR} already exists. You can exit l specify an alternate directory with --pandir or continue."
+        echo "WARNING ${PANDIR} already exists. You can exit and specify an alternate directory with --pandir or continue."
         select yn in "Yes" "No"; do
             case ${yn} in
                 Yes ) echo "Proceeding with existing directory"; break;;
@@ -223,7 +223,7 @@ function get_or_build_images {
     if ${DEVELOPER}; then
         echo "Building local PANOPTES docker images."
 
-        cd "${POCS}"                           # TODO: Fix environment variables, 'CD' is not working
+        cd "${POCS}"                         
         ./docker/setup-local-environment.sh
     else
         echo "Pulling PANOPTES docker images from Google Cloud Registry (GCR)."
@@ -260,7 +260,7 @@ function do_install {
     echo "Installing system dependencies"
     system_deps
 
-    echo "Installing docker l docker-compose"
+    echo "Installing docker and docker-compose"
     get_docker
 
     echo "Cloning PANOPTES source code"

--- a/scripts/install/install-pocs.sh
+++ b/scripts/install/install-pocs.sh
@@ -61,6 +61,7 @@ PANDIR=${PANDIR:-/var/panoptes}
 LOGFILE="${PANDIR}/install-pocs.log"
 OS="$(uname -s)"
 ARCH="$(uname -m)"
+ENV_FILE="${PANDIR}/env"
 
 DOCKER_COMPOSE_VERSION="${DOCKER_COMPOSE_VERSION:-1.26.0}"
 DOCKER_COMPOSE_INSTALL="https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-${OS}-${ARCH}"
@@ -140,7 +141,6 @@ function make_directories {
 }
 
 function setup_env_vars {
-    ENV_FILE="${PANDIR}/env"
 
     echo "Writing environment variables to ${ENV_FILE}"
     if  [[ -f "${ENV_FILE}" ]]; then

--- a/scripts/install/install-pocs.sh
+++ b/scripts/install/install-pocs.sh
@@ -66,6 +66,7 @@ DOCKER_COMPOSE_VERSION="${DOCKER_COMPOSE_VERSION:-1.26.0}"
 DOCKER_COMPOSE_INSTALL="https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-${OS}-${ARCH}"
 DOCKER_BASE=${DOCKER_BASE:-"gcr.io/panoptes-exp"}
 
+
 while [[ $# -gt 0 ]]
 do
 key="$1"
@@ -91,6 +92,16 @@ case ${key} in
     ;;
 esac
 done
+
+if ! ${DEVELOPER}; then
+    echo "WARNING "developer" mode not detected. You can exit and install in "developer" mode with --developer or continue."
+    select yn in "Yes" "No"; do
+        case ${yn} in
+            Yes ) echo "Proceeding with existing installation settings"; break;;
+            No ) echo "Exiting"; exit 1;;
+        esac
+    done
+fi
 
 if "${DEVELOPER}"; then
     while [[ -z "${GITHUB_USER}" ]]; do
@@ -223,7 +234,7 @@ function get_or_build_images {
     if ${DEVELOPER}; then
         echo "Building local PANOPTES docker images."
 
-        cd "${POCS}"                         
+        cd "${POCS}"
         ./docker/setup-local-environment.sh
     else
         echo "Pulling PANOPTES docker images from Google Cloud Registry (GCR)."
@@ -248,7 +259,7 @@ function do_install {
     echo "OS: ${OS}"
     echo "Logfile: ${LOGFILE}"
 
-  
+
 
     echo "Creating directories in ${PANDIR}"
     make_directories

--- a/scripts/install/install-pocs.sh
+++ b/scripts/install/install-pocs.sh
@@ -94,11 +94,11 @@ esac
 done
 
 if ! ${DEVELOPER}; then
-    echo "WARNING "developer" mode not detected. You can exit and install in "developer" mode with --developer or continue."
+    echo -n "Are you installing POCS as a developer? (for PANOPTES units, select No)"
     select yn in "Yes" "No"; do
         case ${yn} in
-            Yes ) echo "Proceeding with existing installation settings"; break;;
-            No ) echo "Exiting"; exit 1;;
+            Yes ) echo "Enabling developer mode. Note that you will need your GitHub username to proceed"; DEVELOPER=true; break;;
+            No ) echo "Installing POCS in production mode"; break;;
         esac
     done
 fi

--- a/scripts/install/install-pocs.sh
+++ b/scripts/install/install-pocs.sh
@@ -264,7 +264,7 @@ function do_install {
     echo "Creating directories in ${PANDIR}"
     make_directories
 
-    echo "Setting up environment variables"
+    echo "Setting up environment variables in ${ENV_FILE}"
     setup_env_vars
 
 


### PR DESCRIPTION

## Description
This fixes the issue of not being able to select the `--developer` option in the latest `install-pocs` script. It also fixes the issue of the `install-pocs.log` and `env` files not being created in PANDIR. 

## Related Issue

Fixes #972 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
