### PR TITLE
CEM40 and mount updates

### DIFF
--- a/conf_files/pocs.yaml
+++ b/conf_files/pocs.yaml
@@ -58,9 +58,13 @@ mount:
     port: /dev/ttyUSB0
     timeout: 0.
     baudrate: 9600  #  115200 for cem40
-  non_sidereal_available: True
-  min_tracking_threshold: 100 # ms
-  max_tracking_threshold: 99999 # ms
+  settings:
+    non_sidereal_available: True
+    min_tracking_threshold: 100 # ms
+    max_tracking_threshold: 99999 # ms
+    # After moving to hardware park position, move Dec axis so cameras point down.
+    park_direction: north
+    park_seconds: 15
 
 pointing:
   max_iterations: 5  # Set to 0 to disable

--- a/src/panoptes/pocs/mount/ioptron/cem40.py
+++ b/src/panoptes/pocs/mount/ioptron/cem40.py
@@ -136,7 +136,7 @@ class Mount(AbstractSerialMount):
 
         return self.is_initialized
 
-    def park(self, park_direction='north', park_seconds=11, *args, **kwargs):
+    def park(self, park_direction=None, park_seconds=None, *args, **kwargs):
         """Slews to the park position and parks the mount.
 
         This still uses a custom park command because the orientation of the camera
@@ -149,10 +149,15 @@ class Mount(AbstractSerialMount):
         Returns:
             bool: indicating success
         """
-
         if self.at_mount_park:
             self.logger.success("Mount is already parked")
             return self.at_mount_park
+
+        # Get the direction and timing
+        park_direction = park_direction or self.get_config('mount.settings.park_direction', 'north')
+        park_seconds = park_seconds or self.get_config('mount.settings.park_seconds', 11)
+
+        self.logger.debug(f'Parking mount: {park_direction=} {park_seconds=}')
 
         self.unpark()
         self.query('park')
@@ -167,6 +172,11 @@ class Mount(AbstractSerialMount):
         return self.at_mount_park
 
     def search_for_home(self):
+        """Search for the home position.
+
+        This method uses the internal homing pin on the CEM40 mount to return the
+        mount to the home (or zero) position.
+        """
         self.logger.info('Searching for the home position.')
         self.query('search_for_home')
 

--- a/src/panoptes/pocs/mount/ioptron/cem40.py
+++ b/src/panoptes/pocs/mount/ioptron/cem40.py
@@ -139,12 +139,18 @@ class Mount(AbstractSerialMount):
     def park(self, park_direction=None, park_seconds=None, *args, **kwargs):
         """Slews to the park position and parks the mount.
 
-        This still uses a custom park command because the orientation of the camera
-        box is perpendicular to what the mount expects, so we cannot use the
-        mount's built-in commands.
+        This still uses a custom park command because the mount will not allow
+        the Declination axis to move below 0 degrees.
 
         Note:
             When mount is parked no movement commands will be accepted.
+
+        Args:
+            park_direction (str or None): The direction to move the Declination axis. If
+                not provided (the default), then look at config setting, otherwise 'north'.
+            park_seconds (str or None): The number of seconds to move the Declination axis at
+                maximum move speed. If not provided (the default), then look at config setting,
+                otherwise 11 seconds.
 
         Returns:
             bool: indicating success

--- a/src/panoptes/pocs/mount/ioptron/ieq30pro.py
+++ b/src/panoptes/pocs/mount/ioptron/ieq30pro.py
@@ -81,9 +81,9 @@ class Mount(AbstractSerialMount):
 
         self.logger.info('Mount created')
 
-    ##################################################################################################
+    ################################################################################################
     # Properties
-    ##################################################################################################
+    ################################################################################################
 
     @property
     def is_home(self):
@@ -106,9 +106,9 @@ class Mount(AbstractSerialMount):
 
         return self._is_slewing
 
-    ##################################################################################################
+    ################################################################################################
     # Public Methods
-    ##################################################################################################
+    ################################################################################################
 
     def initialize(self, set_rates=True, unpark=False, *arg, **kwargs):
         """ Initialize the connection with the mount and setup for location.
@@ -190,7 +190,7 @@ class Mount(AbstractSerialMount):
         """
 
         if self.is_parked:
-            self.logger.info("Mount is parked")
+            self.logger.info('Mount is parked')
             return self._is_parked
 
         if self.slew_to_home(blocking=True):
@@ -198,11 +198,11 @@ class Mount(AbstractSerialMount):
             self.query('set_button_moving_rate', 9)
             self.move_direction(direction=ra_direction, seconds=ra_seconds)
             while self.is_slewing:
-                self.logger.debug("Slewing RA axis to park position...")
+                self.logger.debug('Slewing RA axis to park position...')
                 time.sleep(3)
             self.move_direction(direction=dec_direction, seconds=dec_seconds)
             while self.is_slewing:
-                self.logger.debug("Slewing Dec axis to park position...")
+                self.logger.debug('Slewing Dec axis to park position...')
                 time.sleep(3)
 
             self._is_parked = True
@@ -210,21 +210,21 @@ class Mount(AbstractSerialMount):
 
         return self._is_parked
 
-    ##################################################################################################
+    ################################################################################################
     # Private Methods
-    ##################################################################################################
+    ################################################################################################
     def _set_initial_rates(self):
         # Make sure we start at sidereal
         self.set_tracking_rate()
 
         self.logger.debug('Setting manual moving rate to max')
         self.query('set_button_moving_rate', 9)
-        self.logger.debug(f"Mount guide rate: {self.query('get_guide_rate')}")
+        self.logger.debug(f'Mount guide rate: {self.query("get_guide_rate")}')
         self.query('set_guide_rate', '9090')
         guide_rate = self.query('get_guide_rate')
         self.ra_guide_rate = int(guide_rate[0:2]) / 100
         self.dec_guide_rate = int(guide_rate[2:]) / 100
-        self.logger.debug(f"Mount guide rate: {self.ra_guide_rate} {self.dec_guide_rate}")
+        self.logger.debug(f'Mount guide rate: {self.ra_guide_rate} {self.dec_guide_rate}')
 
     def _setup_location_for_mount(self):
         """
@@ -284,8 +284,6 @@ class Mount(AbstractSerialMount):
 
         coords = None
 
-        # self.logger.debug("Mount coordinates: {}".format(coords_match))
-
         if coords_match is not None:
             ra = (coords_match.group('ra_millisecond') * u.millisecond).to(u.hour)
             dec = (coords_match.group('dec_arcsec') * u.centiarcsecond).to(u.arcsec)
@@ -296,8 +294,7 @@ class Mount(AbstractSerialMount):
 
             coords = SkyCoord(ra=ra, dec=dec, frame='icrs', unit=(u.hour, u.arcsecond))
         else:
-            self.logger.warning(
-                "Cannot create SkyCoord from mount coordinates")
+            self.logger.warning('Cannot create SkyCoord from mount coordinates')
 
         return coords
 
@@ -325,22 +322,23 @@ class Mount(AbstractSerialMount):
 
         # RA in milliseconds
         ra_ms = (coords.ra.hour * u.hour).to(u.millisecond)
-        mount_ra = "{:08.0f}".format(ra_ms.value)
-        self.logger.debug("RA (ms): {}".format(ra_ms))
+        mount_ra = f'{ra_ms.value:08.0f}'
+        self.logger.debug(f'RA (ms): {ra_ms}')
 
         dec_dms = (coords.dec.degree * u.degree).to(u.centiarcsecond)
-        self.logger.debug("Dec (centiarcsec): {}".format(dec_dms))
-        mount_dec = "{:=+08.0f}".format(dec_dms.value)
+        self.logger.debug(f'Dec (centiarcsec): {dec_dms}')
+        mount_dec = f'{dec_dms.value:=+08.0f}'
 
         mount_coords = (mount_ra, mount_dec)
 
         return mount_coords
 
+    @property
     def _set_zero_position(self):
         """ Sets the current position as the zero position.
 
         The iOptron allows you to set the current position directly, so
         we simply call the iOptron command.
         """
-        self.logger.info("Setting zero position")
+        self.logger.info('Setting zero position')
         return self.query('set_zero_position')

--- a/src/panoptes/pocs/mount/mount.py
+++ b/src/panoptes/pocs/mount/mount.py
@@ -48,9 +48,7 @@ class AbstractMount(PanBase):
 
         # setup commands for mount
         self.logger.debug("Setting up commands for mount")
-        if commands is None:
-            commands = dict()
-        self.commands = self._setup_commands(commands)
+        self._setup_commands(commands)
         self.logger.debug("Mount commands set up")
 
         # Set the initial location
@@ -772,11 +770,11 @@ class AbstractMount(PanBase):
         setting the pre- and post-commands. We could also do some basic checking here
         to make sure required commands are in fact available.
         """
-        self.logger.debug('Setting up commands for mount')
+        commands = commands or dict()
+        self.logger.debug('Setting up commands for mount.')
 
         if len(commands) == 0:
             mount_dir = self.get_config('directories.mounts')
-
             commands_file = self.get_config('mount.commands_file')
 
             if commands_file is None:
@@ -798,9 +796,9 @@ class AbstractMount(PanBase):
         # Get the pre- and post- commands
         self._pre_cmd = commands.setdefault('cmd_pre', ':')
         self._post_cmd = commands.setdefault('cmd_post', '#')
+        self.commands = commands
 
         self.logger.debug('Mount commands set up')
-        return commands
 
     def _set_zero_position(self):  # pragma: no cover
         """ Sets the current position as the zero (home) position. """

--- a/src/panoptes/pocs/mount/mount.py
+++ b/src/panoptes/pocs/mount/mount.py
@@ -370,7 +370,7 @@ class AbstractMount(PanBase):
         if 0 <= pointing_ha <= 12:
             pier_side = 'west'
 
-        self.logger.debug(f"Mount pier side: {pier_side} {pointing_ha:.02f}")
+        self.logger.debug(f'Mount pier side: {pier_side} {pointing_ha:.02f}')
 
         if min_tracking_threshold is None:
             min_tracking_threshold = self.min_tracking_threshold

--- a/src/panoptes/pocs/mount/serial.py
+++ b/src/panoptes/pocs/mount/serial.py
@@ -1,11 +1,12 @@
 import re
+from abc import ABC
 
 from panoptes.utils import error
 from panoptes.utils import rs232
 from panoptes.pocs.mount import AbstractMount
 
 
-class AbstractSerialMount(AbstractMount):
+class AbstractSerialMount(AbstractMount, ABC):
 
     def __init__(self, *args, **kwargs):
         """Initialize an AbstractSerialMount for the port defined in the config.

--- a/src/panoptes/pocs/mount/serial.py
+++ b/src/panoptes/pocs/mount/serial.py
@@ -124,7 +124,7 @@ class AbstractSerialMount(AbstractMount):
 
         response = self.serial.read()
 
-        self.logger.debug(f'Mount Read: {response}')
+        self.logger.trace(f'Mount Read: {response}')
 
         # Strip the line ending (#) and return
         response = response.rstrip('#')

--- a/src/panoptes/pocs/mount/simulator.py
+++ b/src/panoptes/pocs/mount/simulator.py
@@ -67,7 +67,7 @@ class Mount(AbstractMount):
 
         status = dict()
 
-        status['timestamp'] = current_time()
+        status['timestamp'] = current_time().isot
         status['tracking_rate_ra'] = self.tracking_rate
         status['state'] = self.state
 
@@ -208,4 +208,4 @@ class Mount(AbstractMount):
         return False
 
     def _setup_commands(self, commands):
-        return commands
+        self.commands = commands


### PR DESCRIPTION
Updates to various mount classes, mostly adding better support for newer iOptron CEM40 options.

## Description
* CEM40 proper initialization for v250 command set.
* Custom park command for rotating Dec axis.
* Added `search_for_home` method that uses the CEM40 command directly.
* CEM40 sets meridian treatment and altitude limit upon init.
* The `_setup_commands` sets the commands rather than returns them.
* Mount simulator uses proper timestamp.
* Mount read log is less noisy.
* Moving some of the mount settings in the config file.
* Adding parking direction and number of seconds to move to config file.
* Base mount and serial mount class are proper abstract methods.
* f-strings and double quotes.

## Related Issue
Pulled from #1112 