### PR TITLE
Increased timeout for waiting for response from focuser. Fixed some indentations. 

### DIFF
--- a/src/panoptes/pocs/focuser/serial.py
+++ b/src/panoptes/pocs/focuser/serial.py
@@ -84,7 +84,7 @@ class AbstractSerialFocuser(AbstractFocuser):
             self._serial_port.bytesize = serial.EIGHTBITS
             self._serial_port.parity = serial.PARITY_NONE
             self._serial_port.stopbits = serial.STOPBITS_ONE
-            self._serial_port.timeout = 2.0
+            self._serial_port.timeout = self.timeout
             self._serial_port.xonxoff = False
             self._serial_port.rtscts = False
             self._serial_port.dsrdtr = False


### PR DESCRIPTION
Added timeout as a parameter to the focuser base class and increased it to 5 instead of 2.

## Description
This PR adds timeout as a parameter to the focuser base class instead of having it harcoded. It changes the timeout from 2 to 5 seconds (as default). This also fixes some incorrect indentations

## How Has This Been Tested?
Local tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
