### PR TITLE
Astromech find serial port

### DIFF
--- a/.github/workflows/pythontest.yaml
+++ b/.github/workflows/pythontest.yaml
@@ -23,7 +23,7 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=100 --statistics
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     strategy:
       matrix:
         python-version: [ 3.8 ]

--- a/.github/workflows/pythontest.yaml
+++ b/.github/workflows/pythontest.yaml
@@ -23,7 +23,7 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=100 --statistics
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 60
     strategy:
       matrix:
         python-version: [ 3.8 ]

--- a/src/panoptes/pocs/focuser/astromechanics.py
+++ b/src/panoptes/pocs/focuser/astromechanics.py
@@ -1,39 +1,47 @@
+from panoptes.utils import error
+from panoptes.utils.serial.device import find_serial_port
 from panoptes.pocs.focuser.serial import AbstractSerialFocuser
 
 
 class Focuser(AbstractSerialFocuser):
     """
-    Focuser class for control of a Canon DSLR lens via an Astromechanics Engineering Canon EF/EF-S adapter.
+    Focuser class for control of a Canon DSLR lens via an Astromechanics
+    Engineering Canon EF/EF-S adapter.
 
     Args:
         name (str, optional): default 'Astromechanics Focuser'
         model (str, optional): default 'Canon EF/EF-S'
+        vendor_id (str, optional): idVendor of device, can be retrieved with lsusb -v from terminal.
+        product_id (str, optional): idProduct of device, can be retrieved with lsusb -v from terminal.
 
-    Additional positonal and keyword arguments are passed to the base class, AbstractSerialFocuser. See
-    that class' documentation for a complete list.
+    Additional positonal and keyword arguments are passed to the base class,
+    AbstractSerialFocuser. See that base class documentation for a complete list.
 
     Min/max commands do not exist for the astromechanics controller, as well as
     other commands to get serial numbers and library/hardware versions. However,
     as they are marked with the decorator @abstractmethod, we have to override them.
     """
 
-    def __init__(self,
-                 name='Astromechanics Focuser Controller',
-                 model='astromechanics',
-                 *args, **kwargs):
-        super().__init__(name=name, model=model, *args, **kwargs)
-        self.logger.debug('Initialising Astromechanics Lens Controller')
+    def __init__(self, name='Astromechanics Focuser', model='Canon EF-232', vendor_id=None,
+                 product_id=None, *args, **kwargs):
+        # Check if have device, raise error.NotFound if unable to find.
+        self._serial_number = find_serial_port(vendor_id, product_id)
+        self._vendor_id = vendor_id
+        self._product_id = product_id
 
-    ##################################################################################################
+        super().__init__(name=name, model=model, *args, **kwargs)
+        self.logger.debug(f'Initializing {name}')
+
+    ################################################################################################
     # Properties
-    ##################################################################################################
+    ################################################################################################
 
     @AbstractSerialFocuser.position.getter
     def position(self):
         """
         Returns current focus position in the lens focus encoder units.
         """
-        response = self._send_command("P#").rstrip("#")
+        response = self._send_command("P").rstrip("#")
         return int(response)
 
     @property
@@ -50,23 +58,21 @@ class Focuser(AbstractSerialFocuser):
         """
         return None
 
-    ##################################################################################################
+    ################################################################################################
     # Public Methods
-    ##################################################################################################
+    ################################################################################################
 
     def connect(self, port):
+        self._connect(port)
 
-        self._connect(port, baudrate=38400)
-
-        # Return string that makes it clear there is no serial number
-        return "no_serial_number_available"
+        return self._serial_number
 
     def move_to(self, new_position):
         """
         Moves focuser to a new position.
 
         Args:
-            position (int): new focuser position, in encoder units
+            new_position (int): new focuser position, in encoder units
 
         Returns:
             int: focuser position following the move, in encoder units.
@@ -76,7 +82,7 @@ class Focuser(AbstractSerialFocuser):
         """
         self._is_moving = True
         try:
-            self._send_command(f'M{int(new_position):d}#')
+            self._send_command(f'M{int(new_position):d}')
         finally:
             # Focuser move commands block until the move is finished, so if the command has
             # returned then the focuser is no longer moving.
@@ -98,7 +104,7 @@ class Focuser(AbstractSerialFocuser):
         self._is_moving = True
         try:
             new_pos = self.position + increment
-            self._send_command(f'M{int(new_pos):d}#')
+            self._send_command(f'M{int(new_pos):d}')
         finally:
             # Focuser move commands block until the move is finished, so if the command has
             # returned then the focuser is no longer moving.
@@ -107,62 +113,63 @@ class Focuser(AbstractSerialFocuser):
         self.logger.debug(f"Moved by {increment} encoder units. Current position is {new_pos}")
         return new_pos
 
-    ##################################################################################################
+    ################################################################################################
     # Private Methods
-    ##################################################################################################
+    ################################################################################################
 
-    def _send_command(self, command):
+    def _send_command(self, command, pre_cmd='', post_cmd='#'):
         """
         Sends a command to the focuser adaptor and retrieves the response.
 
         Args:
-            command (string): command string to send (without newline), e.g. 'P#'
-            response length (integer, optional, default=None): number of lines of response expected.
-                For most commands this should be 0 or 1. If None readlines() will be called to
-                capture all responses. As this will block until the timeout expires it should only
-                be used if the number of lines expected is not known (e.g. 'ds' command).
+            command (string): command string to send (without newline), e.g. 'P#'.
+            pre_cmd (string): Prefix for the command, default empty string.
+            post_cmd (string): Post for the command, default '#' for astromechs.
+
 
         Returns:
             string:  containing the '\r' terminated lines of the response from the adaptor.
         """
         if not self.is_connected:
-            self.logger.critical("Attempt to send command to {} when not connected!".format(self))
+            self.logger.critical(f"Attempt to send command to {self} when not connected!")
             return
 
         # Clear the input buffer in case there's anything left over in there.
         self._serial_port.reset_input_buffer()
 
         # Send command
-        self._serial_io.write(command + '\r')
+        self._serial_io.write(f'{command}{post_cmd}\r')
 
-        return self._serial_io.readline()
+        return self._serial_io.readline(self._serial_port.in_waiting)
 
     def _initialise(self):
-        self._is_moving = True
-        try:
-            # Initialise the aperture motor. This also has the side effect of fully opening the iris.
-            self._initialise_aperture()
+        # Initialise the aperture motor. This also has the side effect of fully opening the iris.
+        self._initialise_aperture()
 
-            # Initalise focus. First move the focus to the close stop.
-            self._move_zero()
-            self._min_position = 0
+        # Initalise focus. First move the focus to the close stop.
+        self._move_zero()
+        self._min_position = 0
 
-            self.logger.info(f'{self} initialised')
-        finally:
-            self._is_moving = False
+        self.logger.info(f'{self} initialised')
 
     def _initialise_aperture(self):
         self.logger.debug('Initialising aperture motor')
-        self._send_command('A00#')
-        self.logger.debug('Aperture initialised')
+        self._is_moving = True
+        try:
+            self._send_command('A00')
+            self.logger.debug('Aperture initialised')
+        finally:
+            self._is_moving = False
 
     def _move_zero(self):
         self.logger.debug('Setting focus encoder zero point')
-        self._is_moving = True
-        try:
-            # Set focuser to 0 position
-            self._send_command('M0#')
-
-            self.logger.debug('Moved to encoder position 0')
-        finally:
-            self._is_moving = False
+        if self.position != 0:
+            self._is_moving = True
+            try:
+                # Set focuser to 0 position
+                self._send_command('M0')
+                self.logger.debug('Focuser has been set to encoder position 0')
+            finally:
+                self._is_moving = False
+        else:
+            self.logger.debug('Focuser already at encoder position 0')

--- a/src/panoptes/pocs/focuser/astromechanics.py
+++ b/src/panoptes/pocs/focuser/astromechanics.py
@@ -138,7 +138,7 @@ class Focuser(AbstractSerialFocuser):
         self._serial_port.reset_input_buffer()
 
         # Send command
-        self._serial_io.write(f'{command}{post_cmd}\r')
+        self._serial_io.write(f'{pre_cmd}{command}{post_cmd}\r')
 
         return self._serial_io.readline(self._serial_port.in_waiting)
 

--- a/tests/test_focuser.py
+++ b/tests/test_focuser.py
@@ -146,4 +146,4 @@ def test_camera_association_on_init():
 
 def test_astromechs_find_fail(focuser, tolerance):
     with pytest.raises(error.NotFound):
-        AstroMechanicsFocuser(vendor_id='foo', product_id='bar')
+        AstroMechanicsFocuser(vendor_id='0xfoo', product_id='0xbar')

--- a/tests/test_focuser.py
+++ b/tests/test_focuser.py
@@ -146,4 +146,4 @@ def test_camera_association_on_init():
 
 def test_astromechs_find_fail(focuser, tolerance):
     with pytest.raises(error.NotFound):
-        AstroMechanicsFocuser(vendor_id='0xfoo', product_id='0xbar')
+        AstroMechanicsFocuser(vendor_id=0xf00, product_id=0xba2)


### PR DESCRIPTION
* Use the `vendor_id` and `product_id` of the astromech to find the matching serial device path. This is mostly taken from #1070 but minimizes the changes to just the astromech and leaves the Birger and base focuser class alone. **This is expecting the vendor and product ids to be in hex (e.g. `0x12345`), is this correct?**
* Moves the `#` command terminator to `_send_command` as a `post_cmd` default param. I've added `pre_cmd` for completeness and to be compatible with a future change to the base class.
* Also adds a `hint` to `readline` to try and speed up the reading from serial.
* Whitespace and f-string replacements included.

## Related Issue
Replaces #1070 
#1124 might not be necessary with this.

@JAAlvarado-Montes does this accomplish what #1070 was supposed to? 