### PR TITLE
parse port in birger init

### DIFF
--- a/src/panoptes/pocs/focuser/birger.py
+++ b/src/panoptes/pocs/focuser/birger.py
@@ -68,7 +68,7 @@ class Focuser(AbstractSerialFocuser):
 
         self._max_command_retries = max_command_retries
 
-        super().__init__(name=name, model=model, *args, **kwargs)
+        super().__init__(name=name, model=model, port=port, *args, **kwargs)
         self.logger.debug('Initialising Birger focuser')
 
         if serial_number_pattern.match(self.port):


### PR DESCRIPTION
Fixes a bug where the port is not parsed on Birger focuser init function.

## How Has This Been Tested?
Tested on hardware.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)