### PR TITLE
Power Board - AC_OK and BAT_LOW

### DIFF
--- a/resources/arduino/PowerBoard/PowerBoard.ino
+++ b/resources/arduino/PowerBoard/PowerBoard.ino
@@ -4,6 +4,14 @@
 // POCS looks for this name.
 const char BOARD_NAME[] = "power_board";
 
+// Meanwell UPS AC and Battery pins.
+const int AC_OK = 12;
+const int BAT_LOW = 11;
+
+/******************************************/
+/* Shouldn't need to change anything below.
+/******************************************/
+
 // Set initial states for each relay. Change as needed.
 const bool DEFAULT_START_0 = HIGH;
 const bool DEFAULT_START_1 = HIGH;
@@ -17,10 +25,6 @@ const int RELAY_1 = 3;  // 1_0 PROFET-0 Channel 1
 const int RELAY_2 = 4;  // 0_1 PROFET-1 Channel 0
 const int RELAY_3 = 7;  // 1_1 PROFET-1 Channel 1
 const int RELAY_4 = 8;  // 0_2 PROFET-2 Channel 0
-
-// AC_ok and Battery_low pins
-const int AC_OK = 12;
-const int BAT_LOW = 11;
 
 // Current Sense
 const int IS_0 = A0; // (PROFET-0 A0 = 14)

--- a/resources/arduino/PowerBoard/PowerBoard.ino
+++ b/resources/arduino/PowerBoard/PowerBoard.ino
@@ -11,15 +11,16 @@ const bool DEFAULT_START_2 = HIGH;
 const bool DEFAULT_START_3 = HIGH;
 const bool DEFAULT_START_4 = HIGH;
 
-//conversion factor to compute Iload from sensed voltage. From Luc.
-//const float MULTIPLIER = 5 / 1023 * 2360 / 1200;
-
 // Relays
 const int RELAY_0 = A3; // 0_0 PROFET-0 Channel 0 (A3 = 17)
 const int RELAY_1 = 3;  // 1_0 PROFET-0 Channel 1
 const int RELAY_2 = 4;  // 0_1 PROFET-1 Channel 0
 const int RELAY_3 = 7;  // 1_1 PROFET-1 Channel 1
 const int RELAY_4 = 8;  // 0_2 PROFET-2 Channel 0
+
+// AC_ok and Battery_low pins
+const int AC_OK = 12;
+const int BAT_LOW = 11;
 
 // Current Sense
 const int IS_0 = A0; // (PROFET-0 A0 = 14)
@@ -51,6 +52,10 @@ void setup() {
   pinMode(IS_0, INPUT);
   pinMode(IS_1, INPUT);
   pinMode(IS_2, INPUT);
+
+  // Setup AC and Battery pins
+  pinMode(AC_OK, INPUT);
+  pinMode(BAT_LOW, INPUT);
 
   // Setup diagnosis enable pins
   pinMode(DEN_0, OUTPUT);
@@ -135,6 +140,9 @@ void get_readings() {
   int seconds_stamp = millis() / time_period;
 
   StaticJsonDocument<192> doc;
+
+  doc["ac_ok"] = digitalRead(AC_OK);
+  doc["battery_low"] = digitalRead(BAT_LOW);
 
   JsonArray relays = doc.createNestedArray("relays");
   relays.add(is_relay_on(RELAY_0));


### PR DESCRIPTION
This PR adds the reading of digital pins `11` (`BAT_LOW`) and `12` (`AC_OK`) on the Arduino Uno attached to the TruckerBoard.

This will likely need some tweaking depending on how the Meanwell UPS is outputting, which should be verified with hardware testing.

