### PR TITLE
Log warning rather than raise an error if control value outside range in ZWO camera

### DIFF
--- a/src/panoptes/pocs/camera/zwo.py
+++ b/src/panoptes/pocs/camera/zwo.py
@@ -334,20 +334,17 @@ class Camera(AbstractSDKCamera):
             # Check limits.
             max_value = self._control_info[control_type]['max_value']
             if value > max_value:
-                msg = "Cannot set {} to {}, clipping to max value {}".format(
-                    control_name, value, max_value)
+                self.logger.warning(f"Cannot set {control_name} to {value}, clipping to max value:"
+                                    f" {max_value}.")
                 Camera._driver.set_control_value(self._handle, control_type, max_value)
-                raise error.IllegalValue(msg)
 
             min_value = self._control_info[control_type]['min_value']
             if value < min_value:
-                msg = "Cannot set {} to {}, clipping to min value {}".format(
-                    control_name, value, min_value)
+                self.logger.warning(f"Cannot set {control_name} to {value}, clipping to min value:"
+                                    f" {min_value}.")
                 Camera._driver.set_control_value(self._handle, control_type, min_value)
-                raise error.IllegalValue(msg)
         else:
             if not self._control_info[control_type]['is_auto_supported']:
-                msg = "{} cannot set {} to AUTO".format(self.model, control_name)
-                raise error.IllegalValue(msg)
+                raise error.IllegalValue(f"{self.model} cannot set {control_name} to AUTO")
 
         Camera._driver.set_control_value(self._handle, control_type, value)

--- a/src/panoptes/pocs/camera/zwo.py
+++ b/src/panoptes/pocs/camera/zwo.py
@@ -337,12 +337,14 @@ class Camera(AbstractSDKCamera):
                 self.logger.warning(f"Cannot set {control_name} to {value}, clipping to max value:"
                                     f" {max_value}.")
                 Camera._driver.set_control_value(self._handle, control_type, max_value)
+                return
 
             min_value = self._control_info[control_type]['min_value']
             if value < min_value:
                 self.logger.warning(f"Cannot set {control_name} to {value}, clipping to min value:"
                                     f" {min_value}.")
                 Camera._driver.set_control_value(self._handle, control_type, min_value)
+                return
         else:
             if not self._control_info[control_type]['is_auto_supported']:
                 raise error.IllegalValue(f"{self.model} cannot set {control_name} to AUTO")


### PR DESCRIPTION
"Zero" exposure times are required for bias frames, which should be clipped at the minimum exposure time of the camera. Currently errors are raised despite the intended behaviour of clipping the control values in the ZWO camera code.

## How Has This Been Tested?
Unit tests and on Huntsman.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
