### PR TITLE
Small updates to match docker changes in panoptes-utils

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,8 +9,8 @@ Added
 ~~~~~
 
 * Better error checking in cameras, including ability to store error. (@AnthonyHorton #1007)
-* Added `error.InvalidConfig` exception. (@wtgee #1007)
-* Config options to control observation processiong options: (@wtgee #1007)
+* Added ``error.InvalidConfig`` exception. (@wtgee #1007)
+* Config options to control observation processing options: (@wtgee #1007)
 
   * ``observations.compress_fits`` if FITS files should be fpacked. Default True.
   * ``observations.record_observations`` if observation metadata should be recorded. Default True.
@@ -34,8 +34,12 @@ Bug fixes
 Changed
 ~~~~~~~
 
-* Updated ``panoptes-utils`` to ``v0.2.28``. (@wtgee #1007)
-* Updated ``panoptes-utils`` to ``v0.2.27`` to support the envvars for starting config server. (@wtgee #1001)
+* Changelog cleanup. (@wtgee #1008)
+* ``panoptes-utils`` updates:
+
+  * Updated ``panoptes-utils`` to ``v0.2.28``. (@wtgee #1007)
+  * Updated ``panoptes-utils`` to ``v0.2.27`` to support the envvars for starting config server. (@wtgee #1001)
+
 * Move the ``wait-for-it.sh`` script into ``scripts``. (@wtgee #1001)
 * Camera:
 
@@ -43,14 +47,14 @@ Changed
   * Camera and subcomponent stringification changed for clarity. (@wtgee #1007)
   * Can reassign SDK camera if same UID is presented with flag to ``create_cameras_from_config``. (@wtgee #1007)
   * Add support for taking "dark" frames for cameras with mechanical shutters or opaque filters in the filterwheel. (@AnthonyHorton #989)
-  * `_poll_exposure` was needlessly being called in a `threading.Timer` rather than a simple `threading.Event`. (@wtgee @1007)
+  * ``_poll_exposure`` was needlessly being called in a ``threading.Timer`` rather than a simple ``threading.Event``. (@wtgee @1007)
   * Slight improvements to the timeout and readout for exposures with the simulators. (@wtgee #1007)
 
 * Docker:
 
+  * Updated to match ``panoptes-utils`` Docker updates: removal of ``source-extractor`` and more. (@wtgee #1008)
   * ``gphoto2`` comes from apt. (@wtgee #1007)
   * Local setup script doesn't build ``panoptes-utils`` but assumes done otherwise or uses ``gcr.io``. (@wtgee #1007)
-
 
 * Testing:
 
@@ -78,18 +82,18 @@ Changed
 
 * Dependency updates:
 
-  * `panoptes-utils` to `0.2.26`. (#995)
-  * `panoptes-utils` to `0.2.21`. (#979)
-  * `panoptes-utils` to `0.2.20`. (#974)
+  * ``panoptes-utils`` to ``0.2.26``. (#995)
+  * ``panoptes-utils`` to ``0.2.21``. (#979)
+  * ``panoptes-utils`` to ``0.2.20``. (#974)
 
 * Install script. (#974)
 
   * Env var file is sourced for zshrc and bashrc.
   * Fix the clone of the repos in install script. (#978)
   * Adding a date version to script. (#979)
-  * `docker-compose` version bumped to `1.26.2`. (#979)
+  * ``docker-compose`` version bumped to ``1.26.2``. (#979)
   * Better testing for ssh access. (#984)
-  * Using `linuxserver.io docker-compose <https://hub.docker.com/r/linuxserver/docker-compose>`_ so we also have `arm` version without work. (#986)
+  * Using `linuxserver.io docker-compose <https://hub.docker.com/r/linuxserver/docker-compose>`_ so we also have ``arm`` version without work. (#986)
   * Fixing conditional so script can proceed without restart. (#986)
   * Generalizing install script in sections. (#986)
 
@@ -101,7 +105,7 @@ Changed
 
 * Docker image updates (#972)
 
-  * Updated `install-pocs.sh` script.
+  * Updated ``install-pocs.sh`` script.
   * ``latest`` installs the ``panoptes-pocs`` module from pip
   * ``develop`` installs via ``pip install -e[google.testing]`` and is used for running the CI tests.
   * ``developer-env`` installs locally but with all options, i.e. ``pip install -e[google,testing,plotting,developer]``. Also builds ``jupyterlab`` and other developer tools. Starts a ``jupyterlab`` instance by default.
@@ -116,29 +120,29 @@ Changed
 * Testing (#974)
 
   * Removing all the dynamic config server info, making things a lot simpler.
-  * `docker-compose` files for running tests.
+  * ``docker-compose`` files for running tests.
   * Misc documentation updates.
   * Code coverage no longer ignores test.
-  * Testing is run via `panoptes-develop test`.
+  * Testing is run via ``panoptes-develop test``.
   * Log files are rotated during each run.
 
 * POCS (#974)
 
-  * POCS instance cannot `initialize` unless it's `observatory.can_observe`.
-  * Set `simulator` config item at start of `POCS` init method if `simulators` (note plural) is passed.
-  * Simplification of the `run` method and the various predicates used to control it.  Now just use the computed `keep_running`.
-  * Adding some action flags to the `pocs.yaml` file.
-  * Remove `POCS.check_environment` class method.
-  * Add a `console_log_level` and `stderr_log_level`. The former is written to the log file in `$PANLOG` and is meant to be tailed in the console. The `stderr_log_level` is what would be displayed, e.g. in a jupyter notebook. (#977)
+  * POCS instance cannot ``initialize`` unless it's ``observatory.can_observe``.
+  * Set ``simulator`` config item at start of ``POCS`` init method if ``simulators`` (note plural) is passed.
+  * Simplification of the ``run`` method and the various predicates used to control it.  Now just use the computed ``keep_running``.
+  * Adding some action flags to the ``pocs.yaml`` file.
+  * Remove ``POCS.check_environment`` class method.
+  * Add a ``console_log_level`` and ``stderr_log_level``. The former is written to the log file in ``$PANLOG`` and is meant to be tailed in the console. The ``stderr_log_level`` is what would be displayed, e.g. in a jupyter notebook. (#977)
   * Mount simulator better name and stringify. (#977)
-  * Global db object for `PanBase` (#977)
+  * Global db object for ``PanBase`` (#977)
   * Allow for custom folder for metadata. (#979)
-    * Default changed to `metadata`.
+    * Default changed to ``metadata``.
 
 * Camera simulator cleanup. (#974)
 * Scheduler (#974)
 
-    * The `fields_file` is read when scheduler is created.
+    * The ``fields_file`` is read when scheduler is created.
 
 [0.7.4] - 2020-05-31
 --------------------
@@ -228,13 +232,13 @@ Changed
 * Renamed codecov configuration file to be compliant.
 * Switch to pyscaffold for package maintenance.
 * "Waiting" method changes:
-    * `sleep` has been renamed to `wait`.
+    * ``sleep`` has been renamed to ``wait``.
 * All `status()` methods have been converted to properties that return a useful dict.
 * Making proper abstractmethods.
 * Documentation updates where found.
 * Many log and f-string fixes.
-* `pocs.config_port` property available publicly.
-* horizon check for state happens directly in `run`.
+* ``pocs.config_port`` property available publicly.
+* horizon check for state happens directly in ``run``.
 
 Removed
 ~~~~~~~
@@ -399,7 +403,7 @@ Changed
 * State machine location more flexible
    `209 <https://github.com/panoptes/POCS/pull/209>`__,
    `219 <https://github.com/panoptes/POCS/pull/219>`__
-* Testing improvments
+* Testing improvements
    `249 <https://github.com/panoptes/POCS/pull/249>`__.
 * Updates to many wiki pages.
 * Misc bug fixes and improvements.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,6 @@ ARG panuser=panoptes
 ARG userid=1000
 ARG pan_dir=/var/panoptes
 ARG pocs_dir="${pan_dir}/POCS"
-ARG conda_env_name="panoptes"
 
 ARG arduino_url="https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh"
 ARG gphoto2_url="https://raw.githubusercontent.com/gonzalo/gphoto2-updater/master/gphoto2-updater.sh"
@@ -46,7 +45,7 @@ RUN mkdir -p "${PANDIR}/scripts" && \
 USER ${PANUSER}
 # Can't seem to get around the hard-coding here.
 COPY --chown=panoptes:panoptes . .
-RUN "${PANDIR}/conda/envs/${conda_env_name}/bin/pip" install -e ".${pip_extras}" && \
+RUN "${PANDIR}/conda/bin/pip" install -e ".${pip_extras}" && \
     # Cleanup
     sudo apt-get autoremove --purge --yes && \
     sudo apt-get autoclean --yes && \

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -5,7 +5,7 @@ timeout: 18000s  # 5 hours
 
 substitutions:
   _PLATFORMS: linux/amd64,linux/arm64
-  _BASE_IMAGE: panoptes-utils:latest
+  _BASE_IMAGE: panoptes-utils
   _IMAGE_NAME: panoptes-pocs
   _REPO_URL: https://github.com/panoptes/POCS
   _TAG: latest
@@ -59,7 +59,7 @@ steps:
       - "--push"
       - "--platform=${_PLATFORMS}"
       - "-f=docker/Dockerfile"
-      - "--build-arg=image_url=gcr.io/${PROJECT_ID}/${_BASE_IMAGE}"
+      - "--build-arg=image_url=gcr.io/${PROJECT_ID}/${_BASE_IMAGE}:${_TAG}"
       - "--tag=gcr.io/${PROJECT_ID}/${_IMAGE_NAME}:${_TAG}"
       - "--cache-from=gcr.io/${PROJECT_ID}/${_IMAGE_NAME}:${_TAG}"
       - "POCS"

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,10 +48,9 @@ install_requires =
     matplotlib
     numpy
     pyserial>=3.1.1
-    panoptes-utils==0.2.28
+    panoptes-utils>=0.2.28
     python-dotenv
     requests
-    scalpl
     scipy
     transitions
 # The usage of test_requires is discouraged, see `Dependency Management` docs


### PR DESCRIPTION
* `source-extractor` has been removed but shouldn't impact POCS.
* Use correct pip and python in Dockerfile.
* Cleanup changelog

