### PR TITLE
Focuser class  consistency

### DIFF
--- a/src/panoptes/pocs/focuser/astromechanics.py
+++ b/src/panoptes/pocs/focuser/astromechanics.py
@@ -61,22 +61,21 @@ class Focuser(AbstractSerialFocuser):
         # Return string that makes it clear there is no serial number
         return "no_serial_number_available"
 
-    def move_to(self, new_position):
-        """
-        Moves focuser to a new position.
-
-        Args:
-            position (int): new focuser position, in encoder units
-
-        Returns:
-            int: focuser position following the move, in encoder units.
+    def move_to(self, position):
+        """ Moves focuser to a new position.
 
         Does not do any checking of the requested position but will warn if the lens reports
         hitting a stop.
+
+        Args:
+            position (int): new focuser position, in encoder units.
+
+        Returns:
+            int: focuser position following the move, in encoder units.
         """
         self._is_moving = True
         try:
-            self._send_command(f'M{int(new_position):d}#')
+            self._send_command(f'M{int(position):d}#')
         finally:
             # Focuser move commands block until the move is finished, so if the command has
             # returned then the focuser is no longer moving.
@@ -86,14 +85,16 @@ class Focuser(AbstractSerialFocuser):
         return self.position
 
     def move_by(self, increment):
-        """
-        Move focuser by a given amount.
+        """ Move focuser by a given amount.
+
+        Does not do any checking of the requested increment but will warn if the lens reports
+        hitting a stop.
 
         Args:
             increment (int): distance to move the focuser, in encoder units.
 
         Returns:
-            int: distance moved, in encoder units.
+            int: focuser position following the move, in encoder units.
         """
         self._is_moving = True
         try:
@@ -105,7 +106,7 @@ class Focuser(AbstractSerialFocuser):
             self._is_moving = False
 
         self.logger.debug(f"Moved by {increment} encoder units. Current position is {new_pos}")
-        return new_pos
+        return self.position
 
     ##################################################################################################
     # Private Methods

--- a/src/panoptes/pocs/focuser/birger.py
+++ b/src/panoptes/pocs/focuser/birger.py
@@ -99,7 +99,7 @@ class Focuser(AbstractSerialFocuser):
                     warn(message)
                     return
                 else:
-                    self.logger.debug('Connected Birger focusers: {}'.format(Focuser._adaptor_nodes))
+                    self.logger.debug(f'Connected Birger focusers: {Focuser._adaptor_nodes}')
 
             # Search in cached device node scanning results for serial number
             try:
@@ -181,14 +181,14 @@ class Focuser(AbstractSerialFocuser):
         """
         Moves focuser to a new position.
 
+        Does not do any checking of the requested position but will warn if the lens reports
+        hitting a stop.
+
         Args:
-            position (int): new focuser position, in encoder units
+            position (int): new focuser position, in encoder units.
 
         Returns:
             int: focuser position following the move, in encoder units.
-
-        Does not do any checking of the requested position but will warn if the lens reports
-        hitting a stop.
         """
         self._is_moving = True
         try:
@@ -199,21 +199,21 @@ class Focuser(AbstractSerialFocuser):
             # returned then the focuser is no longer moving.
             self._is_moving = False
 
-        self.logger.debug("Moved to encoder position {}".format(new_position))
-        return new_position
+        self.logger.debug(f"Moved to encoder position {new_position}")
+        return self.position
 
     def move_by(self, increment):
         """
         Move focuser by a given amount.
 
+        Does not do any checking of the requested increment but will warn if the lens reports
+        hitting a stop.
+
         Args:
             increment (int): distance to move the focuser, in encoder units.
 
         Returns:
-            int: distance moved, in encoder units.
-
-        Does not do any checking of the requested increment but will warn if the lens reports
-        hitting a stop.
+            int: focuser position following the move, in encoder units.
         """
         self._is_moving = True
         try:
@@ -225,7 +225,7 @@ class Focuser(AbstractSerialFocuser):
             self._is_moving = False
 
         self.logger.debug("Moved by {} encoder units".format(moved_by))
-        return moved_by
+        return self.position
 
     ##################################################################################################
     # Private Methods

--- a/src/panoptes/pocs/focuser/focuser.py
+++ b/src/panoptes/pocs/focuser/focuser.py
@@ -168,11 +168,25 @@ class AbstractFocuser(PanBase, metaclass=ABCMeta):
 
     @abstractmethod
     def move_to(self, position):
-        """ Move focuser to new encoder position """
+        """ Move focuser to new encoder position.
+
+        Args:
+            position (int): new focuser position, in encoder units.
+
+        Returns:
+            int: focuser position following the move, in encoder units.
+        """
         raise NotImplementedError
 
     def move_by(self, increment):
-        """ Move focuser by a given amount """
+        """ Move focuser by a given amount.
+
+        Args:
+            increment (int): distance to move the focuser, in encoder units.
+
+        Returns:
+            int: focuser position following the move, in encoder units.
+        """
         return self.move_to(self.position + increment)
 
     def autofocus(self,

--- a/src/panoptes/pocs/focuser/simulator.py
+++ b/src/panoptes/pocs/focuser/simulator.py
@@ -65,7 +65,7 @@ class Focuser(AbstractFocuser):
 
     def move_by(self, increment):
         """ Move focuser by a given amount """
-        self.logger.debug('Moving focuser {} by {}'.format(self.uid, increment))
+        self.logger.debug(f'Moving focuser {self.uid} by {increment}')
         self._is_moving = True
         time.sleep(1)
         previous_position = self._position
@@ -74,4 +74,4 @@ class Focuser(AbstractFocuser):
         position = max(position, self.min_position)
         self._position = position
         self._is_moving = False
-        return position - previous_position
+        return self.position

--- a/tests/test_focuser.py
+++ b/tests/test_focuser.py
@@ -78,8 +78,7 @@ def test_move_to(focuser, tolerance):
 
 
 def test_move_by(focuser, tolerance):
-    focuser.move_to(100)
-    previous_position = focuser.position
+    previous_position = focuser.move_to(100)
     increment = -13
     new_position = focuser.move_by(increment)
     assert new_position == pytest.approx((previous_position + increment), abs=tolerance)

--- a/tests/test_focuser.py
+++ b/tests/test_focuser.py
@@ -72,7 +72,8 @@ def test_init(focuser):
 
 
 def test_move_to(focuser, tolerance):
-    focuser.move_to(100)
+    new_position = focuser.move_to(100)
+    assert focuser.position == new_position
     assert focuser.position == pytest.approx(100, abs=tolerance)
 
 
@@ -80,8 +81,8 @@ def test_move_by(focuser, tolerance):
     focuser.move_to(100)
     previous_position = focuser.position
     increment = -13
-    focuser.move_by(increment)
-    assert focuser.position == pytest.approx((previous_position + increment), abs=tolerance)
+    new_position = focuser.move_by(increment)
+    assert new_position == pytest.approx((previous_position + increment), abs=tolerance)
 
 
 def test_is_ready(focuser):


### PR DESCRIPTION
## Description
* Make the `move_to` and `move_by` classes more consistent. Always return the `self.position`.
* Update docstrings.

@danjampro I didn't quite understand what you meant with https://github.com/panoptes/POCS/pull/1125#discussion_r656677589 so it's not part of this PR but could be. Or a separate small one.

> I noticed that the move to initial position is currently done in the Birger class rather than the abstract serial class or abstract focuser class. Maybe it should be implemented here or in the base class for consistency?

## Related Issue
Closes #1106
Related to #1125