### PR TITLE
Focuser port and baudrate cleanup

### DIFF
--- a/src/panoptes/pocs/focuser/astromechanics.py
+++ b/src/panoptes/pocs/focuser/astromechanics.py
@@ -22,14 +22,17 @@ class Focuser(AbstractSerialFocuser):
     as they are marked with the decorator @abstractmethod, we have to override them.
     """
 
-    def __init__(self, name='Astromechanics Focuser', model='Canon EF-232', vendor_id=None,
-                 product_id=None, *args, **kwargs):
+    def __init__(self, name='Astromechanics Focuser', model='Canon EF-232', port=None,
+                 vendor_id=None, product_id=None, *args, **kwargs):
         # Check if have device, raise error.NotFound if unable to find.
-        self._serial_number = find_serial_port(vendor_id, product_id)
-        self._vendor_id = vendor_id
-        self._product_id = product_id
+        try:
+            port = find_serial_port(vendor_id, product_id)
+            self._vendor_id = vendor_id
+            self._product_id = product_id
+        except error.NotFound:
+            self.logger.debug(f'Could not find device port for {vendor_id=} and {product_id=}')
 
-        super().__init__(name=name, model=model, *args, **kwargs)
+        super().__init__(name=name, model=model, port=port, *args, **kwargs)
         self.logger.debug(f'Initializing {name}')
 
     ################################################################################################
@@ -62,8 +65,8 @@ class Focuser(AbstractSerialFocuser):
     # Public Methods
     ################################################################################################
 
-    def connect(self, port):
-        self._connect(port)
+    def connect(self, port=None, baudrate=38400):
+        self._connect(port=port, baudrate=baudrate)
 
         return self._serial_number
 

--- a/src/panoptes/pocs/focuser/astromechanics.py
+++ b/src/panoptes/pocs/focuser/astromechanics.py
@@ -151,7 +151,7 @@ class Focuser(AbstractSerialFocuser):
         # Send command
         self._serial_io.write(f'{pre_cmd}{command}{post_cmd}\r')
 
-        return self._serial_io.readline(self._serial_port.in_waiting)
+        return self._serial_io.readline()
 
     def _initialise(self):
         # Initialise the aperture motor. This also has the side effect of fully opening the iris.

--- a/src/panoptes/pocs/focuser/astromechanics.py
+++ b/src/panoptes/pocs/focuser/astromechanics.py
@@ -49,6 +49,7 @@ class Focuser(AbstractSerialFocuser):
         response = ''
         try:
             response = int(self._send_command("P").rstrip("#"))
+            self._position = response
         except Exception as e:
             self.logger.warning(f'Astromech focuser could not get current position: {e!r}')
         return response
@@ -173,7 +174,7 @@ class Focuser(AbstractSerialFocuser):
 
     def _move_zero(self):
         self.logger.debug('Setting focus encoder zero point')
-        if self.position != 0:
+        if self._position != 0:
             self._is_moving = True
             try:
                 # Set focuser to 0 position

--- a/src/panoptes/pocs/focuser/astromechanics.py
+++ b/src/panoptes/pocs/focuser/astromechanics.py
@@ -26,13 +26,9 @@ class Focuser(AbstractSerialFocuser):
     def __init__(self, name='Astromechanics Focuser', model='Canon EF-232', port=None,
                  vendor_id=0x0403, product_id=0x6001, *args, **kwargs):
         if vendor_id and product_id:
-            # Check if have device, raise error.NotFound if unable to find.
-            try:
-                port = find_serial_port(vendor_id, product_id)
-                self._vendor_id = vendor_id
-                self._product_id = product_id
-            except Exception as e:
-                get_logger().debug(f'Could not find device port for {vendor_id=} and {product_id=}')
+            port = find_serial_port(vendor_id, product_id)
+            self._vendor_id = vendor_id
+            self._product_id = product_id
 
         super().__init__(name=name, model=model, port=port, *args, **kwargs)
         self.logger.debug(f'Initializing {name}')
@@ -84,7 +80,7 @@ class Focuser(AbstractSerialFocuser):
         hitting a stop.
 
         Args:
-            new_position (int): new focuser position, in encoder units.
+            position (int): new focuser position, in encoder units.
 
         Returns:
             int: focuser position following the move, in encoder units.

--- a/src/panoptes/pocs/focuser/birger.py
+++ b/src/panoptes/pocs/focuser/birger.py
@@ -125,7 +125,8 @@ class Focuser(AbstractSerialFocuser):
         Returns current focus position in the lens focus encoder units.
         """
         response = self._send_command('pf', response_length=1)
-        return int(response[0].rstrip())
+        self._position = int(response[0].rstrip())
+        return self._position
 
     @property
     def min_position(self):

--- a/src/panoptes/pocs/focuser/birger.py
+++ b/src/panoptes/pocs/focuser/birger.py
@@ -49,7 +49,7 @@ class Focuser(AbstractSerialFocuser):
         model (str, optional): default 'Canon EF-232'
         initial_position (int, optional): if given the focuser will drive to this encoder position
             following initialisation.
-        dev_node_pattern (str, optional): Unix shell pattern to use to identify device nodes that
+        port (str, optional): Unix shell pattern to use to identify device nodes that
             may have a Birger adaptor attached. Default is '/dev/tty.USA49*.?', which is intended
             to match all the nodes created by Tripplite Keyway USA-49 USB-serial adaptors, as
             used at the time of writing by Huntsman.
@@ -62,7 +62,7 @@ class Focuser(AbstractSerialFocuser):
                  name='Birger Focuser',
                  model='Canon EF-232',
                  initial_position=None,
-                 dev_node_pattern='/dev/tty.USA49*.?',
+                 port='/dev/tty.USA49*.?',
                  max_command_retries=5,
                  *args, **kwargs):
 
@@ -80,7 +80,7 @@ class Focuser(AbstractSerialFocuser):
                 self.logger.debug('Getting serial numbers for all connected Birger focusers')
                 Focuser._adaptor_nodes = {}
                 # Find nodes matching pattern
-                device_nodes = glob.glob(dev_node_pattern)
+                device_nodes = glob.glob(port)
 
                 # Open each device node and see if a Birger focuser answers
                 for device_node in device_nodes:
@@ -166,9 +166,8 @@ class Focuser(AbstractSerialFocuser):
     # Public Methods
     ##################################################################################################
 
-    def connect(self, port):
-
-        self._connect(port, baudrate=115200)
+    def connect(self, port=None, baudrate=115200):
+        self._connect(port=port, baudrate=baudrate)
 
         # Set 'verbose' and 'legacy' response modes. The response from this depends on
         # what the current mode is... but after a power cycle it should be 'rm1,0', 'OK'

--- a/src/panoptes/pocs/focuser/serial.py
+++ b/src/panoptes/pocs/focuser/serial.py
@@ -7,7 +7,6 @@ from panoptes.pocs.focuser import AbstractFocuser
 
 
 class AbstractSerialFocuser(AbstractFocuser):
-
     # Class variable to cache the device node scanning results
     _adaptor_nodes = None
 
@@ -75,7 +74,8 @@ class AbstractSerialFocuser(AbstractFocuser):
     # Private Methods
     ##################################################################################################
 
-    def _connect(self, port, baudrate):
+    def _connect(self, port=None, baudrate=9600):
+        port = port or self.port
         try:
             # Configure serial port.
             self._serial_port = serial.Serial()
@@ -96,7 +96,7 @@ class AbstractSerialFocuser(AbstractFocuser):
 
         except serial.SerialException as err:
             self._serial_port = None
-            self.logger.critical('Could not open {}!'.format(port))
+            self.logger.critical(f'Could not open {port}!')
             raise err
 
         # Want to use a io.TextWrapper in order to have a readline() method with universal newlines
@@ -104,4 +104,4 @@ class AbstractSerialFocuser(AbstractFocuser):
         # a write contains a newline character.
         self._serial_io = io.TextIOWrapper(io.BufferedRWPair(self._serial_port, self._serial_port),
                                            newline='\r', encoding='ascii', line_buffering=True)
-        self.logger.debug('Established serial connection to {} on {}.'.format(self.name, port))
+        self.logger.debug(f'Established serial connection to {self.name} on {port}.')

--- a/tests/test_focuser.py
+++ b/tests/test_focuser.py
@@ -144,6 +144,8 @@ def test_camera_association_on_init():
     assert focuser.camera is sim_camera
 
 
-def test_astromechs_find_fail(focuser, tolerance):
-    with pytest.raises(error.NotFound):
-        AstroMechanicsFocuser(vendor_id=0xf00, product_id=0xba2)
+def test_astromechs_find_fail(focuser, tolerance, caplog):
+    v_id = 0xf00
+    p_id = 0xba2
+    focuser = AstroMechanicsFocuser(vendor_id=v_id, product_id=p_id)
+    assert caplog.records[-1].message == f'Could not find device port for {v_id} and {p_id}'

--- a/tests/test_focuser.py
+++ b/tests/test_focuser.py
@@ -148,4 +148,10 @@ def test_astromechs_find_fail(focuser, tolerance, caplog):
     v_id = 0xf00
     p_id = 0xba2
     focuser = AstroMechanicsFocuser(vendor_id=v_id, product_id=p_id)
-    assert caplog.records[-1].message == f'Could not find device port for {v_id} and {p_id}'
+    found_log = False
+    for record in caplog.records:
+        if record.message == f'Could not find device port for {v_id} and {p_id}':
+            found_log = True
+            break
+
+    assert found_log

--- a/tests/test_focuser.py
+++ b/tests/test_focuser.py
@@ -150,7 +150,7 @@ def test_astromechs_find_fail(focuser, tolerance, caplog):
     focuser = AstroMechanicsFocuser(vendor_id=v_id, product_id=p_id)
     found_log = False
     for record in caplog.records:
-        if record.message == f'Could not find device port for {v_id} and {p_id}':
+        if record.message == f'Could not find device port for {v_id:x} and {p_id:x}':
             found_log = True
             break
 

--- a/tests/test_focuser.py
+++ b/tests/test_focuser.py
@@ -147,11 +147,5 @@ def test_camera_association_on_init():
 def test_astromechs_find_fail(focuser, tolerance, caplog):
     v_id = 0xf00
     p_id = 0xba2
-    focuser = AstroMechanicsFocuser(vendor_id=v_id, product_id=p_id)
-    found_log = False
-    for record in caplog.records:
-        if record.message == f'Could not find device port for {v_id:x} and {p_id:x}':
-            found_log = True
-            break
-
-    assert found_log
+    with pytest.raises(error.NotFound):
+        AstroMechanicsFocuser(vendor_id=v_id, product_id=p_id)


### PR DESCRIPTION
* base `connect()` method accepts optional `port` and `baudrate` params. If `port` is not specified it uses `self.port`, which should be assigned upon init by the concrete classes.
* Birger `dev_node_pattern` changed to `port` for consistency, but it can handle a pattern instead of just a specific port.
* Astromechs attempt to look up the port via a `vendor_id` and `product_id` and if error or none provided revert to the `port` param.
* Set baudrate defaults for Birger and Astromech

## Related Issue
Fixes issues introduced in #1126 