### PR TITLE
Return `readout_thread` from `take_exposure`

### DIFF
--- a/src/panoptes/pocs/camera/camera.py
+++ b/src/panoptes/pocs/camera/camera.py
@@ -441,9 +441,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
                 the exposure, if True will block until it completes and file exists.
 
         Returns:
-            threading.Event: Event that indicates an exposure is in progress.
-                Will be set to False when exposure is complete.
-
+            threading.Thread: The readout thread, which joins when readout has finished.
         """
         self._exposure_error = None
 

--- a/src/panoptes/pocs/camera/camera.py
+++ b/src/panoptes/pocs/camera/camera.py
@@ -468,7 +468,8 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
                                       self.filterwheel.filter_name(self.filterwheel._dark_position))
                 except (AttributeError, error.NotFound):
                     # No filterwheel, or no opaque filter (dark_position not set)
-                    self.logger.warning("Taking dark exposure without shutter or opaque filter. Is the lens cap on?")
+                    self.logger.warning("Taking dark exposure without shutter or opaque filter."
+                                        " Is the lens cap on?")
             else:
                 with suppress(AttributeError, error.NotFound):
                     # Ignoring exceptions from no filterwheel, or no last light position
@@ -516,7 +517,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
                 time.sleep(0.1)
             self.logger.debug(f"Blocking complete on {self} for filename={filename!r}")
 
-        return self._is_exposing_event
+        return readout_thread
 
     def process_exposure(self,
                          metadata,

--- a/src/panoptes/pocs/tests/test_camera.py
+++ b/src/panoptes/pocs/tests/test_camera.py
@@ -461,7 +461,7 @@ def test_exposure_timeout(camera, tmpdir, caplog):
     camera._timeout = 0.01
     # This should result in a timeout error in the poll thread, but the exception won't
     # be seen in the main thread. Can check for logged error though.
-    exposure_event = camera.take_exposure(seconds=2.0, filename=fits_path)
+    readout_thread = camera.take_exposure(seconds=2.0, filename=fits_path)
 
     # Wait for it all to be over.
     time.sleep(4)
@@ -471,8 +471,8 @@ def test_exposure_timeout(camera, tmpdir, caplog):
     # Should be no data file, camera should not be exposing, and exposure event should be set
     assert not os.path.exists(fits_path)
     assert not camera.is_exposing
-    assert exposure_event is camera._is_exposing_event
-    assert not exposure_event.is_set()
+    assert not readout_thread.is_alive()
+    assert not camera._is_exposing_event.is_set()
 
     # Reset camera because it's scoped on a module level
     camera._timeout = original_timeout

--- a/src/panoptes/pocs/tests/test_filterwheel.py
+++ b/src/panoptes/pocs/tests/test_filterwheel.py
@@ -173,12 +173,12 @@ def test_move_exposing(tmpdir):
     sim_camera = SimCamera(filterwheel={'model': 'panoptes.pocs.filterwheel.simulator.FilterWheel',
                                         'filter_names': ['one', 'deux', 'drei', 'quattro']})
     fits_path = str(tmpdir.join('test_exposure.fits'))
-    exp_event = sim_camera.take_exposure(filename=fits_path, seconds=0.1)
+    readout_thread = sim_camera.take_exposure(filename=fits_path, seconds=0.1)
     with pytest.raises(error.PanError):
         # Attempt to move while camera is exposing
         sim_camera.filterwheel.move_to(2, blocking=True)
     assert sim_camera.filterwheel.position == 1  # Should not have moved
-    exp_event.wait()
+    readout_thread.join()
 
 
 def test_is_moving(filterwheel):


### PR DESCRIPTION
Huntsman remote cameras need to know when cameras have finished exposing and readout has completed. At the moment, this is not possible because `camera.take_exposure` returns `camera._is_exposing_event`, which generally clears before readout has finished. 

This solution simply returns the `readout_thread` rather than the `camera._is_exposing_event`, requiring no further additions to the code apart from some minor changes to the tests.

## Related Issue
#1031 

## How Has This Been Tested?
`POCS` unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
