### PR TITLE
Fix fractional seconds in logging timestamp

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -25,8 +25,8 @@ logger.enable('panoptes')
 # Add a level above TRACE and below DEBUG
 logger.level("testing", no=15, icon="🤖", color="<LIGHT-BLUE><white>")
 log_fmt = "<lvl>{level:.1s}</lvl> " \
-          "<light-blue>{time:MM-DD HH:mm:ss.ss!UTC}</>" \
-          "<blue> ({time:HH:mm:ss.ss})</> " \
+          "<light-blue>{time:MM-DD HH:mm:ss.SSS!UTC}</>" \
+          "<blue> ({time:HH:mm:ss zz})</> " \
           "| <c>{name} {function}:{line}</c> | " \
           "<lvl>{message}</lvl>"
 

--- a/src/panoptes/pocs/utils/logger.py
+++ b/src/panoptes/pocs/utils/logger.py
@@ -86,7 +86,7 @@ def get_logger(console_log_file='panoptes.log',
             loguru_logger.remove(0)
 
         stderr_format = "<lvl>{level:.1s}</lvl> " \
-                        "<light-blue>{time:MM-DD HH:mm:ss.ss!UTC}</> " \
+                        "<light-blue>{time:MM-DD HH:mm:ss.SSS!UTC}</> " \
                         "<lvl>{message}</lvl>"
 
         stderr_id = loguru_logger.add(

--- a/src/panoptes/pocs/utils/logger.py
+++ b/src/panoptes/pocs/utils/logger.py
@@ -19,8 +19,8 @@ class PanLogger:
         self.padding = 0
         # Level Time_UTC Time_Local dynamic_padding Message
         self.fmt = "<lvl>{level:.1s}</lvl> " \
-                   "<light-blue>{time:MM-DD HH:mm:ss.ss!UTC}</>" \
-                   " <blue>({time:HH:mm:ss.ss})</> " \
+                   "<light-blue>{time:MM-DD HH:mm:ss.SSS!UTC}</>" \
+                   " <blue>({time:HH:mm:ss zz})</> " \
                    "| <c>{name} {function}:{line}{extra[padding]}</c> | " \
                    "<lvl>{message}</lvl>\n"
         self.handlers = dict()


### PR DESCRIPTION
Fixing the format for the fractional seconds in the logging call, which was repeating the seconds.

For the UTC time show the ms, for the local show the timezone name.

Formats here: https://loguru.readthedocs.io/en/stable/api/logger.html#time

## Description
Small change to time formatting.

## How Has This Been Tested?
Visual inspection

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)