### PR TITLE
WIP: Improved camera error handling for take_exposure & autofocus

### DIFF
--- a/src/panoptes/pocs/camera/camera.py
+++ b/src/panoptes/pocs/camera/camera.py
@@ -547,9 +547,8 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         except Exception as err:
             err = error.PanError("Error starting exposure on {}: {}".format(self, err))
             self._exposure_error = repr(err)
-            raise err
-        finally:
             self._exposure_event.set()
+            raise err
 
         # Start polling thread that will call camera type specific _readout method when done
         readout_thread = threading.Timer(interval=get_quantity_value(seconds, unit=u.second),

--- a/src/panoptes/pocs/camera/camera.py
+++ b/src/panoptes/pocs/camera/camera.py
@@ -587,7 +587,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         field_name = info['field_name']
 
         if not os.path.exists(file_path):
-            self.logger.error(f"Expected image at '{filepath}' does not exist or " +
+            self.logger.error(f"Expected image at '{file_path}' does not exist or " +
                               "cannot be accessed, cannot process.")
             observation_event.set()
             return

--- a/src/panoptes/pocs/camera/camera.py
+++ b/src/panoptes/pocs/camera/camera.py
@@ -586,6 +586,12 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         exptime = info['exptime']
         field_name = info['field_name']
 
+        if not os.path.exists(file_path):
+            self.logger.error(f"Expected image at '{filepath}' does not exist or " +
+                              "cannot be accessed, cannot process.")
+            observation_event.set()
+            return
+
         image_title = '{} [{}s] {} {}'.format(field_name,
                                               exptime,
                                               seq_id.replace('_', ' '),

--- a/src/panoptes/pocs/camera/simulator_sdk/ccd.py
+++ b/src/panoptes/pocs/camera/simulator_sdk/ccd.py
@@ -71,7 +71,7 @@ class Camera(AbstractSDKCamera, Camera, ABC):
     def connect(self):
         self._is_cooled_camera = True
         self._cooling_enabled = False
-        self._temperature = 25 * u.Celsius
+        self._temperature = 5 * u.Celsius
         self._max_temp = 25 * u.Celsius
         self._min_temp = -15 * u.Celsius
         self._temp_var = 0.05 * u.Celsius
@@ -79,12 +79,6 @@ class Camera(AbstractSDKCamera, Camera, ABC):
         self._last_temp = 25 * u.Celsius
         self._last_time = time.monotonic()
         self._connected = True
-
-    def _check_temperature_stability(self, required_stable_time=10*u.second,
-                                     sleep_delay=5*u.second, **kwargs):
-        """Override default parameters to speed-up tests."""
-        super()._check_temperature_stability(required_stable_time=required_stable_time,
-                                             sleep_delay=sleep_delay, **kwargs)
 
     def _set_target_temperature(self, target):
         # Upon init the camera won't have an existing temperature.

--- a/src/panoptes/pocs/camera/zwo.py
+++ b/src/panoptes/pocs/camera/zwo.py
@@ -44,7 +44,7 @@ class Camera(AbstractSDKCamera):
             its serial number or, if it doesn't have one, by the user set ID.
         """
         kwargs['readout_time'] = kwargs.get('readout_time', 0.1)
-        kwargs['timeout'] = kwargs.get('timeout', 0.5)
+        kwargs['timeout'] = kwargs.get('timeout', 5)
         # ZWO cameras cannot take internal darks (not even supported in the API yet).
         kwargs['internal_darks'] = kwargs.get('internal_darks', False)
 

--- a/src/panoptes/pocs/focuser/focuser.py
+++ b/src/panoptes/pocs/focuser/focuser.py
@@ -48,8 +48,6 @@ class AbstractFocuser(PanBase, metaclass=ABCMeta):
             saturated pixel mask (determine size of masked regions), default 10
         autofocus_make_plots (bool, optional: Whether to write focus plots to images folder,
             default False.
-        autofocus_focus_time (scalar, optional): Maximum time taken to change focus position +
-            maximum time taken to process each autofocus exposure, in seconds. Default 5.
     """
 
     def __init__(self,
@@ -68,7 +66,6 @@ class AbstractFocuser(PanBase, metaclass=ABCMeta):
                  autofocus_merit_function_kwargs=None,
                  autofocus_mask_dilations=None,
                  autofocus_make_plots=False,
-                 autofocus_focus_time=5,
                  *args, **kwargs):
 
         super().__init__(*args, **kwargs)
@@ -94,8 +91,7 @@ class AbstractFocuser(PanBase, metaclass=ABCMeta):
                                        autofocus_merit_function,
                                        autofocus_merit_function_kwargs,
                                        autofocus_mask_dilations,
-                                       autofocus_make_plots,
-                                       autofocus_focus_time)
+                                       autofocus_make_plots)
         self._autofocus_error = None
 
         self._camera = camera
@@ -591,8 +587,7 @@ class AbstractFocuser(PanBase, metaclass=ABCMeta):
                                   autofocus_merit_function,
                                   autofocus_merit_function_kwargs,
                                   autofocus_mask_dilations,
-                                  autofocus_make_plots,
-                                  autofocus_focus_time):
+                                  autofocus_make_plots):
         # Moved to a separate private method to make it possible to override.
         if autofocus_range:
             self.autofocus_range = (int(autofocus_range[0]), int(autofocus_range[1]))
@@ -612,12 +607,6 @@ class AbstractFocuser(PanBase, metaclass=ABCMeta):
         self.autofocus_merit_function_kwargs = autofocus_merit_function_kwargs
         self.autofocus_mask_dilations = autofocus_mask_dilations
         self.autofocus_make_plots = bool(autofocus_make_plots)
-        try:
-            # This will work if it's an astropy.units.Quantity or simular.
-            self.autofocus_focus_time = autofocus_focus_time.to_value(unit=u.second)
-        except AttributeError:
-            # Not a Quantity so it should be a scalar numeric type.
-            self.autofocus_focus_time = float(autofocus_focus_time)
 
     def _add_fits_keywords(self, header):
         header.set('FOC-NAME', self.name, 'Focuser name')

--- a/src/panoptes/pocs/tests/test_camera.py
+++ b/src/panoptes/pocs/tests/test_camera.py
@@ -92,7 +92,8 @@ def camera(request):
                 break
 
     camera.logger.debug(f'Yielding camera {camera}')
-    camera._check_temperature_stability(blocking=True)  # Need to wait for stable temperature
+    if camera.is_cooled_camera:
+        camera._check_temperature_stability(blocking=True)  # Need to wait for stable temperature
     assert camera.is_ready
     yield camera
 

--- a/src/panoptes/pocs/tests/test_camera.py
+++ b/src/panoptes/pocs/tests/test_camera.py
@@ -93,7 +93,9 @@ def camera(request):
 
     camera.logger.debug(f'Yielding camera {camera}')
     if camera.is_cooled_camera:
-        camera._check_temperature_stability(blocking=True)  # Need to wait for stable temperature
+        camera._check_temperature_stability(required_stable_time=1*u.second,
+                                            sleep_delay=0.1*u.second,
+                                            blocking=True)  # Need to wait for stable temperature
     assert camera.is_ready
     yield camera
 


### PR DESCRIPTION
Improved error handling for the main asynchronous operations of cameras and focusers: taking an exposure and doing autofocus. This has been prompted by the problems caused by unreliable cameras in the Huntsman Telescope. Calling code is unable to detect problems that occur after an exposure or autofocus sequence have started, leading to attempts to continue using a failed camera and, in the case of autofocus, possible deadlock.

## Description
<!--- Describe your changes in detail -->
1. Add an `exposure_error` property to the `pocs.camera.camera.AbstractCamera` class. This will be `None` unless an exception is raised during an exposure, at which point it will be set to the string representation of the exception that occurred. Note that exceptions that occur after an exposure has started occur in a `threading.Thread` and so are otherwise invisible to the calling code in the main thread. This property allows code in the main thread to check whether an exception did occur, and respond accordingly.
1. Changes to `AbstractCamera.take_exposure()` to ensure that `exposure_error` gets set if exceptions are raised when starting the exposure.
1. Changes to `AbstractCamera._poll_exposure()` to ensure that `exposure_error` gets set if exceptions are raised either while waiting for the exposure to complete, or if the subsequent call to `._readout()` raises an exception. `._poll_exposure()` and `._readout()` run in a `Thread` so these exceptions would otherwise be invisible to the main thread.
1. Changes to `AbstractCamera.get_thumbnail()` so that it checks `exposure_error` after taking an exposure and raises an `error.PanError` if the exposure failed. Also removed the suppression of exceptions from the call to `img_utils.crop_data()`. Between them these changes are intended to ensure that if anything goes wrong during `get_thumbnail()` a relevant, descriptive exception will be raised.
1. Add an `autofocus_error` property to the `pocs.focuser.focuser.AbstractFocuser` class. This will be `None` unless an exception is raised during an autofocus sequence, at which point it will be set to the string representation of the exception that occurred. Note that exceptions that occur during an autofocus sequence occur in a `threading.Thread` and so are otherwise invisible to the calling code in the main thread. This property allows code in the main thread to check whether an exception did occur, and responding accordingly.
1. Changes to `AbstractFocuser._autofocus()` so that all calls to `self._camera.get_thumbnail()` (which will now raise an exception in the case of a failed exposure) are wrapped in `try ... except` blocks which will set `autotocus_error`, set the focus `threading.Event` and re-raise the exception, terminating the `Thread` that `_autofocus()` runs in. Previously exceptions from `get_thumbnail()` were not handled and would terminate the thread without setting the `Event`, relying on the calling code to implement a timeout to prevent deadlocks.
1. Make it possible to set the autofocus option `make_plots` when creating the focuser via a new `autofocus_make_plots` constructor argument. This makes it possible to enable or disable plots using the config. These plots are very useful for troubleshooting but currently there is no way to turn them on.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Incidentally fixes #925 along the way, but the main focus of this PR relates to https://github.com/AstroHuntsman/huntsman-pocs/issues/205

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
So far, not at all.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
