### PR TITLE
Pass camera bit depth to mask_saturated

### DIFF
--- a/src/panoptes/pocs/focuser/focuser.py
+++ b/src/panoptes/pocs/focuser/focuser.py
@@ -349,7 +349,9 @@ class AbstractFocuser(PanBase, metaclass=ABCMeta):
                                                         keep_file=True,
                                                         dark=True)
                 # Mask 'saturated' with a low threshold to remove hot pixels
-                dark_thumb = mask_saturated(dark_thumb, threshold=0.3)
+                dark_thumb = mask_saturated(dark_thumb,
+                                            threshold=0.3,
+                                            bit_depth=self.camera.bit_depth)
             except TypeError:
                 self.logger.warning("Camera {} does not support dark frames!".format(self._camera))
             except Exception as e:

--- a/src/panoptes/pocs/focuser/focuser.py
+++ b/src/panoptes/pocs/focuser/focuser.py
@@ -395,7 +395,7 @@ class AbstractFocuser(PanBase, metaclass=ABCMeta):
 
             thumbnail = self._camera.get_thumbnail(
                 seconds, file_path, thumbnail_size, keep_file=keep_files)
-            masks[i] = mask_saturated(thumbnail).mask
+            masks[i] = mask_saturated(thumbnail, bit_depth=self.camera.bit_depth).mask
             if dark_thumb is not None:
                 thumbnail = thumbnail - dark_thumb
             thumbnails[i] = thumbnail


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Passes the value of the camera's `.bit_depth` attribute in the calls to `panoptes.utils.images.mask_saturated()` in `pocs.focuser.focuser.AbstractFocuser._autofocus()`. This makes use of the changes to `mask_saturated` in https://github.com/panoptes/panoptes-utils/pull/244, enabling `mask_saturated()` to infer a sensible saturation level for images with a bit depth less than that which the data type would imply, e.g. `uint16` images from a 12 bits/pixel camera. Without this change saturated pixels in these images will not be masked.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Usual unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
