### PR TITLE
Silence missing filter name warning for dark observations

### DIFF
--- a/src/panoptes/pocs/camera/camera.py
+++ b/src/panoptes/pocs/camera/camera.py
@@ -379,6 +379,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
                 override the default file naming system.
             blocking (bool): If method should wait for observation event to be complete
                 before returning, default False.
+            dark (bool, optional): Observation exposure is a dark frame, default False.
             **kwargs (dict): Optional keyword arguments (`exptime`, dark)
 
         Returns:

--- a/src/panoptes/pocs/camera/camera.py
+++ b/src/panoptes/pocs/camera/camera.py
@@ -873,7 +873,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
                                       f' {observation.filter_name}: {e!r}')
                     raise (e)
 
-            elif not dark:
+            elif not (dark and observation.filter_name is None):
                 self.logger.warning(f'Filter {observation.filter_name} requested by'
                                     f' observation but {self.filterwheel} is missing that filter, '
                                     f'using {self.filter_type}.')


### PR DESCRIPTION
- Currently a logger call at `info` level is made when an observation is taken without a filter specified (`filter_name=None`).
- Dark observations do not know which filter_name corresponds to the dark position for each camera, so `filter_name=None` is always (and necessarily) specified.
- New behaviour is to log a warning if the observation is not dark and the filter is not None