### PR TITLE
Fix autofocus make_plots

### DIFF
--- a/src/panoptes/pocs/focuser/focuser.py
+++ b/src/panoptes/pocs/focuser/focuser.py
@@ -188,7 +188,7 @@ class AbstractFocuser(PanBase, metaclass=ABCMeta):
                   merit_function_kwargs=None,
                   mask_dilations=None,
                   coarse=False,
-                  make_plots=False,
+                  make_plots=None,
                   blocking=False):
         """
         Focuses the camera using the specified merit function. Optionally performs


### PR DESCRIPTION
Default value for `make_plots` is `False`, which means plots are not made even if `autofocus_make_plots=True`.