### PR TITLE
Add optional filter_name arg to focuser.autofocus

### DIFF
--- a/src/panoptes/pocs/focuser/focuser.py
+++ b/src/panoptes/pocs/focuser/focuser.py
@@ -298,19 +298,21 @@ class AbstractFocuser(PanBase, metaclass=ABCMeta):
             make_plots = self.autofocus_make_plots
 
         # Move filterwheel to the correct position
-        if self.camera.has_filterwheel:
+        if self.camera is not None:
+            if self.camera.has_filterwheel:
 
-            if filter_name is None:
-                # NOTE: The camera will move the FW to the last light position automatically
-                self.logger.warning(f"Filter name not provided for autofocus on {self}. Using last"
-                                    " light position.")
-            else:
-                self.logger.info(f"Moving filterwheel to {filter_name} for autofocusing on {self}.")
-                self.camera.filterwheel.move_to(filter_name, blocking=True)
+                if filter_name is None:
+                    # NOTE: The camera will move the FW to the last light position automatically
+                    self.logger.warning(f"Filter name not provided for autofocus on {self}. Using"
+                                        " last light position.")
+                else:
+                    self.logger.info(f"Moving filterwheel to {filter_name} for autofocusing on"
+                                     f" {self}.")
+                    self.camera.filterwheel.move_to(filter_name, blocking=True)
 
-        elif filter_name is None:
-            self.logger.warning(f"Filter {filter_name} requiested for autofocus but {self.camera}"
-                                f" has no filterwheel.")
+            elif filter_name is None:
+                self.logger.warning(f"Filter {filter_name} requiested for autofocus but"
+                                    f" {self.camera} has no filterwheel.")
 
         # Set up the focus parameters
         focus_event = Event()

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -581,7 +581,7 @@ def test_observation_bias(camera, images_dir):
 
 def test_autofocus_coarse(camera, patterns, counter):
 
-    if camera.has_focuser:
+    if not camera.has_focuser:
         pytest.skip("Camera does not have a focuser")
 
     if camera.has_filterwheel:

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -580,10 +580,19 @@ def test_observation_bias(camera, images_dir):
 
 
 def test_autofocus_coarse(camera, patterns, counter):
-    if camera.focuser is None:
+
+    if camera.has_focuser:
         pytest.skip("Camera does not have a focuser")
-    autofocus_event = camera.autofocus(coarse=True)
+
+    if camera.has_filterwheel:
+        camera.filterwheel.move_to("one", blocking=True)
+
+    autofocus_event = camera.autofocus(coarse=True, filter_name="deux")
     autofocus_event.wait()
+
+    if camera.has_filterwheel:
+        assert camera.filterwheel.current_filter == "deux"
+
     counter['value'] += 1
     assert len(glob.glob(patterns['final'])) == counter['value']
 


### PR DESCRIPTION
Add optional `filter_name` arg to `focuser.autofocus`, which will cause the FW to move to that position before autofocusing.

## Related Issue
AstroHuntsman/huntsman-pocs#458

## How Has This Been Tested?
Unit tests.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
