### PR TITLE
Bump panoptes-utils

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
     Flask
     matplotlib
     numpy
-    panoptes-utils>=0.2.21
+    panoptes-utils>=0.2.22
     pyserial>=3.1.1
     PyYaml
     requests

--- a/src/panoptes/pocs/core.py
+++ b/src/panoptes/pocs/core.py
@@ -435,7 +435,7 @@ class POCS(PanStateMachine, PanBase):
         """
         directory = directory or os.getenv('PANDIR')
         req_space = required_space.to(u.gigabyte)
-        self._free_space = get_free_space(dir=directory)
+        self._free_space = get_free_space(directory=directory)
 
         space_is_low = self._free_space.value <= (req_space.value * low_space_percent)
 


### PR DESCRIPTION
* Fixes the usage of the `dir` built-in in `get_free_space`.

This fix exists in #991 #990 #987 but I'm pushing it through here first.