### PR TITLE
Fix focus plot arg in camera

### DIFF
--- a/src/panoptes/pocs/camera/camera.py
+++ b/src/panoptes/pocs/camera/camera.py
@@ -627,7 +627,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
                   merit_function_kwargs=None,
                   mask_dilations=None,
                   coarse=False,
-                  make_plots=False,
+                  make_plots=None,
                   blocking=False,
                   *args, **kwargs):
         """
@@ -659,7 +659,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
             coarse (bool, optional): Whether to perform a coarse focus, otherwise will perform
                 a fine focus. Default False.
             make_plots (bool, optional: Whether to write focus plots to images folder, default
-                False.
+                behaviour is to check the focuser autofocus_make_plots attribute.
             blocking (bool, optional): Whether to block until autofocus complete, default False.
 
         Returns:


### PR DESCRIPTION
Fixes the optional `make_plots` argument to `camera.autofocus` so it uses the `focusers` default behaviour by default.

## How Has This Been Tested?
Unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
