### PR TITLE
Upgrade panoptes-utils (and pillow)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ setup_requires = pyscaffold>=3.2a0,<3.3a0
 install_requires =
     astroplan
     astropy
-    panoptes-utils[config]>=0.2.32
+    panoptes-utils[config]>=0.2.33
     pyserial
     transitions
 # The usage of test_requires is discouraged, see `Dependency Management` docs


### PR DESCRIPTION
Bump `panoptes-utils` version to also include a `Pillow>=8.1.1` bump. Fixes security advisory about Pillow.