### PR TITLE
More install script improvements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Generic
 
   * Python 3.8
   * Default service install does not include ``focuser`` dependencies.
+  * Default service is running a public jupyter lab.
   * Default Docker command is a ``ipython`` console with the simulators loaded.
   * Docker image only contains limited set of files.
   * Directories inside the service image have been simplified for easier mapping onto desired targets on the host. The main top-level directory (i.e. ``$PANDIR``) is now ``/POCS`` with other folders nested underneath.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,7 @@ RUN echo "Building from ${image_name}:${image_tag}" && \
     # Set up directories in PANUSER home.
     sudo mkdir "$image_dir" && sudo chown -R "${userid}:${userid}" "$image_dir" && \
     sudo mkdir "$log_dir" && sudo chown -R "${userid}:${userid}" "$log_dir" && \
-    sudo mkdir "${APP_DIR}" && sudo chown -R "${userid}:${userid}" "${APP_DIR}"
+    sudo chown -R "${userid}:${userid}" "${APP_DIR}"
 
 # Set up arduino cli tools.
 RUN echo "Installing arduino-cli from ${arduino_url}" && \
@@ -55,7 +55,7 @@ COPY --chown="${userid}:${userid}" . .
 RUN echo "Installing ${pip_install_name} module with ${pip_install_extras}" && \
     /conda/bin/pip install "${pip_install_name}${pip_install_extras}" && \
     # Configure jupyter
-    /conda/bin/jupyter labextension install @pyviz/jupyterlab_pyviz && \
+#    /conda/bin/jupyter labextension install @pyviz/jupyterlab_pyviz && \
     # Cleanup
     /conda/bin/pip cache purge && \
     /conda/bin/conda clean -tipsy && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,10 +17,10 @@ ENV USERID $userid
 ARG app_dir=/panoptes-pocs
 ENV APP_DIR $app_dir
 
-ARG images_dir=/images
-ARG log_dir_dir=/logs
+ARG image_dir=/images
+ARG log_dir=/logs
 
-WORKDIR /
+WORKDIR "${APP_DIR}"
 USER "${userid}"
 
 # Dependencies and directories.
@@ -30,8 +30,8 @@ RUN echo "Building from ${image_name}:${image_tag}" && \
         gphoto2 \
         astrometry-data-tycho2-10-19 && \
     # Set up directories in PANUSER home.
-    sudo mkdir $image_dir && sudo chown -R "${userid}:${userid}" $image_dir && \
-    sudo mkdir $log_dir && sudo chown -R "${userid}:${userid}" $log_dir && \
+    sudo mkdir "$image_dir" && sudo chown -R "${userid}:${userid}" "$image_dir" && \
+    sudo mkdir "$log_dir" && sudo chown -R "${userid}:${userid}" "$log_dir" && \
     sudo mkdir "${APP_DIR}" && sudo chown -R "${userid}:${userid}" "${APP_DIR}"
 
 # Set up arduino cli tools.
@@ -44,8 +44,6 @@ RUN echo "Installing arduino-cli from ${arduino_url}" && \
     mv arduino-cli "${HOME}/.local/bin/arduino-cli"  && \
     rm LICENSE.txt && rm arduino-cli.tar.gz
 
-WORKDIR "${APP_DIR}"
-
 # Update conda environment with dependencies.
 COPY docker/environment.yaml .
 RUN /conda/bin/conda env update -n base -f environment.yaml
@@ -56,6 +54,8 @@ ARG pip_install_extras="[google]"
 COPY --chown="${userid}:${userid}" . .
 RUN echo "Installing ${pip_install_name} module with ${pip_install_extras}" && \
     /conda/bin/pip install "${pip_install_name}${pip_install_extras}" && \
+    # Configure jupyter
+    /conda/bin/jupyter labextension install @pyviz/jupyterlab_pyviz && \
     # Cleanup
     /conda/bin/pip cache purge && \
     /conda/bin/conda clean -tipsy && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,6 @@ ARG image_url=gcr.io/panoptes-exp/panoptes-utils
 ARG image_tag=develop
 FROM ${image_url}:${image_tag} AS pocs-base
 
-# Or ARM64 for rpi
 ARG arduino_url="https://downloads.arduino.cc/arduino-cli/arduino-cli_latest"
 
 LABEL description="PANOPTES Observatory Control System Service"
@@ -11,24 +10,31 @@ LABEL repo="github.com/panoptes/POCS"
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
-ENV POCS "/POCS"
 
 ARG userid=1000
 ENV USERID $userid
 
+ARG app_dir=/panoptes-pocs
+ENV APP_DIR $app_dir
+
+ARG images_dir=/images
+ARG log_dir_dir=/logs
+
+WORKDIR /
 USER "${userid}"
 
-# Set up some common directories
+# Dependencies and directories.
 RUN echo "Building from ${image_name}:${image_tag}" && \
     sudo apt-get update && \
     sudo apt-get install -y --no-install-recommends \
         gphoto2 \
         astrometry-data-tycho2-10-19 && \
-    sudo mkdir /images && sudo chown -R "${userid}:${userid}" /images && \
-    sudo mkdir /logs && sudo chown -R "${userid}:${userid}" /logs && \
-    sudo mkdir "${POCS}" && sudo chown -R "${userid}:${userid}" "${POCS}"
+    # Set up directories in PANUSER home.
+    sudo mkdir $image_dir && sudo chown -R "${userid}:${userid}" $image_dir && \
+    sudo mkdir $log_dir && sudo chown -R "${userid}:${userid}" $log_dir && \
+    sudo mkdir "${APP_DIR}" && sudo chown -R "${userid}:${userid}" "${APP_DIR}"
 
-# Set up arduino
+# Set up arduino cli tools.
 RUN echo "Installing arduino-cli from ${arduino_url}" && \
     wget "${arduino_url}_Linux_$(uname -m | sed 's/x86_64/64bit/' | sed 's/aarch64/ARM64/').tar.gz" \
         -O arduino-cli.tar.gz && \
@@ -36,8 +42,11 @@ RUN echo "Installing arduino-cli from ${arduino_url}" && \
     mkdir -p "${HOME}/bin" && \
     mkdir -p "${HOME}/.local/bin" && \
     mv arduino-cli "${HOME}/.local/bin/arduino-cli"  && \
-    rm LICENSE.txt
+    rm LICENSE.txt && rm arduino-cli.tar.gz
 
+WORKDIR "${APP_DIR}"
+
+# Update conda environment with dependencies.
 COPY docker/environment.yaml .
 RUN /conda/bin/conda env update -n base -f environment.yaml
 
@@ -47,23 +56,14 @@ ARG pip_install_extras="[google]"
 COPY --chown="${userid}:${userid}" . .
 RUN echo "Installing ${pip_install_name} module with ${pip_install_extras}" && \
     /conda/bin/pip install "${pip_install_name}${pip_install_extras}" && \
-    # panoptes-utils from dev.
-    /conda/bin/pip install "git+https://github.com/panoptes/panoptes-utils@develop#egg=panoptes-utils[config]" && \
     # Cleanup
     /conda/bin/pip cache purge && \
-    /conda/bin/conda clean -fay && \
+    /conda/bin/conda clean -tipsy && \
     sudo apt-get autoremove --purge --yes \
         gcc pkg-config git && \
     sudo apt-get autoclean --yes && \
     sudo apt-get --yes clean && \
     sudo rm -rf /var/lib/apt/lists/*
 
-WORKDIR "${POCS}"
-COPY --chown="${userid}:${userid}" docker/docker-compose.yaml .
-COPY --chown="${userid}:${userid}" conf_files conf_files
-COPY --chown="${userid}:${userid}" resources resources
-COPY --chown="${userid}:${userid}" scripts scripts
-COPY --chown="${userid}:${userid}" tests/data tests/data
-
-ENTRYPOINT [ "/usr/bin/env", "bash", "-ic" ]
+# TODO replace with pocs-cli.
 CMD [ "ipython" ]

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -38,7 +38,7 @@ services:
     hostname: pocs-control
     network_mode: host
     environment:
-      PANOPTES_CONFIG_HOST: localhost
+      PANOPTES_CONFIG_HOST: 0.0.0.0
       PANOPTES_CONFIG_PORT: 6563
     command: [ "wait-for-it localhost:6563 -- jupyter lab --no-browser --ip 0.0.0.0 -y" ]
     volumes:

--- a/docker/environment.yaml
+++ b/docker/environment.yaml
@@ -3,6 +3,7 @@ channels:
 dependencies:
   - ipywidgets
   - jupyterlab  # Interactive
+  - jupyterlab_widgets
   - matplotlib-base
   - numpy
   - pandas

--- a/docker/environment.yaml
+++ b/docker/environment.yaml
@@ -5,6 +5,7 @@ dependencies:
   - matplotlib-base
   - numpy
   - pandas
+  - nodejs
   - photutils
   - pillow
   - pip

--- a/docker/environment.yaml
+++ b/docker/environment.yaml
@@ -1,11 +1,11 @@
 channels:
   - https://conda.anaconda.org/conda-forge
 dependencies:
+  - ipywidgets
   - jupyterlab  # Interactive
   - matplotlib-base
   - numpy
   - pandas
-  - nodejs
   - photutils
   - pillow
   - pip

--- a/resources/rpi/user-data
+++ b/resources/rpi/user-data
@@ -1,25 +1,11 @@
 #cloud-config
 # https://cloudinit.readthedocs.io/
 
-hostname: pocs-control
-
-#####################################################################
-# You shouldn't need to change anything below.
-#####################################################################
-
 # Setting "expire: true" will force a password change on first login.
 chpasswd:
   expire: true
   list:
     - panoptes:panoptes
-
-ntp:
-  enabled: true
-  servers:
-    - time1.google.com
-    - time2.google.com
-    - time3.google.com
-    - time4.google.com
 
 ssh_pwauth: yes
 

--- a/scripts/install/install-pocs.sh
+++ b/scripts/install/install-pocs.sh
@@ -71,6 +71,7 @@ OS="$(uname -s)"
 CONDA_URL="https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-$(uname -m).sh"
 CONDA_ENV_NAME=conda-pocs
 DEV_BOX=false
+DEFAULT_GROUPS="dialout,plugdev,docker,i2c,input,gpio"
 
 DOCKER_BASE=${DOCKER_BASE:-"gcr.io/panoptes-exp"}
 
@@ -137,12 +138,9 @@ function install_docker() {
   wget -q https://get.docker.com -O get-docker.sh
   bash get-docker.sh
 
-  # Add to docker group if not already.
-  sudo usermod -aG docker "${PANUSER}"
-
   "${PANDIR}/conda/envs/${CONDA_ENV_NAME}/bin/pip" install docker-compose
 
-  rm "${HOME}/install-pocs.sh"
+  rm get-docker.sh
 }
 
 function get_or_build_images() {
@@ -236,11 +234,14 @@ function do_install() {
 
   make_directories
 
-  echo "Installing system dependencies"
+  echo "Installing system dependencies."
   system_deps
 
   if [ "$DEV_BOX" = false ]; then
     install_zsh
+
+    echo "Adding ${PANUSER} to default groups."
+    sudo usermod -aG "${DEFAULT_GROUPS}" "${PANUSER}"
   fi
 
   install_conda

--- a/scripts/install/install-pocs.sh
+++ b/scripts/install/install-pocs.sh
@@ -119,6 +119,8 @@ function system_deps() {
     gcc \
     htop \
     make \
+    nano \
+    neovim \
     wget \
     zsh
   sudo apt-get -y autoremove
@@ -153,14 +155,14 @@ function get_or_build_images() {
     sudo docker run --rm -it \
       -v "${PANDIR}:/temp" \
       "${DOCKER_BASE}/panoptes-pocs:${TAG_NAME}" \
-      "cp /app/docker-compose.yaml /temp/docker-compose.yaml"
+      "cp /panoptes-pocs/docker-compose.yaml /temp/docker-compose.yaml"
     sudo chown "${PANUSER}:${PANUSER}" "${PANDIR}/docker-compose.yaml"
 
     # Copy the config file
     sudo docker run --rm -it \
       -v "${PANDIR}:/temp" \
       "${DOCKER_BASE}/panoptes-pocs:${TAG_NAME}" \
-      "cp /app/conf_files/pocs.yaml /temp/conf_files/pocs.yaml"
+      "cp /panoptes-pocs/conf_files/pocs.yaml /temp/conf_files/pocs.yaml"
     sudo chown "${PANUSER}:${PANUSER}" "${PANDIR}/conf_files/pocs.yaml"
   fi
 }
@@ -182,7 +184,7 @@ function install_conda() {
   # Install panoptes-utils (so we get panoptes-config-server)
   "${PANDIR}/conda/envs/${CONDA_ENV_NAME}/bin/pip" install docker-compose
 
-  rm "${HOME}/install-pocs.sh"
+  rm install-miniforge.sh
 }
 
 function install_zsh() {

--- a/src/panoptes/pocs/camera/simulator/ccd.py
+++ b/src/panoptes/pocs/camera/simulator/ccd.py
@@ -9,7 +9,6 @@ import astropy.units as u
 from panoptes.pocs.camera.simulator.dslr import Camera as SimCamera
 from panoptes.pocs.camera.sdk import AbstractSDKDriver, AbstractSDKCamera
 from panoptes.utils.config.client import get_config
-from panoptes.utils.logging import logger
 
 
 class SDKDriver(AbstractSDKDriver):
@@ -21,14 +20,14 @@ class SDKDriver(AbstractSDKDriver):
         return "Simulated SDK Driver v0.001"
 
     def get_devices(self):
-        logger.debug(f'Getting camera device connection config for {self}')
+        self.logger.debug(f'Getting camera device connection config for {self}')
         camera_devices = dict()
         for cam_info in get_config('cameras.devices'):
             name = cam_info.get('name') or cam_info.get('model')
             port = cam_info.get('port') or cam_info.get('serial_number')
             camera_devices[name] = port
 
-        logger.trace(f'camera_devices={camera_devices!r}')
+        self.logger.trace(f'camera_devices={camera_devices!r}')
 
         return camera_devices
 

--- a/src/panoptes/pocs/utils/theskyx.py
+++ b/src/panoptes/pocs/utils/theskyx.py
@@ -1,7 +1,7 @@
 import socket
 
 from panoptes.utils import error
-from panoptes.utils.logging import logger
+from panoptes.pocs.utils.logger import get_logger
 
 
 class TheSkyX(object):
@@ -11,7 +11,7 @@ class TheSkyX(object):
     """
 
     def __init__(self, host='localhost', port=3040, connect=True, *args, **kwargs):
-        self.logger = logger
+        self.logger = get_logger()
 
         self._host = host
         self._port = port


### PR DESCRIPTION
* Clean up the docker image for consistent directories.
* Default jupyter lab service starts on a public ip.
* RPi installer:
  * Don't change NTP info.
  * Don't set hostname (the install script does).