### PR TITLE
Autofocus import fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ Breaking
 Bug fixes
 ~~~~~~~~~
 
+* Fix incorrect import of autofocus plots. (@wtgee #1034)
 * DSLR simulator cameras properly override the cooling defaults. (@wtgee #1001)
 * Stability checks for cooled cameras so they are only marked ``ready`` when cooled condition has stabilized. (@danjampro #990)
 * Properly closed the autofocus matplotlib figures. (@wtgee #1029)

--- a/src/panoptes/pocs/focuser/focuser.py
+++ b/src/panoptes/pocs/focuser/focuser.py
@@ -14,7 +14,7 @@ from panoptes.utils import current_time
 from panoptes.utils.images import focus as focus_utils
 from panoptes.utils.images import mask_saturated
 
-from src.panoptes.pocs.utils.plotting import make_autofocus_plot
+from panoptes.pocs.utils.plotting import make_autofocus_plot
 
 
 class AbstractFocuser(PanBase, metaclass=ABCMeta):


### PR DESCRIPTION
Fix import of plotting code, which was introduced in #1029 

## Related Issue
Closes #1033 

## How Has This Been Tested?
We are missing good tests for the focuser code, so this was discovered by @danjampro during real-world tests.

