### PR TITLE
Add optional focus position offsets per filter

### DIFF
--- a/src/panoptes/pocs/camera/camera.py
+++ b/src/panoptes/pocs/camera/camera.py
@@ -358,6 +358,11 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         """ Return True if the camera has a focuser, False if not. """
         return self.focuser is not None
 
+    @property
+    def has_filterwheel(self):
+        """ Return True if the camera has a filterwheel, False if not. """
+        return self.filterwheel is not None
+
     ##################################################################################################
     # Methods
     ##################################################################################################

--- a/src/panoptes/pocs/camera/camera.py
+++ b/src/panoptes/pocs/camera/camera.py
@@ -353,6 +353,11 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         """ Error message from the most recent exposure or None, if there was no error."""
         return self._exposure_error
 
+    @property
+    def has_focuser(self):
+        """ Return True if the camera has a focuser, False if not. """
+        return self.focuser is not None
+
     ##################################################################################################
     # Methods
     ##################################################################################################
@@ -676,7 +681,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         Raises:
             ValueError: If invalid values are passed for any of the focus parameters.
         """
-        if self.focuser is None:
+        if not self.has_focuser:
             self.logger.error("Camera must have a focuser for autofocus!")
             raise AttributeError
 

--- a/src/panoptes/pocs/filterwheel/filterwheel.py
+++ b/src/panoptes/pocs/filterwheel/filterwheel.py
@@ -219,9 +219,7 @@ class AbstractFilterWheel(PanBase, metaclass=ABCMeta):
         if self.camera is not None:
 
             if self.camera.is_exposing:
-                msg = f'Attempt to move filter wheel {self} while camera is exposing, ignoring.'
-                self.logger.error(msg)
-                raise error.PanError(msg)
+                raise error.PanError(f'Attempt to move filter wheel {self} while camera is exposing, ignoring.')
 
             if self.camera.has_focuser:
                 try:

--- a/src/panoptes/pocs/filterwheel/filterwheel.py
+++ b/src/panoptes/pocs/filterwheel/filterwheel.py
@@ -216,16 +216,18 @@ class AbstractFilterWheel(PanBase, metaclass=ABCMeta):
         """
         assert self.is_connected, self.logger.error("Filter wheel must be connected to move")
 
-        if self.camera.has_focuser:
-            try:
-                self._apply_filter_focus_offset(new_position)
-            except Exception as err:
-                self.logger.error(f"Unable to apply focus position offset on {self}: {err!r}")
+        if self.camera is not None:
 
-        if self.camera and self.camera.is_exposing:
-            msg = f'Attempt to move filter wheel {self} while camera is exposing, ignoring.'
-            self.logger.error(msg)
-            raise error.PanError(msg)
+            if self.camera.is_exposing:
+                msg = f'Attempt to move filter wheel {self} while camera is exposing, ignoring.'
+                self.logger.error(msg)
+                raise error.PanError(msg)
+
+            if self.camera.has_focuser:
+                try:
+                    self._apply_filter_focus_offset(new_position)
+                except Exception as err:
+                    self.logger.error(f"Unable to apply focus position offset on {self}: {err!r}")
 
         if self.is_moving:
             msg = f'Attempt to move filter wheel {self} while already moving, ignoring.'

--- a/src/panoptes/pocs/filterwheel/filterwheel.py
+++ b/src/panoptes/pocs/filterwheel/filterwheel.py
@@ -349,7 +349,7 @@ class AbstractFilterWheel(PanBase, metaclass=ABCMeta):
         focus_offset = new_offset - current_offset
 
         self.logger.debug(f"Applying focus position offset of {focus_offset} moving from filter "
-                          f"{new_filter} to {self.current_filter}.")
+                          f"{self.current_filter} to {new_filter}.")
         self.camera.focuser.move_by(focus_offset)
 
     def __str__(self):

--- a/src/panoptes/pocs/filterwheel/filterwheel.py
+++ b/src/panoptes/pocs/filterwheel/filterwheel.py
@@ -219,7 +219,7 @@ class AbstractFilterWheel(PanBase, metaclass=ABCMeta):
         if self.camera.has_focuser:
             try:
                 self._apply_filter_focus_offset(new_position)
-            except error.PanError as err:
+            except Exception as err:
                 self.logger.error(f"Unable to apply focus position offset on {self}: {err!r}")
 
         if self.camera and self.camera.is_exposing:

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -707,15 +707,16 @@ def test_move_filterwheel_focus_offset(camera):
         pytest.skip("Camera does not have a filterwheel.")
     if not camera.has_focuser:
         pytest.skip("Camera does not have a focuser.")
+
     if camera.filterwheel._focus_offsets is None:
-        pytest.skip("Filterwheel does not have focus offsets.")
+        offsets = {}
+    else:
+        offsets = camera.filterwheel._focus_offsets
 
     camera.filterwheel.move_to("one", blocking=True)
 
-    focus_offsets = camera.filterwheel._focus_offsets
-
     for filter_name in camera.filterwheel.filter_names:
-        offset = focus_offsets[filter_name] - focus_offsets[camera.filterwheel.current_filter]
+        offset = offsets.get(filter_name, 0) - offsets.get(camera.filterwheel.current_filter, 0)
         initial_position = camera.focuser.position
         camera.filterwheel.move_to(filter_name, blocking=True)
         new_position = camera.focuser.position

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -700,3 +700,21 @@ def test_autofocus_no_focuser(camera):
         camera.autofocus()
     camera.focuser = focuser
     assert camera.focuser.position == initial_focus
+
+
+def test_move_filterwheel_focus_offset(camera):
+    if not camera.has_filterwheel:
+        pytest.skip("Camera does not have a filterwheel.")
+    if not camera.has_focuser:
+        pytest.skip("Camera does not have a focuser.")
+    if camera._focus_offsets is None:
+        pytest.skip("Camera does not have focus offsets.")
+
+    focus_offsets = camera.filterwheel._focus_offsets
+
+    for filter_name in camera.filterwheel.filter_names:
+        initial_position = camera.focuser.position
+        camera.filterwheel.move_to(filter_name)
+        new_position = camera.focuser.position
+        offset = focus_offsets[filter_name] - focus_offsets[camera.filterwheel.current_filter]
+        assert new_position == initial_position + offset

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -707,8 +707,10 @@ def test_move_filterwheel_focus_offset(camera):
         pytest.skip("Camera does not have a filterwheel.")
     if not camera.has_focuser:
         pytest.skip("Camera does not have a focuser.")
-    if camera._focus_offsets is None:
-        pytest.skip("Camera does not have focus offsets.")
+    if camera.filterwheel._focus_offsets is None:
+        pytest.skip("Filterwheel does not have focus offsets.")
+
+    camera.filterwheel.move_to("one")
 
     focus_offsets = camera.filterwheel._focus_offsets
 

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -715,8 +715,8 @@ def test_move_filterwheel_focus_offset(camera):
     focus_offsets = camera.filterwheel._focus_offsets
 
     for filter_name in camera.filterwheel.filter_names:
+        offset = focus_offsets[filter_name] - focus_offsets[camera.filterwheel.current_filter]
         initial_position = camera.focuser.position
         camera.filterwheel.move_to(filter_name, blocking=True)
         new_position = camera.focuser.position
-        offset = focus_offsets[filter_name] - focus_offsets[camera.filterwheel.current_filter]
         assert new_position == initial_position + offset

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -722,7 +722,7 @@ def test_move_filterwheel_focus_offset(camera):
         camera.filterwheel.move_to(filter_name, blocking=True)
         new_position = camera.focuser.position
 
-        if filter_name in camera.filterwheel.filter_names:
+        if filter_name in offsets.keys():
             assert new_position == initial_position + offset
         else:
             assert new_position == initial_position

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -716,8 +716,13 @@ def test_move_filterwheel_focus_offset(camera):
     camera.filterwheel.move_to("one", blocking=True)
 
     for filter_name in camera.filterwheel.filter_names:
+
         offset = offsets.get(filter_name, 0) - offsets.get(camera.filterwheel.current_filter, 0)
         initial_position = camera.focuser.position
         camera.filterwheel.move_to(filter_name, blocking=True)
         new_position = camera.focuser.position
-        assert new_position == initial_position + offset
+
+        if filter_name in camera.filterwheel.filter_names:
+            assert new_position == initial_position + offset
+        else:
+            assert new_position == initial_position

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -710,13 +710,13 @@ def test_move_filterwheel_focus_offset(camera):
     if camera.filterwheel._focus_offsets is None:
         pytest.skip("Filterwheel does not have focus offsets.")
 
-    camera.filterwheel.move_to("one")
+    camera.filterwheel.move_to("one", blocking=True)
 
     focus_offsets = camera.filterwheel._focus_offsets
 
     for filter_name in camera.filterwheel.filter_names:
         initial_position = camera.focuser.position
-        camera.filterwheel.move_to(filter_name)
+        camera.filterwheel.move_to(filter_name, blocking=True)
         new_position = camera.focuser.position
         offset = focus_offsets[filter_name] - focus_offsets[camera.filterwheel.current_filter]
         assert new_position == initial_position + offset

--- a/tests/testing.yaml
+++ b/tests/testing.yaml
@@ -157,6 +157,12 @@ cameras:
         move_time: 0.1
         timeout: 0.5
         dark_position: blank
+        focus_offsets:
+          one: 0
+          deux: 1
+          drei: 2
+          quattro: 3
+          blank: 0
 
 ########################## Observations ########################################
 # An observation folder contains a contiguous sequence of images of a target/field

--- a/tests/testing.yaml
+++ b/tests/testing.yaml
@@ -162,7 +162,6 @@ cameras:
           deux: 1
           drei: 2
           quattro: 3
-          blank: 0
 
 ########################## Observations ########################################
 # An observation folder contains a contiguous sequence of images of a target/field


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changing filters can significantly affect the optimal focus position, meaning fine autofocusing does not always work correctly. This motivates (optional) focus positions to be applied per filter, which are applied during calls to `filterwheel.move_to`.

## How Has This Been Tested?
Unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
