### PR TITLE
Adds a line that exports environment variables to the bashrc

### DIFF
--- a/scripts/install/install-pocs.sh
+++ b/scripts/install/install-pocs.sh
@@ -152,7 +152,11 @@ export PANDIR=${PANDIR}
 export POCS=${PANDIR}/POCS
 export PANLOG=${PANDIR}/logs
 EOF
+
+    echo '. /var/panoptes/env' >> ~/.bashrc
 }
+
+
 
 function system_deps {
     if [[ "${OS}" = "Linux" ]]; then

--- a/scripts/install/install-pocs.sh
+++ b/scripts/install/install-pocs.sh
@@ -156,8 +156,6 @@ EOF
     echo '. /var/panoptes/env' >> ~/.bashrc
 }
 
-
-
 function system_deps {
     if [[ "${OS}" = "Linux" ]]; then
         sudo apt-get update >> "${LOGFILE}" 2>&1

--- a/scripts/install/install-pocs.sh
+++ b/scripts/install/install-pocs.sh
@@ -153,7 +153,7 @@ export POCS=${PANDIR}/POCS
 export PANLOG=${PANDIR}/logs
 EOF
 
-    echo '. /var/panoptes/env' >> ~/.bashrc
+    [ ! -f /var/panoptes/env ] && echo '. /var/panoptes/env' >> ~/.bashrc
 }
 
 function system_deps {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This fix links the Panoptes `env` file to the `bashrc` from within the `install-pocs` script.

Fixes #973 

## Related Issue
Previously, the environment variables weren't getting set after a restart, and the `bashrc` file had to be manually edited to link the environment variables.

## How Has This Been Tested?
This fix has not been tested on a clean install but was tested on an existing Ubuntu 20.03 Panoptes development system. The `env` file was removed beforehand as well as any references to Panoptes environment variables in the `bashrc`.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
