### PR TITLE
Fix calibration of astromechanics focuser

### DIFF
--- a/src/panoptes/pocs/focuser/astromechanics.py
+++ b/src/panoptes/pocs/focuser/astromechanics.py
@@ -174,7 +174,7 @@ class Focuser(AbstractSerialFocuser):
             self._is_moving = False
 
     def _move_zero(self):
-        self.logger.debug('Setting focus encoder zero point at position={self._zero_point}')
+        self.logger.debug('Setting focus encoder zero point at position={self._zero_position}')
 
         self._is_moving = True
         try:

--- a/src/panoptes/pocs/focuser/astromechanics.py
+++ b/src/panoptes/pocs/focuser/astromechanics.py
@@ -87,7 +87,7 @@ class Focuser(AbstractSerialFocuser):
             int: focuser position following the move, in encoder units.
         """
 
-        # Add the the position of the near focus stop to the position we want to move to.
+        # Add the position of the near focus stop to the position we want to move to.
         position = position + self._calibration_position
 
         self._is_moving = True

--- a/src/panoptes/pocs/focuser/astromechanics.py
+++ b/src/panoptes/pocs/focuser/astromechanics.py
@@ -86,7 +86,7 @@ class Focuser(AbstractSerialFocuser):
             int: focuser position following the move, in encoder units.
         """
 
-        # Subtract the near stop value from the position we want to move to
+        # Add the calibration position to the position we want to move to
         position = position + self._calibration_position
 
         self._is_moving = True

--- a/src/panoptes/pocs/focuser/astromechanics.py
+++ b/src/panoptes/pocs/focuser/astromechanics.py
@@ -180,6 +180,6 @@ class Focuser(AbstractSerialFocuser):
         try:
             # Move to a position that is larger than the movement range of the lens.
             self._send_command(f'M{int(self._calibration_position):d}')
-            self.logger.debug('Near stop of focuser has been calibrated')
+            self.logger.debug('Zero point of focuser has been calibrated at {self._zero_point}')
         finally:
             self._is_moving = False

--- a/src/panoptes/pocs/focuser/astromechanics.py
+++ b/src/panoptes/pocs/focuser/astromechanics.py
@@ -44,6 +44,7 @@ class Focuser(AbstractSerialFocuser):
         """
         response = ''
         try:
+            # Subtract the calibration position to get the actual position of the focuser.
             response = int(self._send_command("P").rstrip("#")) - int(self._calibration_position)
             self._position = response
         except Exception as e:
@@ -86,7 +87,7 @@ class Focuser(AbstractSerialFocuser):
             int: focuser position following the move, in encoder units.
         """
 
-        # Add the calibration position to the position we want to move to
+        # Add the the position of the near focus stop to the position we want to move to.
         position = position + self._calibration_position
 
         self._is_moving = True

--- a/src/panoptes/pocs/focuser/astromechanics.py
+++ b/src/panoptes/pocs/focuser/astromechanics.py
@@ -22,7 +22,7 @@ class Focuser(AbstractSerialFocuser):
     """
 
     def __init__(self, name='Astromechanics Focuser', model='Canon EF-232', port=None,
-                 vendor_id=0x0403, product_id=0x6001, calibration_position=-25000, *args, **kwargs):
+                 vendor_id=0x0403, product_id=0x6001, zero_position=-25000, *args, **kwargs):
         if vendor_id and product_id:
             port = find_serial_port(vendor_id, product_id)
             self._vendor_id = vendor_id

--- a/src/panoptes/pocs/focuser/astromechanics.py
+++ b/src/panoptes/pocs/focuser/astromechanics.py
@@ -174,7 +174,7 @@ class Focuser(AbstractSerialFocuser):
         finally:
             self._is_moving = False
 
-    def _calibrate_near_stop(self):
+    def _move_zero(self):
         self.logger.debug('Calibrating focus encoder near stop')
 
         self._is_moving = True

--- a/src/panoptes/pocs/focuser/astromechanics.py
+++ b/src/panoptes/pocs/focuser/astromechanics.py
@@ -180,6 +180,6 @@ class Focuser(AbstractSerialFocuser):
         try:
             # Move to a position that is larger than the movement range of the lens.
             self._send_command(f'M{int(self._calibration_position):d}')
-            self.logger.debug('Zero point of focuser has been calibrated at {self._zero_point}')
+            self.logger.debug('Zero point of focuser has been calibrated at {self._zero_position}')
         finally:
             self._is_moving = False

--- a/src/panoptes/pocs/focuser/astromechanics.py
+++ b/src/panoptes/pocs/focuser/astromechanics.py
@@ -179,7 +179,7 @@ class Focuser(AbstractSerialFocuser):
         self._is_moving = True
         try:
             # Move to a position that is larger than the movement range of the lens.
-            self._send_command(f'M{int(self._calibration_position):d}')
+            self._send_command(f'M{int(self._zero_position):d}')
             self.logger.debug('Zero point of focuser has been calibrated at {self._zero_position}')
         finally:
             self._is_moving = False

--- a/src/panoptes/pocs/focuser/astromechanics.py
+++ b/src/panoptes/pocs/focuser/astromechanics.py
@@ -28,7 +28,7 @@ class Focuser(AbstractSerialFocuser):
             self._vendor_id = vendor_id
             self._product_id = product_id
 
-        self._calibration_position = calibration_position
+        self._zero_position = zero_position
 
         super().__init__(name=name, model=model, port=port, *args, **kwargs)
         self.logger.debug(f'Initializing {name}')

--- a/src/panoptes/pocs/focuser/astromechanics.py
+++ b/src/panoptes/pocs/focuser/astromechanics.py
@@ -45,7 +45,7 @@ class Focuser(AbstractSerialFocuser):
         response = ''
         try:
             # Subtract the calibration position to get the actual position of the focuser.
-            response = int(self._send_command("P").rstrip("#")) - int(self._calibration_position)
+            response = int(self._send_command("P").rstrip("#")) - int(self._zero_position)
             self._position = response
         except Exception as e:
             self.logger.warning(f'Astromech focuser could not get current position: {e!r}')

--- a/src/panoptes/pocs/focuser/astromechanics.py
+++ b/src/panoptes/pocs/focuser/astromechanics.py
@@ -159,9 +159,8 @@ class Focuser(AbstractSerialFocuser):
         self._initialise_aperture()
 
         # Calibrate near stop of the astromechanics focuser.
-        self._calibrate_near_stop()
-
-        self._min_position = self._calibration_position
+        self._move_zero()
+        self._min_position = self._zero_position
 
         self.logger.info(f'{self} initialised')
 

--- a/src/panoptes/pocs/focuser/astromechanics.py
+++ b/src/panoptes/pocs/focuser/astromechanics.py
@@ -174,7 +174,7 @@ class Focuser(AbstractSerialFocuser):
             self._is_moving = False
 
     def _move_zero(self):
-        self.logger.debug('Calibrating focus encoder near stop')
+        self.logger.debug('Setting focus encoder zero point at position={self._zero_point}')
 
         self._is_moving = True
         try:

--- a/src/panoptes/pocs/focuser/astromechanics.py
+++ b/src/panoptes/pocs/focuser/astromechanics.py
@@ -88,7 +88,7 @@ class Focuser(AbstractSerialFocuser):
         """
 
         # Add the position of the near focus stop to the position we want to move to.
-        position = position + self._calibration_position
+        position = position + self._zero_position
 
         self._is_moving = True
         try:


### PR DESCRIPTION
This small PR improves the way at how astromechanics focusers are calibrated.

## Description
A new way to calibrate the astromechanics focusers is added here. Now the "zero point" is found by forcing the focuser to hit the near stop value when moving outside the movement range of the lens.

## How Has This Been Tested?
Current tests should test this.

## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
