### PR TITLE
Warn on missing state transition

### DIFF
--- a/src/panoptes/pocs/state/machine.py
+++ b/src/panoptes/pocs/state/machine.py
@@ -191,8 +191,6 @@ class PanStateMachine(Machine):
         Returns:
             bool: If state was successfully changed.
         """
-        state_changed = False
-
         # Get the next transition method based off `state` and `next_state`
         transition_method_name = self._lookup_trigger()
         transition_method = getattr(self, transition_method_name, self.park)
@@ -337,6 +335,7 @@ class PanStateMachine(Machine):
                     return state_info['trigger']
 
         # Return parking if we don't find anything
+        self.logger.warning(f'No transition for {self.state} -> {self.next_state}, going to park')
         return 'parking'
 
     def _update_status(self, event_data):

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -32,7 +32,7 @@ def test_load_state_info(observatory):
     pocs._load_state('ready', state_info={'tags': ['at_twilight']})
 
 
-def test_lookup_trigger_default_park(observatory):
+def test_lookup_trigger_default_park(observatory, caplog):
     pocs = POCS(observatory)
 
     pocs._load_state('ready', state_info={'tags': ['at_twilight']})
@@ -40,6 +40,9 @@ def test_lookup_trigger_default_park(observatory):
     pocs.next_state = 'foobar'
     next_state = pocs._lookup_trigger()
     assert next_state == 'parking'
+
+    assert caplog.records[-1].levelname == 'WARNING'
+    assert caplog.records[-1].message == 'No transition for ready -> foobar, going to park'
 
 
 def test_state_machine_absolute(temp_file):

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -32,6 +32,16 @@ def test_load_state_info(observatory):
     pocs._load_state('ready', state_info={'tags': ['at_twilight']})
 
 
+def test_lookup_trigger_default_park(observatory):
+    pocs = POCS(observatory)
+
+    pocs._load_state('ready', state_info={'tags': ['at_twilight']})
+    pocs.state = 'ready'
+    pocs.next_state = 'foobar'
+    next_state = pocs._lookup_trigger()
+    assert next_state == 'parking'
+
+
 def test_state_machine_absolute(temp_file):
     state_table = POCS.load_state_table()
     assert isinstance(state_table, dict)


### PR DESCRIPTION
Logs a warning if not valid transition exists between `state` and `next_state`.  Still returns `parking`.

Removes unnecessary variable creation.

## Related Issue
Closes #1110 