### PR TITLE
Update Bisque mount status

### DIFF
--- a/src/panoptes/pocs/mount/bisque.py
+++ b/src/panoptes/pocs/mount/bisque.py
@@ -212,7 +212,7 @@ class Mount(AbstractMount):
                     'ra': mount_coords[0], 'dec': mount_coords[1]}, timeout=timeout)
                 success = response['success']
                 if success:
-                    while not self.is_slewing:
+                    while self.is_slewing:
                         time.sleep(2)
                 else:
                     raise error.PanError(f"Slewing was unsuccessful: {response['response']}")

--- a/src/panoptes/pocs/mount/bisque.py
+++ b/src/panoptes/pocs/mount/bisque.py
@@ -30,6 +30,40 @@ class Mount(AbstractMount):
         self.template_dir = template_dir
 
     ##########################################################################
+    # Properties
+    ##########################################################################
+
+    @property
+    def is_parked(self):
+        """ bool: Mount parked status. """
+        self._update_status()
+        return self._is_parked
+
+    @property
+    def is_home(self):
+        """ bool: Mount home status. """
+        self._update_status()
+        return self._is_home
+
+    @property
+    def is_tracking(self):
+        """ bool: Mount tracking status.  """
+        self._update_status()
+        return self._is_tracking
+
+    @property
+    def is_slewing(self):
+        """ bool: Mount slewing status. """
+        self._update_status()
+        return self._is_slewing
+
+    @property
+    def at_mount_park(self):
+        """ bool: Mount slewing status. """
+        self._update_status()
+        return self._at_mount_park
+
+    ##########################################################################
     # Methods
     ##########################################################################
 
@@ -172,16 +206,16 @@ class Mount(AbstractMount):
             mount_coords = self._skycoord_to_mount_coord(self._target_coordinates)
 
             # Send coordinates to mount
+            self.logger.info(f"Slewing to target coordinates: {mount_coords}")
             try:
                 response = self.query('slew_to_coordinates', {
-                    'ra': mount_coords[0],
-                    'dec': mount_coords[1],
-                }, timeout=timeout)
+                    'ra': mount_coords[0], 'dec': mount_coords[1]}, timeout=timeout)
                 success = response['success']
                 if success:
-                    while self.is_slewing:
+                    while not self.is_slewing:
                         time.sleep(2)
-
+                else:
+                    raise error.PanError(f"Slewing was unsuccessful: {response['response']}")
             except Exception as e:
                 self.logger.warning(f"Problem slewing to mount coordinates: {mount_coords} {e}")
 

--- a/src/panoptes/pocs/mount/mount.py
+++ b/src/panoptes/pocs/mount/mount.py
@@ -171,6 +171,11 @@ class AbstractMount(PanBase):
         return self._is_parked
 
     @property
+    def at_mount_park(self):
+        """ bool: True if mount is at park position. """
+        return self._at_mount_park
+
+    @property
     def is_home(self):
         """ bool: Mount home status. """
         return self._is_home
@@ -631,7 +636,7 @@ class AbstractMount(PanBase):
         else:
             self.logger.warning('Problem with slew_to_park')
 
-        while not self._at_mount_park:
+        while not self.at_mount_park:
             self.status
             time.sleep(2)
 


### PR DESCRIPTION
The Bisque mount status properties (`is_parked`, `is_tacking`, `is_slewing` etc) do not get updated unless `mount._update_status()` is explicitly called. This led to some errors when calling `slewing_to_target`, which was not blocking properly. The fix is to override the properties in `bisque.Mount` to automatically update the status in the properties.

## How Has This Been Tested?
Unit tests and on Huntsman.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)