### PR TITLE
Add command lock to bisque mount

### DIFF
--- a/src/panoptes/pocs/mount/bisque.py
+++ b/src/panoptes/pocs/mount/bisque.py
@@ -126,8 +126,11 @@ class Mount(AbstractMount):
         return self.is_initialized
 
     def query(self, *args, **kwargs):
-        """ Override the query method to use the command lock. This is required because TheSkyX
-        cannot handle simulataneous commands."""
+        """ Override the query method to use the command lock.
+
+        This is required because TheSkyX cannot handle simulataneous commands. This function will
+        block until the lock is released.
+        """
         with self._command_lock:
             return super().query(*args, **kwargs)
 

--- a/src/panoptes/pocs/mount/mount.py
+++ b/src/panoptes/pocs/mount/mount.py
@@ -269,14 +269,13 @@ class AbstractMount(PanBase):
 
     def set_target_coordinates(self, coords):
         """ Sets the RA and Dec for the mount's current target.
+
         Args:
-            coords (astropy.coordinates.SkyCoord): coordinates specifying target location.
+            coords (astropy.coordinates.SkyCoord): coordinates specifying target location
+
         Returns:
             bool:  Boolean indicating success
         """
-        if not isinstance(coords, SkyCoord):
-            raise TypeError("coords should be an instance of astropy.coordinates.SkyCoord,"
-                            f" got {type(coords)}.")
         target_set = False
 
         # Save the skycoord coordinates
@@ -292,9 +291,9 @@ class AbstractMount(PanBase):
             self.query('set_dec', mount_coords[1])
             target_set = True
         except Exception as e:
-            raise error.PanError(f"Unable to set mount coordinates: {mount_coords}: {e!r}")
+            self.logger.warning(f"Problem setting mount coordinates: {mount_coords} {e!r}")
 
-        self.logger.debug(f'Mount set target coordinates: {target_set}.')
+        self.logger.debug(f'Mount simulator set target coordinates: {target_set}')
         return target_set
 
     def get_current_coordinates(self):
@@ -472,7 +471,7 @@ class AbstractMount(PanBase):
     ##################################################################################################
 
     def slew_to_coordinates(self, coords, ra_rate=15.0, dec_rate=0.0, *args, **kwargs):
-        """ Convenience function to set target coordinates and slew over to them.
+        """ Slews to given coordinates.
 
         Note:
             Slew rates are not implemented yet.
@@ -487,8 +486,19 @@ class AbstractMount(PanBase):
         Returns:
             bool: indicating success
         """
-        self.set_target_coordinates(coords)
-        self.slew_to_target(*args, **kwargs)
+        if not isinstance(coords, SkyCoord):
+            raise TypeError("coords should be an instance of astropy.coordinates.SkyCoord,"
+                            f" got {type(coords)}.")
+        response = 0
+
+        if not self.is_parked:
+            # Set the coordinates
+            if self.set_target_coordinates(coords):
+                response = self.slew_to_target(*args, **kwargs)
+            else:
+                self.logger.warning("Could not set target_coordinates")
+
+        return response
 
     def home_and_park(self, *args, **kwargs):
         """ Convenience method to first slew to the home position and then park.
@@ -531,35 +541,34 @@ class AbstractMount(PanBase):
         success = False
 
         if self.is_parked:
-            raise error.PanError("Could not slew to target because mount is parked.")
-
+            self.logger.info("Mount is parked")
         elif not self.has_target:
-            raise error.PanError("Could not slew to target because target coordinates are not set.")
-
+            self.logger.info("Target Coordinates not set")
         else:
-            self.logger.debug('Slewing to target...')
+            self.logger.debug('Slewing to target')
             success = self.query('slew_to_target')
-            self.logger.debug("Mount response to slew command: {success}")
 
-            if not success:
-                raise error.PanError("Unable to slew to target.")
+            self.logger.debug("Mount response: {}".format(success))
+            if success:
+                if blocking:
+                    # Set up the timeout timer
+                    self.logger.debug(f'Setting slew timeout timer for {timeout} sec')
+                    timeout_timer = CountdownTimer(timeout)
+                    block_time = 3  # seconds
 
-            if blocking:
-                # Set up the timeout timer
-                self.logger.debug(f'Setting slew timeout timer for {timeout} seconds.')
-                timeout_timer = CountdownTimer(timeout)
-                block_time = 3  # seconds
+                    while self.is_tracking is False:
+                        if timeout_timer.expired():
+                            self.logger.warning(f'slew_to_target timout: {timeout} seconds')
+                            raise error.Timeout('Problem slewing to target')
 
-                while self.is_tracking is False:
+                        self.logger.debug(f'Slewing to target, sleeping for {block_time} seconds')
+                        timeout_timer.sleep(max_sleep=block_time)
 
-                    if timeout_timer.expired():
-                        self.logger.warning(f'slew_to_target timout: {timeout} seconds.')
-                        raise error.Timeout("Timeout while slewing to target.")
+                    self.logger.debug(f'Done with slew_to_target block')
+            else:
+                self.logger.warning('Problem with slew_to_target')
 
-                    self.logger.debug(f'Slewing to target, sleeping for {block_time} seconds.')
-                    timeout_timer.sleep(max_sleep=block_time)
-
-                    self.logger.debug('Finished blocking on slew_to_target.')
+        return success
 
     def slew_to_home(self, blocking=False, timeout=180):
         """Slews the mount to the home position.
@@ -579,28 +588,29 @@ class AbstractMount(PanBase):
             blocking (bool, optional): If command should block while slewing to
                 home, default False.
         """
+        response = 0
+
         # Set up the timeout timer
         timeout_timer = CountdownTimer(timeout)
         block_time = 3  # seconds
 
-        if self.is_parked:
-            raise error.PanError("Could not slew to home because mount is parked.")
+        if not self.is_parked:
+            # Reset target coordinates
+            self._target_coordinates = None
+            # Start the slew
+            response = self.query('slew_to_home')
+            if response and blocking:
+                while self.is_home is False:
+                    if timeout_timer.expired():
+                        self.logger.warning(f'slew_to_home timout: {timeout} seconds')
+                        response = 0
+                        break
+                    self.logger.debug(f'Slewing to home, sleeping for {block_time} seconds')
+                    timeout_timer.sleep(max_sleep=block_time)
+        else:
+            self.logger.info('Mount is parked')
 
-        # Reset target coordinates
-        self._target_coordinates = None
-
-        # Start the slew
-        success = self.query('slew_to_home')
-        if not success:
-            raise error.PanError("Unable to slew to home.")
-
-        if blocking:
-            while self.is_home is False:
-                if timeout_timer.expired():
-                    raise error.Timeout("Timeout while slewing to home.")
-
-                self.logger.debug(f'Slewing to home, sleeping for {block_time} seconds.')
-                timeout_timer.sleep(max_sleep=block_time)
+        return response
 
     def slew_to_zero(self, blocking=False):
         """ Calls `slew_to_home` in base class. Can be overridden.  """
@@ -615,20 +625,24 @@ class AbstractMount(PanBase):
         Returns:
             bool: indicating success
         """
+
         self.set_park_coordinates()
         self.set_target_coordinates(self._park_coordinates)
 
-        success = self.query('park')
-        if not success:
-            raise error.PanError("Unable to park mount.")
+        response = self.query('park')
 
-        self.logger.debug('Slewing to park position.')
-        while not self.at_mount_park:  # TODO: Implement timeout
+        if response:
+            self.logger.debug('Slewing to park')
+        else:
+            self.logger.warning('Problem with slew_to_park')
+
+        while not self.at_mount_park:
             self.status
             time.sleep(2)
 
-        self.logger.info('Successfully parked mount.')
         self._is_parked = True
+
+        return response
 
     def unpark(self):
         """ Unparks the mount. Does not do any movement commands but makes them available again.
@@ -636,11 +650,16 @@ class AbstractMount(PanBase):
         Returns:
             bool: indicating success
         """
-        success = self.query('unpark')
-        if not success:
-            raise error.PanError("Unable to unpark mount.")
-        self._is_parked = False
-        self.logger.info('Successfully unparked mount.')
+
+        response = self.query('unpark')
+
+        if response:
+            self._is_parked = False
+            self.logger.debug('Mount unparked')
+        else:
+            self.logger.warning('Problem with unpark')
+
+        return response
 
     def move_direction(self, direction='north', seconds=1.0):
         """ Move mount in specified `direction` for given amount of `seconds`


### PR DESCRIPTION
TheSkyX cannot handle simultaneous commands, which can cause `TheSkyXTimeout` errors which can lead to other errors. The solution is to use a lock to ensure commands are sent one after the other.

## Related Issue
https://github.com/AstroHuntsman/huntsman-pocs/issues/303

## How Has This Been Tested?
Unit tests, will test on Huntsman.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
