### PR TITLE
Fix FW moving error

### DIFF
--- a/src/panoptes/pocs/filterwheel/filterwheel.py
+++ b/src/panoptes/pocs/filterwheel/filterwheel.py
@@ -345,7 +345,7 @@ class AbstractFilterWheel(PanBase, metaclass=ABCMeta):
             self.logger.warning(f"No focus offset found for {new_filter} filter.")
             return
 
-        current_offset = self._focus_offsets[self.current_filter]
+        current_offset = self._focus_offsets.get(self.current_filter, 0)
         focus_offset = new_offset - current_offset
 
         self.logger.debug(f"Applying focus position offset of {focus_offset} moving from filter "

--- a/src/panoptes/pocs/filterwheel/filterwheel.py
+++ b/src/panoptes/pocs/filterwheel/filterwheel.py
@@ -216,21 +216,22 @@ class AbstractFilterWheel(PanBase, metaclass=ABCMeta):
         """
         assert self.is_connected, self.logger.error("Filter wheel must be connected to move")
 
+        if self.is_moving:
+            msg = f'Attempt to move filter wheel {self} while already moving, ignoring.'
+            self.logger.error(msg)
+            raise error.PanError(msg)
+
         if self.camera is not None:
 
             if self.camera.is_exposing:
-                raise error.PanError(f'Attempt to move filter wheel {self} while camera is exposing, ignoring.')
+                raise error.PanError(f'Attempt to move filter wheel {self} while camera is'
+                                     ' exposing, ignoring.')
 
             if self.camera.has_focuser:
                 try:
                     self._apply_filter_focus_offset(new_position)
                 except Exception as err:
                     self.logger.error(f"Unable to apply focus position offset on {self}: {err!r}")
-
-        if self.is_moving:
-            msg = f'Attempt to move filter wheel {self} while already moving, ignoring.'
-            self.logger.error(msg)
-            raise error.PanError(msg)
 
         # Will raise a ValueError at this point if new_position is not a valid position
         new_position = self._parse_position(new_position)

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -433,7 +433,6 @@ def test_exposure_collision(camera, tmpdir):
 
 def test_exposure_scaling(camera, tmpdir):
     """Regression test for incorrect pixel value scaling.
-
     Checks for zero padding of LSBs instead of MSBs, as encountered
     with ZWO ASI cameras.
     """


### PR DESCRIPTION
I broke POCS with my last PR. I am sorry. The fix is to check if the FW is moving before applying focus offsets, rather than after.

## How Has This Been Tested?
Unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
