### PR TITLE
Set FW light position

### DIFF
--- a/src/panoptes/pocs/filterwheel/filterwheel.py
+++ b/src/panoptes/pocs/filterwheel/filterwheel.py
@@ -222,14 +222,13 @@ class AbstractFilterWheel(PanBase, metaclass=ABCMeta):
 
         if new_position == self.position:
             # Already at requested position, don't go nowhere.
-            self.logger.debug(f"{self} already at position {new_position}" + \
+            self.logger.debug(f"{self} already at position {new_position}"
                               f" ({self.filter_name(new_position)})")
             return self._move_event
 
-        if new_position == self._dark_position:
-            # Moving from light into darkness... Store current position so we can revert
-            # back to it if requested with move_to_light_position()
-            self._last_light_position = self.position
+        if new_position != self._dark_position:
+            # Store current position so we can revert back with move_to_light_position()
+            self._last_light_position = new_position
 
         self.logger.info("Moving {} to position {} ({})".format(
             self, new_position, self.filter_name(new_position)))

--- a/src/panoptes/pocs/filterwheel/filterwheel.py
+++ b/src/panoptes/pocs/filterwheel/filterwheel.py
@@ -226,8 +226,10 @@ class AbstractFilterWheel(PanBase, metaclass=ABCMeta):
                               f" ({self.filter_name(new_position)})")
             return self._move_event
 
-        if new_position != self._dark_position:
-            # Store current position so we can revert back with move_to_light_position()
+        # Store current position so we can revert back with move_to_light_position()
+        if new_position == self._dark_position:
+            self._last_light_position = self.position
+        else:
             self._last_light_position = new_position
 
         self.logger.info("Moving {} to position {} ({})".format(


### PR DESCRIPTION
Fixes the (annoying) problem that a light position is not set unless the FW firsts moves to a dark position. This causes errors to be raised unnecessarily. The solution is to set last light position to the new position in `move_to`, provided it is not the dark position.

## How Has This Been Tested?
Unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)