### PR TITLE
Use utils for serial port lookup

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,6 +47,8 @@ ARG pip_install_extras="[google]"
 COPY --chown="${userid}:${userid}" . .
 RUN echo "Installing ${pip_install_name} module with ${pip_install_extras}" && \
     /conda/bin/pip install "${pip_install_name}${pip_install_extras}" && \
+    # panoptes-utils from dev.
+    /conda/bin/pip install "git+https://github.com/panoptes/panoptes-utils@develop#egg=panoptes-utils[config]" && \
     # Cleanup
     /conda/bin/pip cache purge && \
     /conda/bin/conda clean -fay && \

--- a/src/panoptes/peas/power.py
+++ b/src/panoptes/peas/power.py
@@ -239,7 +239,7 @@ class PowerBoard(PanBase):
         return f'{self.name} - {relay_states}'
 
     @classmethod
-    def lookup_port(cls, vendor_id=0x2341, product_id=0x0043, return_all=False, **kwags):
+    def lookup_port(cls, vendor_id=0x2341, product_id=0x0043, **kwargs):
         """Tries to guess the port hosting the power board arduino.
 
         The default vendor_id is for official Arduino products. The default product_id

--- a/src/panoptes/peas/power.py
+++ b/src/panoptes/peas/power.py
@@ -9,6 +9,7 @@ import numpy as np
 from panoptes.utils.rs232 import SerialData, get_serial_port_info
 from panoptes.utils.serializers import from_json
 from panoptes.pocs.base import PanBase
+from panoptes.utils.rs232 import find_serial_port
 from panoptes.utils import error
 
 
@@ -94,7 +95,7 @@ class PowerBoard(PanBase):
         """
         super().__init__(*args, **kwargs)
         if port is None:
-            port = PowerBoard.guess_port(**kwargs)
+            port = PowerBoard.lookup_port(**kwargs)
             self.logger.info(f'Guessing that arduino is on {port=}')
 
         self.port = port
@@ -238,7 +239,7 @@ class PowerBoard(PanBase):
         return f'{self.name} - {relay_states}'
 
     @classmethod
-    def guess_port(cls, vendor_id=0x2341, product_id=0x0043, return_all=False, **kwags):
+    def lookup_port(cls, vendor_id=0x2341, product_id=0x0043, return_all=False, **kwags):
         """Tries to guess the port hosting the power board arduino.
 
         The default vendor_id is for official Arduino products. The default product_id
@@ -247,13 +248,4 @@ class PowerBoard(PanBase):
         https://github.com/arduino/Arduino/blob/1.8.0/hardware/arduino/avr/boards.txt#L51-L58
 
         """
-        # Get all serial ports.
-        arduino_ports = [p for p in get_serial_port_info() if
-                         p.vid == vendor_id and p.pid == product_id]
-
-        if len(arduino_ports) == 1:
-            return arduino_ports[0].device
-        elif return_all:
-            return arduino_ports
-        else:
-            raise error.NotFound(f'No official arduino devices found.')
+        return find_serial_port(vendor_id, product_id)

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -34,6 +34,8 @@ RUN /conda/bin/conda env update -n base -f environment.yaml
 WORKDIR "${POCS}"
 COPY --chown="${userid}:${userid}" . .
 RUN /conda/bin/pip install -e ".${pip_extras}" && \
+    # panoptes-utils from dev.
+    /conda/bin/pip install "git+https://github.com/panoptes/panoptes-utils@develop#egg=panoptes-utils[config]" && \
     # Cleanup
     /conda/bin/pip cache purge && \
     /conda/bin/conda clean -tipy && \

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -4,6 +4,7 @@ import pytest
 import responses
 
 from panoptes.peas import remote_sensors
+from panoptes.peas import power
 from panoptes.utils import error
 
 
@@ -62,3 +63,9 @@ def test_remote_sensor(remote_response, remote_response_power):
 def test_remote_sensor_no_endpoint():
     with pytest.raises(error.PanError):
         remote_sensors.RemoteMonitor(sensor_name='should_fail')
+
+
+def test_power_board_no_device():
+    """Attempt to find an arduino device, which should fail."""
+    with pytest.raises(error.NotFound):
+        power.PowerBoard()


### PR DESCRIPTION
Small PR to use utils tool.

* Use the `find_serial_port` helper.
* Install `panoptes-utils` from dev for now.

