### PR TITLE
Install gsuitl with google tools

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Changelog
 Added
 ~~~~~
 
-* Add the `google-cloud-sdk` to default Docker build. Required for uploading data. (@wtgee #1036)
+* Add the `gsutil` to `google` install options. Required for uploading data. (@wtgee #1036, #1037)
 * Ability to specify autofocus plots in config file. (@wtgee #1029)
 * A "developer" version of the ``panoptes-pocs`` docker image is cloudbuilt automatically on merge with ``develop``. (@wtgee #1010)
 * Better error checking in cameras, including ability to store error. (@AnthonyHorton #1007)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,8 +51,6 @@ RUN "${PANDIR}/conda/bin/pip" install -e ".${pip_extras}" && \
     sudo apt-get autoclean --yes && \
     sudo apt-get --yes clean && \
     sudo rm -rf /var/lib/apt/lists/* && \
-    # Install the Google Cloud utils.
-    "${PANDIR}/conda/bin/conda" install google-cloud-sdk && \
     # Cleanup conda.
     "${PANDIR}/conda/bin/conda" clean -tipy
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,7 @@ exclude =
 
 [options.extras_require]
 # Add here additional requirements for extra features, to install with:
-# `pip install POCS[PDF]` like:
+# `pip install POCS[google,testing]`:
 developer =
     google-cloud-sdk
     google-cloud-bigquery[pandas,pyarrow]
@@ -76,6 +76,7 @@ developer =
     tabulate
 google =
     google-cloud-storage
+    gsutil
 plotting =
     altair
     bokeh


### PR DESCRIPTION
This replaces the `google-cloud-sdk` with `gsutil` directly for ease of install on `arm` architectures (namely the Raspberry Pi).

