### PR TITLE
Add google cloud sdk to Docker build

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Changelog
 Added
 ~~~~~
 
+* Add the `google-cloud-sdk` to default Docker build. Required for uploading data. (@wtgee #1036)
 * Ability to specify autofocus plots in config file. (@wtgee #1029)
 * A "developer" version of the ``panoptes-pocs`` docker image is cloudbuilt automatically on merge with ``develop``. (@wtgee #1010)
 * Better error checking in cameras, including ability to store error. (@AnthonyHorton #1007)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,6 +51,9 @@ RUN "${PANDIR}/conda/bin/pip" install -e ".${pip_extras}" && \
     sudo apt-get autoclean --yes && \
     sudo apt-get --yes clean && \
     sudo rm -rf /var/lib/apt/lists/* && \
+    # Install the Google Cloud utils.
+    "${PANDIR}/conda/bin/conda" install google-cloud-sdk && \
+    # Cleanup conda.
     "${PANDIR}/conda/bin/conda" clean -tipy
 
 USER root

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,7 +75,6 @@ developer =
     pandas
     tabulate
 google =
-    google-cloud-sdk
     google-cloud-storage
 plotting =
     altair

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,6 +75,7 @@ developer =
     pandas
     tabulate
 google =
+    google-cloud-sdk
     google-cloud-storage
 plotting =
     altair


### PR DESCRIPTION
* Add the google-cloud-sdk to the default build.

## Description
The default Docker build (`develop`) needs access to `gcloud` and `gsutil` for uploading of data to the cloud. This adds the library to the `google` extras install option, which is included in the default build.

