### PR TITLE
Add option to skip solve WCS during analyzing_image

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Added
   * ``cameras.defaults.compress_fits`` if FITS files should be fpacked. Default True.
   * ``cameras.defaults.record_observations`` if observation metadata should be recorded. Default True.
   * ``cameras.defaults.make_pretty_images`` to make jpgs from images. Default True.
-  * ``cameras.defaults.analyize_recent_offset`` to compare World Coordinate System (WCS) to last
+  * ``cameras.defaults.analyze_recent_offset`` to compare World Coordinate System (WCS) to last
 image. Default True.
 
 Breaking

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ Added
   * ``cameras.defaults.compress_fits`` if FITS files should be fpacked. Default True.
   * ``cameras.defaults.record_observations`` if observation metadata should be recorded. Default True.
   * ``cameras.defaults.make_pretty_images`` to make jpgs from images. Default True.
+  * ``cameras.defaults.analyize_recent_offset`` to compare World Coordinate System (WCS) to last
+image. Default True.
 
 Breaking
 ~~~~~~~~

--- a/conf_files/pocs.yaml
+++ b/conf_files/pocs.yaml
@@ -147,6 +147,7 @@ observations:
   record_observations: True
   make_pretty_images: True
   keep_jpgs: True
+  analyize_recent_offset: True
 
 ######################## Google Network ########################################
 # By default all images are stored on googlecloud servers and we also

--- a/conf_files/pocs.yaml
+++ b/conf_files/pocs.yaml
@@ -147,7 +147,7 @@ observations:
   record_observations: True
   make_pretty_images: True
   keep_jpgs: True
-  analyize_recent_offset: True
+  analyze_recent_offset: True
 
 ######################## Google Network ########################################
 # By default all images are stored on googlecloud servers and we also

--- a/src/panoptes/pocs/state/states/default/analyzing.py
+++ b/src/panoptes/pocs/state/states/default/analyzing.py
@@ -9,7 +9,8 @@ def on_enter(event_data):
     pocs.next_state = 'tracking'
     try:
 
-        pocs.observatory.analyze_recent()
+        if pocs.get_config('observations.analyize_recent_offset', default=True):
+            pocs.observatory.analyze_recent()
 
         if pocs.get_config('actions.FORCE_RESCHEDULE'):
             pocs.say("Forcing a move to the scheduler")

--- a/src/panoptes/pocs/state/states/default/analyzing.py
+++ b/src/panoptes/pocs/state/states/default/analyzing.py
@@ -9,7 +9,7 @@ def on_enter(event_data):
     pocs.next_state = 'tracking'
     try:
 
-        if pocs.get_config('observations.analyize_recent_offset', default=True):
+        if pocs.get_config('observations.analyze_recent_offset', default=True):
             pocs.observatory.analyze_recent()
 
         if pocs.get_config('actions.FORCE_RESCHEDULE'):

--- a/tests/testing.yaml
+++ b/tests/testing.yaml
@@ -66,7 +66,7 @@ cameras:
     compress_fits: True
     make_pretty_images: True
     keep_jpgs: False
-    analyize_recent_offset: True
+    analyze_recent_offset: True
     readout_time: 0.5  # seconds
     timeout: 10  # seconds
     filter_type: RGGB

--- a/tests/testing.yaml
+++ b/tests/testing.yaml
@@ -66,6 +66,7 @@ cameras:
     compress_fits: True
     make_pretty_images: True
     keep_jpgs: False
+    analyize_recent_offset: True
     readout_time: 0.5  # seconds
     timeout: 10  # seconds
     filter_type: RGGB


### PR DESCRIPTION
Solving for WCS may not be needed in all cases, so adding a configuration option to disable it. By default it will still happen.

## Description
Simply added an option `observations.analyize_recent_offset`. When set to False (not the default), it will skip the WCS solve field step after an image is taking. 

## Related Issue
See huntsman slack channel for discussion.

## How Has This Been Tested?
Trying to install on MacOS to test. github tests ran OK.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
