### PR TITLE
Build a development version of POCS for use in binder, etc.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Changelog
 Added
 ~~~~~
 
+* A "developer" version of the ``panoptes-pocs`` docker image is cloudbuilt automatically on merge with ``develop``. (@wtgee #1010)
 * Better error checking in cameras, including ability to store error. (@AnthonyHorton #1007)
 * Added ``error.InvalidConfig`` exception. (@wtgee #1007)
 * Config options to control observation processing options: (@wtgee #1007)

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -48,7 +48,7 @@ steps:
       - "--driver=docker-container"
     waitFor: ["setup-buildx"]
 
-  # Build with cloned panoptes-utils as source directory
+  # Build with cloned panoptes-utils as source directory.
   - name: "gcr.io/cloud-builders/docker"
     id: "build-images"
     env:
@@ -64,3 +64,20 @@ steps:
       - "--cache-from=gcr.io/${PROJECT_ID}/${_IMAGE_NAME}:${_TAG}"
       - "POCS"
     waitFor: ["build-builder", "clone-repo"]
+
+  # Build a developer version.
+  - name: "gcr.io/cloud-builders/docker"
+    id: "build-developer-images"
+    env:
+      - "DOCKER_CLI_EXPERIMENTAL=enabled"
+    args:
+      - "buildx"
+      - "build"
+      - "--push"
+      - "--platform=linux/amd64"
+      - "-f=docker/developer/Dockerfile"
+      - "--build-arg=image_url=gcr.io/${PROJECT_ID}/${_IMAGE_NAME}:${_TAG}"
+      - "--tag=gcr.io/${PROJECT_ID}/${_IMAGE_NAME}:developer"
+      - "--cache-from=gcr.io/${PROJECT_ID}/${_IMAGE_NAME}:developer"
+      - "POCS"
+    waitFor: ["build-images"]

--- a/docker/developer/Dockerfile
+++ b/docker/developer/Dockerfile
@@ -10,7 +10,7 @@ ARG panuser=panoptes
 ARG userid=1000
 ARG pan_dir=/var/panoptes
 ARG pocs_dir="${pan_dir}/POCS"
-ARG conda_env_name="panoptes"
+ARG conda_env_name="base"
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
@@ -33,16 +33,21 @@ RUN echo "Installing developer tools" && \
     "${PANDIR}/conda/bin/conda" install --name "${conda_env_name}" \
         altair \
         bokeh \
-        httpie \
-        jupyterlab \
-        jq \
         holoviews \
+        httpie \
         hvplot \
+        ipywidgets \
+        jq \
+        jupyter-offlinenotebook \
+        jupyter-panel-proxy \
+        jupyterlab \
         nodejs \
-        seaborn && \
+        pyarrow \
+        seaborn \
+        && \
     # Set some jupyterlab defaults.
     mkdir -p /home/panoptes/.jupyter && \
-    /usr/bin/env zsh -c "${PANDIR}/conda/envs/${conda_env_name}/bin/jupyter-lab --no-browser --generate-config" && \
+    /usr/bin/env zsh -c "${PANDIR}/conda/bin/jupyter-lab --no-browser --generate-config" && \
     # Jupyterlab extensions.
     echo "c.JupyterApp.answer_yes = True" >> \
         "/home/panoptes/.jupyter/jupyter_notebook_config.py" && \


### PR DESCRIPTION
Fix the developer docker version to use updated conda environment from `panoptes-utils`. Update cloudbuild so that a developer image is built automatically from the `develop` branch.