### PR TITLE
Logger and other minor improvements for developers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,11 +9,6 @@ adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`__.
 [0.7.5dev]
 ----------
 
-
-    Mount simulator better name and stringify.
-    Global db.
-
-
 Changed
 ~~~~~~~
 
@@ -55,6 +50,8 @@ Changed
   * Adding some action flags to the `pocs.yaml` file.
   * Remove `POCS.check_environment` class method.
   * Add a console_log_level and stderr_log_level. The former is written to the log file in $PANLOG and is meant to be tailed in the console. The stderr_log_level is what would be displayed, e.g. in a jupyter notebook. (#977)
+  * Mount simulator better name and stringify. (#977)
+  * Global db. (#977)
 
 * Camera simulator cleanup. (#974)
 * Scheduler (#974)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,11 @@ adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`__.
 [0.7.5dev]
 ----------
 
+
+    Mount simulator better name and stringify.
+    Global db.
+
+
 Changed
 ~~~~~~~
 
@@ -49,6 +54,7 @@ Changed
   * Simplification of the `run` method and the various predicates used to control it.  Now just use the computed `keep_running`.
   * Adding some action flags to the `pocs.yaml` file.
   * Remove `POCS.check_environment` class method.
+  * Add a console_log_level and stderr_log_level. The former is written to the log file in $PANLOG and is meant to be tailed in the console. The stderr_log_level is what would be displayed, e.g. in a jupyter notebook. (#977)
 
 * Camera simulator cleanup. (#974)
 * Scheduler (#974)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,9 +49,9 @@ Changed
   * Simplification of the `run` method and the various predicates used to control it.  Now just use the computed `keep_running`.
   * Adding some action flags to the `pocs.yaml` file.
   * Remove `POCS.check_environment` class method.
-  * Add a console_log_level and stderr_log_level. The former is written to the log file in $PANLOG and is meant to be tailed in the console. The stderr_log_level is what would be displayed, e.g. in a jupyter notebook. (#977)
+  * Add a `console_log_level` and `stderr_log_level`. The former is written to the log file in `$PANLOG` and is meant to be tailed in the console. The `stderr_log_level` is what would be displayed, e.g. in a jupyter notebook. (#977)
   * Mount simulator better name and stringify. (#977)
-  * Global db. (#977)
+  * Global db object for `PanBase` (#977)
 
 * Camera simulator cleanup. (#974)
 * Scheduler (#974)

--- a/src/panoptes/pocs/base.py
+++ b/src/panoptes/pocs/base.py
@@ -6,6 +6,9 @@ from panoptes.utils.config import client
 from panoptes.pocs.utils.logger import get_logger
 from panoptes.pocs import hardware
 
+# Global database.
+_db = None
+
 
 class PanBase(object):
     """ Base class for other classes within the PANOPTES ecosystem
@@ -24,7 +27,11 @@ class PanBase(object):
         db_type = kwargs.get('db_type', self.get_config('db.type', default='file'))
         db_name = kwargs.get('db_name', self.get_config('db.name', default='panoptes'))
 
-        self.db = PanDB(db_type=db_type, db_name=db_name)
+        global _db
+        if _db is None:
+            _db = PanDB(db_type=db_type, db_name=db_name)
+
+        self.db = _db
 
     def get_config(self, *args, **kwargs):
         """Thin-wrapper around client based get_config that sets default port.

--- a/src/panoptes/pocs/base.py
+++ b/src/panoptes/pocs/base.py
@@ -7,7 +7,7 @@ from panoptes.pocs.utils.logger import get_logger
 from panoptes.pocs import hardware
 
 # Global database.
-_db = None
+PAN_DB_OBJ = None
 
 
 class PanBase(object):
@@ -27,11 +27,11 @@ class PanBase(object):
         db_type = kwargs.get('db_type', self.get_config('db.type', default='file'))
         db_name = kwargs.get('db_name', self.get_config('db.name', default='panoptes'))
 
-        global _db
-        if _db is None:
-            _db = PanDB(db_type=db_type, db_name=db_name)
+        global PAN_DB_OBJ
+        if PAN_DB_OBJ is None:
+            PAN_DB_OBJ = PanDB(db_type=db_type, db_name=db_name)
 
-        self.db = _db
+        self.db = PAN_DB_OBJ
 
     def get_config(self, *args, **kwargs):
         """Thin-wrapper around client based get_config that sets default port.

--- a/src/panoptes/pocs/camera/camera.py
+++ b/src/panoptes/pocs/camera/camera.py
@@ -901,7 +901,8 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
                     else:
                         s += f" & {subcomponent.name}"
                     sub_count += 1
-        except Exception:
+        except Exception as e:
+            self.logger.warning(f'Unable to stringify camera: {e=}')
             s = str(self.__class__)
 
         return s

--- a/src/panoptes/pocs/mount/__init__.py
+++ b/src/panoptes/pocs/mount/__init__.py
@@ -112,10 +112,10 @@ def create_mount_simulator(mount_info=None,
         current_simulators.remove('mount')
 
     mount_config = mount_info or {
-        'model': 'simulator',
+        'model': 'Mount Simulator',
         'driver': 'simulator',
         'serial': {
-            'port': 'simulator'
+            'port': '/dev/FAKE'
         }
     }
 
@@ -132,6 +132,6 @@ def create_mount_simulator(mount_info=None,
 
     mount = module.Mount(earth_location, *args, **kwargs)
 
-    logger.success(f"{mount_config['driver']} mount created")
+    logger.success(f"{mount_config['driver'].title()} mount created")
 
     return mount

--- a/src/panoptes/pocs/mount/mount.py
+++ b/src/panoptes/pocs/mount/mount.py
@@ -1,4 +1,5 @@
 import time
+from contextlib import suppress
 
 from astropy import units as u
 from astropy.coordinates import EarthLocation
@@ -43,7 +44,7 @@ class AbstractMount(PanBase):
         # Create an object for just the mount config items
         self.mount_config = self.get_config('mount')
 
-        self.logger.debug("Mount config: {}".format(self.mount_config))
+        self.logger.debug(f"Mount config: {self.mount_config}")
 
         # setup commands for mount
         self.logger.debug("Setting up commands for mount")
@@ -86,6 +87,14 @@ class AbstractMount(PanBase):
         self._target_coordinates = None
         self._current_coordinates = None
         self._park_coordinates = None
+
+    def __str__(self):
+        brand = self.mount_config.get('brand', '')
+        model = self.mount_config.get('model', '')
+        port = ''
+        with suppress(KeyError):
+            port = self.mount_config['serial']['port']
+        return f'{brand} {model} ({port})'
 
     def connect(self):  # pragma: no cover
         raise NotImplementedError

--- a/src/panoptes/pocs/observatory.py
+++ b/src/panoptes/pocs/observatory.py
@@ -54,7 +54,7 @@ class Observatory(PanBase):
 
         self._primary_camera = None
         if cameras:
-            self.logger.info(f'Adding the cameras to the observatory: {cameras}')
+            self.logger.info(f'Adding cameras to the observatory: {cameras}')
             for cam_name, camera in cameras.items():
                 self.add_camera(cam_name, camera)
 
@@ -242,7 +242,7 @@ class Observatory(PanBase):
         hw_attr = getattr(self, hw_type)
 
         if isinstance(new_hardware, hw_class):
-            self.logger.success(f'Adding {new_hardware=}')
+            self.logger.success(f'Adding {new_hardware}')
             setattr(self, hw_type, new_hardware)
         elif new_hardware is None:
             if hw_attr is not None:

--- a/src/panoptes/pocs/tests/utils/test_logger.py
+++ b/src/panoptes/pocs/tests/utils/test_logger.py
@@ -11,8 +11,7 @@ def profile():
 
 def test_base_logger(caplog, profile, tmp_path):
     logger = get_logger(log_dir=str(tmp_path),
-                        full_log_file=None,
-                        profile=profile)
+                        full_log_file=None)
     logger.debug('Hello')
     time.sleep(0.5)
     assert caplog.records[-1].message == 'Hello'

--- a/src/panoptes/pocs/tests/utils/test_logger.py
+++ b/src/panoptes/pocs/tests/utils/test_logger.py
@@ -13,6 +13,6 @@ def test_base_logger(caplog, profile, tmp_path):
     logger = get_logger(log_dir=str(tmp_path),
                         full_log_file=None)
     logger.debug('Hello')
-    time.sleep(0.5)
+    time.sleep(1)  # Wait for log to make it there.
     assert caplog.records[-1].message == 'Hello'
     assert caplog.records[-1].levelname == 'DEBUG'


### PR DESCRIPTION
* Logger
  * Add a `console_log_level` and `stderr_log_level`. The former is written to the log file in $PANLOG and is meant to be `tail`ed in the console. The `stderr_log_level` is what would be displayed, e.g. in a jupyter notebook.
  * The `panoptes` logger is enabled inside `get_logger`.
* Mount simulator better name and stringify.
* Global db.
