### PR TITLE
Autofocus plots refactor

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Changelog
 Added
 ~~~~~
 
+* Ability to specify autofocus plots in config file. (@wtgee #1029)
 * A "developer" version of the ``panoptes-pocs`` docker image is cloudbuilt automatically on merge with ``develop``. (@wtgee #1010)
 * Better error checking in cameras, including ability to store error. (@AnthonyHorton #1007)
 * Added ``error.InvalidConfig`` exception. (@wtgee #1007)
@@ -32,6 +33,8 @@ Bug fixes
 
 * DSLR simulator cameras properly override the cooling defaults. (@wtgee #1001)
 * Stability checks for cooled cameras so they are only marked ``ready`` when cooled condition has stabilized. (@danjampro #990)
+* Properly closed the autofocus matplotlib figures. (@wtgee #1029)
+* Prevent thumbnails from being larger than image. (@wtgee #1029)
 
 Changed
 ~~~~~~~
@@ -45,6 +48,7 @@ Changed
   * ``_process_fits`` is responsible for writing the headers rather than calling out to panoptes-utils. Allows for easier overrides. (@wtgee #1009)
   * dslr simulator readout time improved. (@wtgee #1009)
   * ``process_exposure`` doesn't require the exposure_event to be passed because that is the cameras is_exposing property. (@wtgee #1009)
+  * The autofocus plotting has been moved to an external file. (@wtgee #1029)
 
 
 * Changelog cleanup. (@wtgee #1008)

--- a/conf_files/pocs.yaml
+++ b/conf_files/pocs.yaml
@@ -97,6 +97,7 @@ cameras:
       autofocus_seconds: 0.1  # seconds
       autofocus_size: 500  # seconds
       autofocus_keep_files: False
+      autofocus_make_plots: False
   devices:
     - model: panoptes.pocs.camera.gphoto.canon.Camera
       name: dslr.00

--- a/src/panoptes/pocs/camera/camera.py
+++ b/src/panoptes/pocs/camera/camera.py
@@ -707,7 +707,9 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
             os.unlink(file_path)
 
         # Make sure thumbnail is not bigger than image.
-        thumbnail_size = min(thumbnail_size, *image.shape)
+        actual_thumbnail_size = min(thumbnail_size, *image.shape)
+        if actual_thumbnail_size != thumbnail_size:
+            self.logger.info(f'Requested thumbnail size is smaller than image, using {actual_thumbnail_size}')
 
         return img_utils.crop_data(image, box_width=thumbnail_size)
 

--- a/src/panoptes/pocs/camera/camera.py
+++ b/src/panoptes/pocs/camera/camera.py
@@ -705,6 +705,10 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         image = fits.getdata(file_path)
         if not keep_file:
             os.unlink(file_path)
+
+        # Make sure thumbnail is not bigger than image.
+        thumbnail_size = min(thumbnail_size, *image.shape)
+
         return img_utils.crop_data(image, box_width=thumbnail_size)
 
     @abstractmethod
@@ -923,7 +927,9 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
             self.logger.trace(f'Updating {file_path} metadata with provided headers')
             metadata.update(headers)
 
-        self.logger.debug(f'Observation setup: exptime={exptime!r} file_path={file_path!r} image_id={image_id!r} metadata={metadata!r}')
+        self.logger.debug(
+            f'Observation setup: exptime={exptime!r} file_path={file_path!r} image_id={image_id!r} metadata='
+            f'{metadata!r}')
 
         return exptime, file_path, image_id, metadata
 
@@ -963,7 +969,8 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
                 # Get the value from either the metadata, the default, or use blank string.
                 fits_value = metadata.get(metadata_key, field_info.get('default', ''))
 
-                self.logger.trace(f'Setting fits_key={fits_key!r} = fits_value={fits_value!r} fits_comment={fits_comment!r}')
+                self.logger.trace(
+                    f'Setting fits_key={fits_key!r} = fits_value={fits_value!r} fits_comment={fits_comment!r}')
                 hdu.header.set(fits_key, fits_value, fits_comment)
 
             self.logger.debug(f"Finished FITS headers: {file_path}")

--- a/src/panoptes/pocs/focuser/focuser.py
+++ b/src/panoptes/pocs/focuser/focuser.py
@@ -375,7 +375,7 @@ class AbstractFocuser(PanBase, metaclass=ABCMeta):
 
         try:
             initial_thumbnail = self._camera.get_thumbnail(seconds, initial_path, thumbnail_size, keep_file=True)
-            if dark_thumbnail:
+            if dark_thumbnail is not None:
                 initial_thumbnail = initial_thumbnail - dark_thumbnail
             initial_thumbnail = mask_saturated(initial_thumbnail, bit_depth=self.camera.bit_depth)
         except Exception as err:

--- a/src/panoptes/pocs/focuser/focuser.py
+++ b/src/panoptes/pocs/focuser/focuser.py
@@ -335,9 +335,7 @@ class AbstractFocuser(PanBase, metaclass=ABCMeta):
 
         See public `autofocus` for information about the parameters.
         """
-        focus_type = 'fine'
-        if coarse:
-            focus_type = 'coarse'
+        focus_type = 'coarse' if coarse else 'fine'
 
         initial_focus = self.position
         self.logger.debug(f"Beginning {focus_type} autofocus of {self._camera} - initial position: {initial_focus}")
@@ -346,6 +344,13 @@ class AbstractFocuser(PanBase, metaclass=ABCMeta):
         image_dir = self.get_config('directories.images')
         start_time = current_time(flatten=True)
         file_path_root = os.path.join(image_dir, 'focus', self._camera.uid, start_time)
+
+        class FocusException(Exception):
+            def __init__(self, err, error_msg):
+                self.logger.error(error_msg)
+                self._autofocus_error = repr(err)
+                focus_event.set()
+                raise err
 
         self._autofocus_error = None
 
@@ -364,10 +369,7 @@ class AbstractFocuser(PanBase, metaclass=ABCMeta):
                                                 threshold=0.3,
                                                 bit_depth=self.camera.bit_depth)
             except Exception as err:
-                self.logger.error(f"Error taking dark frame: {err!r}")
-                self._autofocus_error = repr(err)
-                focus_event.set()
-                raise err
+                raise FocusException(err, f"Error taking dark frame: {err!r}")
 
         # Take an image before focusing, grab a thumbnail from the centre and add it to the plot
         initial_fn = f"{initial_focus}-{focus_type}-initial.{self._camera.file_extension}"
@@ -379,10 +381,7 @@ class AbstractFocuser(PanBase, metaclass=ABCMeta):
                 initial_thumbnail = initial_thumbnail - dark_thumbnail
             initial_thumbnail = mask_saturated(initial_thumbnail, bit_depth=self.camera.bit_depth)
         except Exception as err:
-            self.logger.error(f"Error taking initial image: {err!r}")
-            self._autofocus_error = repr(err)
-            focus_event.set()
-            raise err
+            raise FocusException(err, f"Error taking initial autofocus image: {err!r}")
 
         # Set up encoder positions for autofocus sweep, truncating at focus travel
         # limits if required.
@@ -417,10 +416,7 @@ class AbstractFocuser(PanBase, metaclass=ABCMeta):
             try:
                 thumbnail = self._camera.get_thumbnail(seconds, file_path, thumbnail_size, keep_file=keep_files)
             except Exception as err:
-                self.logger.error(f"Error taking image {i + 1}: {err!r}")
-                self._autofocus_error = repr(err)
-                focus_event.set()
-                raise err
+                raise FocusException(err, f"Error taking autofocus image {i + 1:02d}: {err!r}")
 
             masks[i] = mask_saturated(thumbnail, bit_depth=self.camera.bit_depth).mask
             if dark_thumbnail is not None:
@@ -503,10 +499,7 @@ class AbstractFocuser(PanBase, metaclass=ABCMeta):
                 final_thumbnail = final_thumbnail - dark_thumbnail
             final_thumbnail = mask_saturated(final_thumbnail, bit_depth=self.camera.bit_depth)
         except Exception as err:
-            self.logger.error(f"Error taking final image: {err!r}")
-            self._autofocus_error = repr(err)
-            focus_event.set()
-            raise err
+            raise FocusException(err, f"Error taking final autofocus image: {err!r}")
 
         if make_plots:
             line_fit = None

--- a/src/panoptes/pocs/focuser/focuser.py
+++ b/src/panoptes/pocs/focuser/focuser.py
@@ -370,7 +370,7 @@ class AbstractFocuser(PanBase, metaclass=ABCMeta):
                 raise err
 
         # Take an image before focusing, grab a thumbnail from the centre and add it to the plot
-        initial_fn = f"{initial_focus}_{focus_type}_initial.{self._camera.file_extension}"
+        initial_fn = f"{initial_focus}-{focus_type}-initial.{self._camera.file_extension}"
         initial_path = os.path.join(file_path_root, initial_fn)
 
         try:
@@ -410,7 +410,7 @@ class AbstractFocuser(PanBase, metaclass=ABCMeta):
             encoder_position = self.move_to(position)
             focus_positions[i] = encoder_position
 
-            focus_fn = f"{encoder_position}_{i:02d}.{self._camera.file_extension}"
+            focus_fn = f"{encoder_position}-{i:02d}.{self._camera.file_extension}"
             file_path = os.path.join(file_path_root, focus_fn)
 
             # Take exposure.
@@ -495,7 +495,7 @@ class AbstractFocuser(PanBase, metaclass=ABCMeta):
         final_focus = self.move_to(best_focus)
 
         # Get final thumbnail.
-        final_fn = f"{final_focus}_{focus_type}_final.{self._camera.file_extension}"
+        final_fn = f"{final_focus}-{focus_type}-final.{self._camera.file_extension}"
         file_path = os.path.join(file_path_root, final_fn)
         try:
             final_thumbnail = self._camera.get_thumbnail(seconds, file_path, thumbnail_size, keep_file=True)

--- a/src/panoptes/pocs/focuser/focuser.py
+++ b/src/panoptes/pocs/focuser/focuser.py
@@ -184,7 +184,7 @@ class AbstractFocuser(PanBase, metaclass=ABCMeta):
                   merit_function_kwargs=None,
                   mask_dilations=None,
                   coarse=False,
-                  make_plots=None,
+                  make_plots=False,
                   blocking=False):
         """
         Focuses the camera using the specified merit function. Optionally performs
@@ -214,9 +214,9 @@ class AbstractFocuser(PanBase, metaclass=ABCMeta):
                 saturated pixel mask (determine size of masked regions), default 10
             coarse (bool, optional): Whether to perform a coarse focus, otherwise will perform
                 a fine focus. Default False.
-            make_plots (bool, optional: Whether to write focus plots to images folder. If not
+            make_plots (bool, optional): Whether to write focus plots to images folder. If not
                 given will fall back on value of `autofocus_make_plots` set on initialisation,
-                & if it wasn't set then will default to False.
+                and if it wasn't set then will default to False.
             blocking (bool, optional): Whether to block until autofocus complete, default False.
 
         Returns:
@@ -514,7 +514,6 @@ class AbstractFocuser(PanBase, metaclass=ABCMeta):
                 focus_range = np.arange(focus_positions[fitting_indices[0]], focus_positions[fitting_indices[1]] + 1)
                 fit_line = fit(focus_range)
                 line_fit = [focus_range, fit_line]
-
 
             plot_title = f'{self._camera} {focus_type} focus at {start_time}'
 

--- a/src/panoptes/pocs/tests/test_camera.py
+++ b/src/panoptes/pocs/tests/test_camera.py
@@ -579,6 +579,15 @@ def test_autofocus_keep_files(camera, patterns, counter):
     assert len(glob.glob(patterns['final'])) == counter['value']
 
 
+def test_autofocus_no_darks(camera, patterns, counter):
+    if camera.focuser is None:
+        pytest.skip("Camera does not have a focuser")
+    autofocus_event = camera.autofocus(keep_files=True, take_dark=False)
+    autofocus_event.wait()
+    counter['value'] += 1
+    assert len(glob.glob(patterns['final'])) == counter['value']
+
+
 def test_autofocus_no_size(camera):
     try:
         initial_focus = camera.focuser.position

--- a/src/panoptes/pocs/tests/test_camera.py
+++ b/src/panoptes/pocs/tests/test_camera.py
@@ -579,15 +579,6 @@ def test_autofocus_keep_files(camera, patterns, counter):
     assert len(glob.glob(patterns['final'])) == counter['value']
 
 
-def test_autofocus_no_darks(camera, patterns, counter):
-    if camera.focuser is None:
-        pytest.skip("Camera does not have a focuser")
-    autofocus_event = camera.autofocus(keep_files=True, take_dark=False)
-    autofocus_event.wait()
-    counter['value'] += 1
-    assert len(glob.glob(patterns['final'])) == counter['value']
-
-
 def test_autofocus_no_size(camera):
     try:
         initial_focus = camera.focuser.position

--- a/src/panoptes/pocs/tests/test_camera.py
+++ b/src/panoptes/pocs/tests/test_camera.py
@@ -91,12 +91,12 @@ def counter(camera):
 
 @pytest.fixture(scope='module')
 def patterns(camera, images_dir):
-    patterns = {'final': os.path.join(images_dir, 'focus', camera.uid, '*',
-                                      ('*_final.' + camera.file_extension)),
-                'fine_plot': os.path.join(images_dir, 'focus', camera.uid, '*',
-                                          'fine_focus.png'),
-                'coarse_plot': os.path.join(images_dir, 'focus', camera.uid, '*',
-                                            'coarse_focus.png')}
+    base_dir = os.path.join(images_dir, 'focus', camera.uid, '*')
+    patterns = {
+        'final': os.path.join(base_dir, ('*-final.' + camera.file_extension)),
+        'fine_plot': os.path.join(base_dir, 'fine-focus.png'),
+        'coarse_plot': os.path.join(base_dir, 'coarse-focus.png')
+    }
     return patterns
 
 

--- a/src/panoptes/pocs/utils/plotting.py
+++ b/src/panoptes/pocs/utils/plotting.py
@@ -1,0 +1,93 @@
+import gc
+
+import matplotlib.pyplot as plt
+from matplotlib.colors import LogNorm
+
+from panoptes.utils.images.plot import get_palette, add_colorbar
+from panoptes.pocs.utils.logger import get_logger
+
+logger = get_logger()
+
+
+def make_autofocus_plot(output_path,
+                        initial_thumbnail,
+                        final_thumbnail,
+                        initial_focus,
+                        final_focus,
+                        focus_positions,
+                        metrics,
+                        merit_function,
+                        line_fit=None,
+                        plot_title='Autofocus Plot',
+                        plot_width=9,  # inches
+                        plot_height=18,  # inches
+                        ):
+    """Make autofocus plots.
+
+    This will make three plots, the top and bottom plots showing the initial and
+    final thumbnail, respectively.  The middle plot will contain the scatter plot
+    for the `metrics` for the given `focus_positions`.
+
+    Args:
+        output_path (str): Path for saving plot.
+        initial_thumbnail (np.array): The data for the initial thumbnail.
+        final_thumbnail (np.array): The data for the final thumbnail.
+        initial_focus (int): The initial focus position.
+        final_focus (int): The final focus position.
+        focus_positions (np.array): An array of `int` corresponding the focus positions.
+        metrics (np.array): An array of `float` corresponding to the measured metrics.
+        merit_function (str): The name of the merit function used to produce the metrics.
+        line_fit (tuple(np.array, np.array)): A tuple for the fitted line. The
+            first entry should be an array of `int` used to calculate fit, the second
+            entry should be an array of the fitted values.
+        plot_title (str): Title to use for plot
+        plot_width (int): The plot width in inches.
+        plot_height (int): The plot height in inches.
+
+    Returns:
+        str: Full path the saved plot.
+    """
+    fig, axes = plt.subplots(3, 1)
+    fig.set_size_inches(plot_width, plot_height)
+
+    # Initial thumbnail.
+    ax0 = axes[0]
+    im0 = ax0.imshow(initial_thumbnail, interpolation='none', cmap=get_palette(), norm=LogNorm())
+    add_colorbar(im0)
+    ax0.set_title(f'Initial focus position: {initial_focus}')
+
+    # Focus positions scatter plot.
+    ax1 = axes[1]
+    ax1.plot(focus_positions, metrics, 'bo', label=f'{merit_function}')
+    # Line fit.
+    if line_fit:
+        ax1.plot(line_fit[0], line_fit[1], 'b-', label='Polynomial fit')
+
+    # ax1.set_xlim(focus_positions[0] - focus_step / 2, focus_positions[-1] + focus_step / 2)
+    u_limit = 1.10 * metrics.max()
+    l_limit = min(0.95 * metrics.min(), 1.05 * metrics.min())
+    ax1.set_ylim(l_limit, u_limit)
+    ax1.vlines(initial_focus, l_limit, u_limit, colors='k', linestyles=':', label='Initial focus')
+    ax1.vlines(final_focus, l_limit, u_limit, colors='k', linestyles='--', label='Best focus')
+
+    ax1.set_xlabel('Focus position')
+    ax1.set_ylabel('Focus metric')
+
+    ax1.set_title(plot_title)
+    ax1.legend()
+
+    # Final thumbnail plot.
+    ax2 = axes[2]
+    im2 = ax2.imshow(final_thumbnail, interpolation='none', cmap=get_palette(), norm=LogNorm())
+    add_colorbar(im2)
+    ax2.set_title(f'Final focus position: {final_focus}')
+
+    fig.savefig(output_path, transparent=False, bbox_inches='tight')
+
+    # Close, close, close, and close.
+    plt.cla()
+    plt.clf()
+    plt.close(fig)
+    gc.collect()
+
+    return output_path


### PR DESCRIPTION
* Move the autofocus plotting to a separate file.
* Super dooper explicitly close the figure (closes #1028).
* Logging call cleanups.
* Add default param to config file for making autofocus plots (closes #925).
* Make sure thumbnail is not bigger than image (closes #846 ).
* **Change output filenames for consistency**

## Related Issue
Closes #1028 
Closes #925 
Closes #846 

## How Has This Been Tested?
It hasn't!!  We currently don't save the focus images or data in a way that would allow this to be easily reproduced.