### PR TITLE
Remote Camera Service

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -159,9 +159,7 @@ def pytest_runtest_logfinish(nodeid, location):
         location – a triple of (filename, linenum, testname)
     """
     with suppress(Exception):
-        logger.log('testing', '')
-        logger.log('testing', f'       END TEST {nodeid}')
-        logger.log('testing', '##########' * 8)
+        logger.log('testing', f'{" END TEST " + nodeid:*^80}')
 
 
 @pytest.fixture(scope='session')

--- a/conftest.py
+++ b/conftest.py
@@ -147,9 +147,7 @@ def pytest_runtest_logstart(nodeid, location):
         location – a triple of (filename, linenum, testname)
     """
     with suppress(Exception):
-        logger.log('testing', '##########' * 8)
-        logger.log('testing', f'     START TEST {nodeid}')
-        logger.log('testing', '')
+        logger.log('testing', f'{" START TEST " + nodeid:*^80}')
 
 
 def pytest_runtest_logfinish(nodeid, location):

--- a/conftest.py
+++ b/conftest.py
@@ -45,7 +45,7 @@ logger.add(log_file_path,
            rotation=lambda msg, _: startup_message in msg,
            level=TESTING_LOG_LEVEL)
 
-logger.log('testing', '*' * 25 + startup_message + '*' * 25)
+logger.log('testing', '{startup_message:*^50}')
 
 # Make the log file world readable.
 os.chmod(log_file_path, stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)

--- a/src/panoptes/pocs/camera/__init__.py
+++ b/src/panoptes/pocs/camera/__init__.py
@@ -105,7 +105,8 @@ def create_cameras_from_config(config=None,
             logger.warning(e)
 
         if len(ports) == 0:
-            raise error.CameraNotFound(msg="No cameras detected. For testing, use camera simulator.")
+            raise error.CameraNotFound(
+                msg="No cameras detected. For testing, use camera simulator.")
         else:
             logger.debug(f"Detected ports={ports!r}")
 
@@ -113,16 +114,19 @@ def create_cameras_from_config(config=None,
 
     device_info = camera_config['devices']
     for cam_num, cfg in enumerate(device_info):
+        logger.debug(f'Creating {cam_num=} with {cfg=!r}')
         # Get a copy of the camera defaults and update with device config.
         device_config = camera_defaults.copy()
         device_config.update(cfg)
 
         cam_name = device_config.setdefault('name', f'Cam{cam_num:02d}')
+        logger.debug(f'Camera name set to {cam_name=}')
 
         # Check for proper connection method.
         model = device_config['model']
+        logger.debug(f'Using camera {model=}')
 
-        # Assign an auto-detected port. If none are left, skip
+        # Assign an auto-detected port. If none are left, skip.
         if auto_detect:
             try:
                 device_config['port'] = ports.pop()
@@ -132,11 +136,11 @@ def create_cameras_from_config(config=None,
         elif model == 'simulator':
             device_config['port'] = f'usb:999,{random.randint(0, 1000):03d}'
 
-        logger.debug(f'Creating camera: {model}')
+        logger.debug(f'Creating camera: {model=!r} {device_config=!r}')
 
         try:
             module = load_module(model)
-            logger.debug(f'Camera module: module={module!r}')
+            logger.debug(f'Camera module: {module=!r}')
 
             if recreate_existing:
                 with suppress(AttributeError):
@@ -144,10 +148,10 @@ def create_cameras_from_config(config=None,
 
             # We either got a class or a module.
             if callable(module):
-                camera = module(**device_config)
+                cam_object = module(**device_config)
             else:
                 if hasattr(module, 'Camera'):
-                    camera = module.Camera(**device_config)
+                    cam_object = module.Camera(**device_config)
                 else:
                     raise error.NotFound(f'module={module!r} does not have a Camera object')
         except error.NotFound:
@@ -156,20 +160,20 @@ def create_cameras_from_config(config=None,
             logger.error(f'Cannot create camera type: {model} {e!r}')
         else:
             # Check if the config specified a primary camera and if it matches.
-            if camera.uid == camera_config.get('primary'):
-                camera.is_primary = True
-                primary_camera = camera
+            if cam_object.uid == camera_config.get('primary'):
+                cam_object.is_primary = True
+                primary_camera = cam_object
 
-            logger.debug(f"Camera created: camera={camera!r}")
+            logger.debug(f"Camera created: camera={cam_object!r}")
 
-            cameras[cam_name] = camera
+            cameras[cam_name] = cam_object
 
     if len(cameras) == 0:
         raise error.CameraNotFound(msg="No cameras available")
 
     # If no camera was specified as primary use the first
     if primary_camera is None and auto_primary:
-        logger.info(f'No primary camera given, assigning the first camera (auto_primary={auto_primary!r})')
+        logger.info(f'No primary camera given, assigning the first camera ({auto_primary=!r})')
         primary_camera = list(cameras.values())[0]  # First camera
         primary_camera.is_primary = True
 

--- a/src/panoptes/pocs/camera/__init__.py
+++ b/src/panoptes/pocs/camera/__init__.py
@@ -105,8 +105,7 @@ def create_cameras_from_config(config=None,
             logger.warning(e)
 
         if len(ports) == 0:
-            raise error.CameraNotFound(
-                msg="No cameras detected. For testing, use camera simulator.")
+            raise error.CameraNotFound(msg="No cameras detected. For testing, use simulator.")
         else:
             logger.debug(f"Detected ports={ports!r}")
 

--- a/src/panoptes/pocs/camera/camera.py
+++ b/src/panoptes/pocs/camera/camera.py
@@ -124,14 +124,11 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
             if subcomponent is not None:
                 self.logger.debug(f'Creating {attr_name} with {subcomponent=!r}')
 
-                try:
-                    subcomponent = self._create_subcomponent(class_path, subcomponent)
-                    self.logger.debug(f'Assigning {subcomponent=!r} to {attr_name=!r}')
-                    setattr(self, attr_name, subcomponent)
-                    # Keep a list of active subcomponents
-                    self.subcomponents[attr_name] = subcomponent
-                except error.NotFound:
-                    self.logger.warning(f'Cannot create {attr_name=}')
+                subcomponent = self._create_subcomponent(class_path, subcomponent)
+                self.logger.debug(f'Assigning {subcomponent=!r} to {attr_name=!r}')
+                setattr(self, attr_name, subcomponent)
+                # Keep a list of active subcomponents
+                self.subcomponents[attr_name] = subcomponent
 
         self.logger.info(f'Camera created: {self}')
 

--- a/src/panoptes/pocs/camera/camera.py
+++ b/src/panoptes/pocs/camera/camera.py
@@ -116,22 +116,24 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         self.subcomponents = dict()
         for attr_name, class_path in self._SUBCOMPONENT_LIST.items():
             # Create the subcomponent as an attribute with default None.
-            self.logger.debug(f'Setting default attr_name={attr_name!r} to None')
+            self.logger.debug(f'Setting default {attr_name=!r} to None')
             setattr(self, attr_name, None)
 
             # If given subcomponent class (or dict), try to create instance.
             subcomponent = kwargs.get(attr_name)
             if subcomponent is not None:
-                self.logger.debug(f'Found subcomponent={subcomponent!r}, creating instance')
+                self.logger.debug(f'Creating {attr_name} with {subcomponent=!r}')
 
-                subcomponent = self._create_subcomponent(class_path, subcomponent)
-                self.logger.debug(
-                    f'Assigning subcomponent={subcomponent!r} to attr_name={attr_name!r}')
-                setattr(self, attr_name, subcomponent)
-                # Keep a list of active subcomponents
-                self.subcomponents[attr_name] = subcomponent
+                try:
+                    subcomponent = self._create_subcomponent(class_path, subcomponent)
+                    self.logger.debug(f'Assigning {subcomponent=!r} to {attr_name=!r}')
+                    setattr(self, attr_name, subcomponent)
+                    # Keep a list of active subcomponents
+                    self.subcomponents[attr_name] = subcomponent
+                except error.NotFound:
+                    self.logger.warning(f'Cannot create {attr_name=}')
 
-        self.logger.debug(f'Camera created: {self}')
+        self.logger.info(f'Camera created: {self}')
 
     ############################################################################
     # Properties

--- a/src/panoptes/pocs/camera/gphoto/base.py
+++ b/src/panoptes/pocs/camera/gphoto/base.py
@@ -158,21 +158,6 @@ class AbstractGPhotoCamera(AbstractCamera):  # pragma: no cover
 
         return outs
 
-    def wait_for_command(self, timeout=10):
-        """ Wait for the given command to end
-
-        This method merely waits for a subprocess to complete but doesn't attempt to communicate
-        with the process (see `get_command_result` for that).
-        """
-        self.logger.debug(f"Waiting for proc {self._proc.pid}")
-
-        try:
-            self._proc.wait(timeout=timeout)
-        except subprocess.TimeoutExpired:
-            self.logger.warning(f"Timeout expired for PID {self._proc.pid}")
-
-        self._proc = None
-
     def set_property(self, prop, val):
         """ Set a property on the camera """
         set_cmd = ['--set-config', f'{prop}={val}']

--- a/src/panoptes/pocs/camera/gphoto/canon.py
+++ b/src/panoptes/pocs/camera/gphoto/canon.py
@@ -73,7 +73,7 @@ class Camera(AbstractGPhotoCamera):
             '/main/settings/artist': artist_name,
             '/main/settings/copyright': copy_right,
             '/main/settings/ownername': owner_name,
-            # Current UTC datetime in seconds since epoch.U
+            # Current UTC datetime in seconds since epoch.
             '/main/settings/datetimeutc': f'{current_time(datetime=True):%s}',
         }
 

--- a/src/panoptes/pocs/utils/service/camera.py
+++ b/src/panoptes/pocs/utils/service/camera.py
@@ -1,110 +1,17 @@
 import shutil
 import sys
 import subprocess
-from pathlib import Path
-from typing import Optional, Dict, List
-from threading import Lock
-from datetime import datetime
 from pydantic import BaseModel
 
 from fastapi import FastAPI
 
-from panoptes.pocs.camera import list_connected_cameras
-from panoptes.pocs.camera.gphoto.canon import Camera
 
-# Canon EOS models
-
-iso_index_lookup = {
-    100: 1,
-    200: 2,
-    400: 3,
-    800: 4,
-    1600: 5,
-    3200: 6,
-    6400: 7,
-}
-
-shutter_index_lookup = {
-    30: 1,
-    25: 2,
-    20: 3,
-    15: 4,
-    13: 5,
-    10.3: 6,
-    8: 7,
-    6.3: 8,
-    5: 9,
-    4: 10,
-    3.2: 11,
-    2.5: 12,
-    2: 13,
-    1.6: 14,
-    1.3: 15,
-    1: 16,
-    0.8: 17,
-    0.6: 18,
-    0.5: 19,
-    0.4: 20,
-    0.3: 21,
-    1 / 4: 22,
-    1 / 5: 23,
-    1 / 6: 24,
-    1 / 8: 25,
-    1 / 10: 26,
-    1 / 13: 27,
-    1 / 15: 28,
-    1 / 20: 29,
-    1 / 25: 30,
-    1 / 30: 31,
-    1 / 40: 32,
-    1 / 50: 33,
-    1 / 60: 34,
-    1 / 80: 35,
-    1 / 100: 36,
-    1 / 125: 37,
-    1 / 160: 38,
-    1 / 200: 39,
-    1 / 250: 40,
-    1 / 320: 41,
-    1 / 400: 42,
-    1 / 500: 43,
-    1 / 640: 44,
-    1 / 800: 45,
-    1 / 1000: 46,
-    1 / 1250: 47,
-    1 / 1600: 48,
-    1 / 2000: 49,
-    1 / 2500: 50,
-    1 / 3200: 51,
-    1 / 4000: 52,
-}
-
-eosremoterelease_index_lookup = {
-    'None': 0,
-    'Press Half': 1,
-    'Press Full': 2,
-    'Release Half': 3,
-    'Release Full': 4,
-    'Immediate': 5,
-    'Press 1': 6,
-    'Press 2': 7,
-    'Press 3': 8,
-    'Release 1': 9,
-    'Release 2': 10,
-    'Release 3': 11,
-}
-
-
-class Exposure(BaseModel):
-    exptime: float
-    filename: Optional[str] = None
-    base_dir: Path = '.'
-    iso: int = 100
+class Command(BaseModel):
+    """Accepts an arbitrary command string which is passed to gphoto2."""
+    command: str = '--auto-detect'
 
 
 app = FastAPI()
-cameras: List[Camera] = []
-locks: Dict[str, Lock] = {}
 
 
 @app.on_event('startup')
@@ -114,92 +21,20 @@ def startup_tasks():
         print('Cannot find gphoto2, exiting system.')
         sys.exit(1)
 
-    initialize_cameras()
 
+@app.post('/gphoto')
+def gphoto(command: Command):
+    """Perform arbitrary gphoto2 command."""
 
-def initialize_cameras():
-    """Look for attached cameras"""
-    for i, port in enumerate(list_connected_cameras()):
-        cameras.append(Camera(port=port, name=f'Cam{i:02d}', db_type='memory'))
-
-    print(f'Found {cameras=!r}')
-
-
-@app.post('/camera/{device_number}/startexposure')
-def take_pic(device_number: int, exposure: Exposure):
-    """Takes a picture with the camera."""
-    camera = cameras[device_number]
-    port_lock = locks.get(camera.port, Lock())
-    if port_lock.locked():
-        return {'message': f'Another exposure is currently in process for {camera.port=}',
-                'success': False}
-
-    with port_lock:
-        # Look up shutter index based on requested exptime, otherwise `0` for bulb.
-        shutter_index = shutter_index_lookup.get(exposure.exptime, 0)
-
-        # Look up iso index, otherwise `1` for 100.
-        iso_index = iso_index_lookup.get(exposure.iso, 1)
-
-        commands = [
-            f'--port={camera.port}',
-            '--set-config-index', f'iso={iso_index}',
-            '--set-config-index', f'shutterspeed={shutter_index}',
-            '--wait-event=1s',  # gphoto2 needs this.
-        ]
-
-        # If using `bulb` shutter index we need to specify wait time, otherwise just capture.
-        if shutter_index == 0:
-            # Manually build bulb command.
-            bulb_start_index = eosremoterelease_index_lookup['Press Full']
-            bulb_stop_index = eosremoterelease_index_lookup['Release Full']
-
-            commands.extend([
-                '--set-config-index', f'eosremoterelease={bulb_start_index}',
-                f'--wait-event={exposure.exptime}s',
-                '--set-config-index', f'eosremoterelease={bulb_stop_index}',
-                '--wait-event-and-download=1s'
-            ])
-        else:
-            commands.extend(['--capture-image-and-download'])
-
-        # Set up filename in the base_dir.
-        filename = exposure.filename or datetime.now().strftime('%Y%m%dT%H%M%S')
-        full_path = f'{exposure.base_dir}/{filename}.cr2'
-        commands.extend([f'--filename={full_path}'])
-
-        # Build the full command.
-        full_command = [shutil.which('gphoto2'), *commands]
-
-        completed_proc = gphoto2_command(full_command)
-
-        # Return the full path upon success otherwise the output from command.
-        if completed_proc.returncode:
-            print(completed_proc.stdout)
-            return {'success': False, 'message': completed_proc.stdout}
-        else:
-            print(f'Done taking picture {completed_proc.returncode}')
-            return {'success': True, 'filename': full_path}
-
-
-@app.get('/camera/{device_number}/settings/shutterspeed')
-def get_shutterspeeds(device_number: int):
-    return shutter_index_lookup
-
-
-@app.get('/camera/{device_number}/settings/iso')
-def get_isos(device_number: int):
-    return iso_index_lookup
-
-
-def gphoto2_command(command: List[str]) -> subprocess.CompletedProcess:
-    """Run a gphoto2 command in a separate blocking process.
-
-    Return a subprocess.CompletedProcess.
-    """
+    # Build the full command.
+    full_command = [shutil.which('gphoto2'), command]
     print(f'Running {command=}')
 
-    # Run the blocking command in a separate process.
-    completed_proc = subprocess.run(command, capture_output=True)
-
-    return completed_proc
+    completed_proc = subprocess.run(full_command, capture_output=True)
+    # Return the full path upon success otherwise the output from command.
+    if completed_proc.returncode:
+        print(completed_proc.stdout)
+        return {'success': False, 'message': completed_proc.stdout}
+    else:
+        print(f'Done with {command=}')
+        return {'success': True}

--- a/src/panoptes/pocs/utils/service/camera.py
+++ b/src/panoptes/pocs/utils/service/camera.py
@@ -28,13 +28,11 @@ def gphoto(command: Command):
 
     # Build the full command.
     full_command = [shutil.which('gphoto2'), command]
-    print(f'Running {command=}')
 
+    print(f'Running {command=!r}')
     completed_proc = subprocess.run(full_command, capture_output=True)
+
     # Return the full path upon success otherwise the output from command.
-    if completed_proc.returncode:
-        print(completed_proc.stdout)
-        return {'success': False, 'message': completed_proc.stdout}
-    else:
-        print(f'Done with {command=}')
-        return {'success': True}
+    success = completed_proc.returncode >= 0
+
+    return {'success': success, 'output': completed_proc.stdout}

--- a/src/panoptes/pocs/utils/service/camera.py
+++ b/src/panoptes/pocs/utils/service/camera.py
@@ -1,0 +1,200 @@
+import shutil
+import sys
+import subprocess
+from pathlib import Path
+from typing import Optional, Dict, List
+from threading import Lock
+from datetime import datetime
+from pydantic import BaseModel
+
+from fastapi import FastAPI
+
+from panoptes.pocs.camera import list_connected_cameras
+from panoptes.pocs.camera.gphoto.canon import Camera
+
+# Canon EOS models
+
+iso_index_lookup = {
+    100: 1,
+    200: 2,
+    400: 3,
+    800: 4,
+    1600: 5,
+    3200: 6,
+    6400: 7,
+}
+
+shutter_index_lookup = {
+    30: 1,
+    25: 2,
+    20: 3,
+    15: 4,
+    13: 5,
+    10.3: 6,
+    8: 7,
+    6.3: 8,
+    5: 9,
+    4: 10,
+    3.2: 11,
+    2.5: 12,
+    2: 13,
+    1.6: 14,
+    1.3: 15,
+    1: 16,
+    0.8: 17,
+    0.6: 18,
+    0.5: 19,
+    0.4: 20,
+    0.3: 21,
+    1 / 4: 22,
+    1 / 5: 23,
+    1 / 6: 24,
+    1 / 8: 25,
+    1 / 10: 26,
+    1 / 13: 27,
+    1 / 15: 28,
+    1 / 20: 29,
+    1 / 25: 30,
+    1 / 30: 31,
+    1 / 40: 32,
+    1 / 50: 33,
+    1 / 60: 34,
+    1 / 80: 35,
+    1 / 100: 36,
+    1 / 125: 37,
+    1 / 160: 38,
+    1 / 200: 39,
+    1 / 250: 40,
+    1 / 320: 41,
+    1 / 400: 42,
+    1 / 500: 43,
+    1 / 640: 44,
+    1 / 800: 45,
+    1 / 1000: 46,
+    1 / 1250: 47,
+    1 / 1600: 48,
+    1 / 2000: 49,
+    1 / 2500: 50,
+    1 / 3200: 51,
+    1 / 4000: 52,
+}
+
+eosremoterelease_index_lookup = {
+    'None': 0,
+    'Press Half': 1,
+    'Press Full': 2,
+    'Release Half': 3,
+    'Release Full': 4,
+    'Immediate': 5,
+    'Press 1': 6,
+    'Press 2': 7,
+    'Press 3': 8,
+    'Release 1': 9,
+    'Release 2': 10,
+    'Release 3': 11,
+}
+
+
+class Exposure(BaseModel):
+    exptime: float
+    filename: Optional[str] = None
+    base_dir: Path = '.'
+    iso: int = 100
+
+
+app = FastAPI()
+cameras: List[Camera] = []
+locks: Dict[str, Lock] = {}
+
+
+@app.on_event('startup')
+def startup_tasks():
+    gphoto2_path = shutil.which('gphoto2')
+    if gphoto2_path is None:
+        print('Cannot find gphoto2, exiting system.')
+        sys.exit(1)
+
+    initialize_cameras()
+
+
+def initialize_cameras():
+    """Look for attached cameras"""
+    for i, port in enumerate(list_connected_cameras()):
+        cameras.append(Camera(port=port, name=f'Cam{i:02d}', db_type='memory'))
+
+    print(f'Found {cameras=!r}')
+
+
+@app.post('/camera/{device_number}/startexposure')
+def take_pic(device_number: int, exposure: Exposure):
+    """Takes a picture with the camera."""
+    camera = cameras[device_number]
+    port_lock = locks.get(camera.port, Lock())
+    if port_lock.locked():
+        return {'message': f'Another exposure is currently in process for {camera.port=}',
+                'success': False}
+
+    with port_lock:
+        # Look up shutter index based on requested exptime, otherwise `0` for bulb.
+        shutter_index = shutter_index_lookup.get(exposure.exptime, 0)
+
+        # Look up iso index, otherwise `1` for 100.
+        iso_index = iso_index_lookup.get(exposure.iso, 1)
+
+        commands = [
+            f'--port={camera.port}',
+            '--set-config-index', f'iso={iso_index}',
+            '--set-config-index', f'shutterspeed={shutter_index}',
+            '--wait-event=1s',  # gphoto2 needs this.
+        ]
+
+        # If using `bulb` shutter index we need to specify wait time, otherwise just capture.
+        if shutter_index == 0:
+            # Manually build bulb command.
+            bulb_start_index = eosremoterelease_index_lookup['Press Full']
+            bulb_stop_index = eosremoterelease_index_lookup['Release Full']
+
+            commands.extend([
+                '--set-config-index', f'eosremoterelease={bulb_start_index}',
+                f'--wait-event={exposure.exptime}s',
+                '--set-config-index', f'eosremoterelease={bulb_stop_index}',
+                '--wait-event-and-download=1s'
+            ])
+        else:
+            commands.extend(['--capture-image-and-download'])
+
+        # Set up filename in the base_dir.
+        filename = exposure.filename or datetime.now().strftime('%Y%m%dT%H%M%S')
+        full_path = f'{exposure.base_dir}/{filename}.cr2'
+        commands.extend([f'--filename={full_path}'])
+
+        # Build the full command.
+        full_command = [shutil.which('gphoto2'), *commands]
+
+        completed_proc = gphoto2_command(full_command)
+
+        # Return the full path upon success otherwise the output from command.
+        if completed_proc.returncode:
+            print(completed_proc.stdout)
+            return {'success': False, 'message': completed_proc.stdout}
+        else:
+            print(f'Done taking picture {completed_proc.returncode}')
+            return {'success': True, 'filename': full_path}
+
+
+@app.get('/camera/{device_number}/shutterspeeds')
+def get_shutterspeeds(device_number: int):
+    return shutter_index_lookup
+
+
+def gphoto2_command(command: List[str]) -> subprocess.CompletedProcess:
+    """Run a gphoto2 command in a separate blocking process.
+
+    Return a subprocess.CompletedProcess.
+    """
+    print(f'Running {command=}')
+
+    # Run the blocking command in a separate process.
+    completed_proc = subprocess.run(command, capture_output=True)
+
+    return completed_proc

--- a/src/panoptes/pocs/utils/service/camera.py
+++ b/src/panoptes/pocs/utils/service/camera.py
@@ -182,9 +182,14 @@ def take_pic(device_number: int, exposure: Exposure):
             return {'success': True, 'filename': full_path}
 
 
-@app.get('/camera/{device_number}/shutterspeeds')
+@app.get('/camera/{device_number}/settings/shutterspeed')
 def get_shutterspeeds(device_number: int):
     return shutter_index_lookup
+
+
+@app.get('/camera/{device_number}/settings/iso')
+def get_isos(device_number: int):
+    return iso_index_lookup
 
 
 def gphoto2_command(command: List[str]) -> subprocess.CompletedProcess:

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -156,7 +156,7 @@ def test_sim_bad_focuser():
 
 def test_sim_worse_focuser():
     with pytest.raises(NotFound):
-        sim_camera = SimCamera(focuser='NOTAFOCUSER')
+        SimCamera(focuser='NOTAFOCUSER')
 
 
 def test_sim_string():
@@ -251,7 +251,7 @@ def test_get_temp(camera):
     try:
         temperature = camera.temperature
     except NotImplementedError:
-        pytest.skip("Camera {} doesn't implement temperature info".format(camera.name))
+        pytest.skip(f"Camera {camera.name} doesn't implement temperature info")
     else:
         assert temperature is not None
 
@@ -266,7 +266,7 @@ def test_set_target_temperature(camera):
         camera.target_temperature = 10 * u.Celsius
         assert abs(camera.target_temperature - 10 * u.Celsius) < 0.5 * u.Celsius
     else:
-        pytest.skip("Camera {} doesn't implement temperature control".format(camera.name))
+        pytest.skip(f"Camera {camera.name} doesn't implement temperature control")
 
 
 def test_cooling_enabled(camera):

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -56,38 +56,38 @@ def camera(request):
     CamClass = request.param[0]
     cam_params = request.param[1]
 
-    camera = None
+    cam = None
 
     if isinstance(cam_params, dict):
         # Simulator
-        camera = CamClass(**cam_params)
+        cam = CamClass(**cam_params)
     else:
         # Lookup real hardware device name in real life config server.
         for cam_config in get_config('cameras.devices'):
             if cam_config['model'] == cam_params:
-                camera = CamClass(**cam_config)
+                cam = CamClass(**cam_config)
                 break
 
-    camera.logger.log('testing', f'Camera created: {camera!r}')
+    cam.logger.log('testing', f'Camera created: {cam!r}')
 
     # Wait for cooled camera
-    if camera.is_cooled_camera:
-        camera.logger.log('testing', f'Cooled camera needs to wait for cooling.')
-        assert not camera.is_temperature_stable
+    if cam.is_cooled_camera:
+        cam.logger.log('testing', f'Cooled camera needs to wait for cooling.')
+        assert not cam.is_temperature_stable
         # Wait for cooling
         cooling_timeout = CountdownTimer(60)  # Should never have to wait this long.
-        while not camera.is_temperature_stable and not cooling_timeout.expired():
-            camera.logger.log('testing',
+        while not cam.is_temperature_stable and not cooling_timeout.expired():
+            cam.logger.log('testing',
                               f'Still waiting for cooling: {cooling_timeout.time_left()}')
             cooling_timeout.sleep(max_sleep=2)
-        assert camera.is_temperature_stable and cooling_timeout.expired() is False
+        assert cam.is_temperature_stable and cooling_timeout.expired() is False
 
-    assert camera.is_ready
-    camera.logger.log('testing', f'Yielding {camera=}')
-    yield camera
+    assert cam.is_ready
+    cam.logger.log('testing', f'Yielding {cam=}')
+    yield cam
 
-    camera.logger.log('testing', f'Deleting {camera=}')
-    del camera
+    cam.logger.log('testing', f'Deleting {cam=}')
+    del cam
 
 
 @pytest.fixture(scope='module')

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -83,13 +83,10 @@ def camera(request):
         assert camera.is_temperature_stable and cooling_timeout.expired() is False
 
     assert camera.is_ready
-    camera.logger.debug(f'Yielding camera {camera}')
+    camera.logger.log('testing', f'Yielding camera {camera}')
     yield camera
 
-    # simulator_sdk needs this explicitly removed for some reason.
-    # SDK Camera class destructor *should* be doing this when the fixture goes out of scope.
-    with suppress(AttributeError):
-        type(camera)._assigned_cameras.discard(camera.uid)
+    del camera
 
 
 @pytest.fixture(scope='module')

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -78,7 +78,7 @@ def camera(request):
         cooling_timeout = CountdownTimer(60)  # Should never have to wait this long.
         while not cam.is_temperature_stable and not cooling_timeout.expired():
             cam.logger.log('testing',
-                              f'Still waiting for cooling: {cooling_timeout.time_left()}')
+                           f'Still waiting for cooling: {cooling_timeout.time_left()}')
             cooling_timeout.sleep(max_sleep=2)
         assert cam.is_temperature_stable and cooling_timeout.expired() is False
 
@@ -192,8 +192,8 @@ def test_sdk_already_in_use():
     with pytest.raises(error.PanError):
         SimSDKCamera(serial_number=serial_number)
 
-    # Explicitly delete camera to clear `_assigned_cameras`.
-    del sim_camera
+    # Explicitly clear `_assigned_cameras`.
+    SimSDKCamera._assigned_cameras = set()
 
 
 def test_sdk_camera_not_found():

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -33,7 +33,7 @@ from panoptes.utils.serializers import to_json
 from panoptes.utils.time import CountdownTimer
 
 
-@pytest.fixture(scope='module', params=[
+@pytest.fixture(scope='function', params=[
     pytest.param([SimCamera, dict()]),
     pytest.param([SimCamera, get_config('cameras.devices[0]')]),
     pytest.param([SimCamera, get_config('cameras.devices[1]')]),

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -200,6 +200,9 @@ def test_sdk_camera_not_found():
     with pytest.raises(error.InvalidConfig):
         SimSDKCamera(serial_number='SSC404')
 
+    # Explicitly clear `_assigned_cameras`.
+    SimSDKCamera._assigned_cameras = set()
+
 
 # Hardware independent tests for SBIG camera
 

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -83,9 +83,10 @@ def camera(request):
         assert camera.is_temperature_stable and cooling_timeout.expired() is False
 
     assert camera.is_ready
-    camera.logger.log('testing', f'Yielding camera {camera}')
+    camera.logger.log('testing', f'Yielding {camera=}')
     yield camera
 
+    camera.logger.log('testing', f'Deleting {camera=}')
     del camera
 
 

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -54,17 +54,21 @@ from panoptes.utils.time import CountdownTimer
 ])
 def camera(request):
     CamClass = request.param[0]
-    cam_params = request.param[1]
-
     cam = None
+    cam_model = None
+    cam_params = None
 
-    if isinstance(cam_params, dict):
+    if isinstance(request.param[1], dict):
+        cam_params = request.param[1]
+    else:
+        cam_model = request.param[1]
+
+    if cam_params is not None:
         # Simulator
         cam = CamClass(**cam_params)
     else:
-        # Lookup real hardware device name in real life config server.
         for cam_config in get_config('cameras.devices'):
-            if cam_config['model'] == cam_params:
+            if cam_config['model'] == cam_model:
                 cam = CamClass(**cam_config)
                 break
 

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -32,7 +32,10 @@ def reset_conf(config_host, config_port):
 
 @pytest.fixture(scope='function')
 def cameras():
-    return create_cameras_from_config(recreate_existing=True)
+    cams = create_cameras_from_config(recreate_existing=True)
+    yield cams
+    for cam in cams.values():
+        del cam
 
 
 @pytest.fixture(scope='function')
@@ -52,7 +55,8 @@ def observatory(mount, cameras, images_dir):
     for cam_name, cam in cameras.items():
         obs.add_camera(cam_name, cam)
 
-    return obs
+    yield obs
+    del obs
 
 
 def test_camera_already_exists(observatory, cameras):
@@ -249,7 +253,7 @@ def test_standard_headers(observatory):
         {"field": {
             'name': 'HAT-P-20',
             'position': '07h27m39.89s +24d20m14.7s'},
-         "observation": {'priority': '100'}}
+            "observation": {'priority': '100'}}
     ]
 
     observatory.get_observation()

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -40,7 +40,7 @@ def mount():
     return create_mount_simulator()
 
 
-@pytest.fixture
+@pytest.fixture(scope='function')
 def observatory(mount, cameras, images_dir):
     """Return a valid Observatory instance with a specific config."""
 


### PR DESCRIPTION
A simple camera service that wraps the `gphoto2` command. Currently just supports the simple taking of a picture via a POST.

## Description
The service is a [fastapi](https://fastapi.tiangolo.com/) service that is capable of simple picture taking.  The service accepts a POST request defined by the following pydantic class:

```py
class Exposure(BaseModel):
    exptime: float
    filename: Optional[str] = None
    base_dir: Path = '.'
    iso: int = 100
```

If the `filename` is not provided it will default to a timestamp. `exptime` is required and the given value will first be checked if it corresponds to a built-in shutter speed, in which case that shutter speed will be used directly, otherwise a manual bulb setting will be used. `exptime` is a `float` so to use, for example the `1/4000` shutter speed index the value of `0.00025` should be given.

Since fastapi is used there is built in documentation available.  The endpoints will attempt to mimic the [Alpaca API](https://ascom-standards.org/api/) although it deviates from this implementation and may be changed in the future.  Currently the only supported endpoint is `/camera/{camera_number}/startexposure` which accepts the above.

The service will currently block until exposure is complete although there are plans to change this going forward.

## Examples:
These examples assume the service is running on the localhost on port 8080.  A Dockerfile and docker-compose is provided.

From python:
```py
import requests

camera_host = 'http://localhost'
camera_port = 8080
camera_num = 0

camera_url = f'{camera_host}:{camera_port}/camera/{camera_num}/startexposure'

exptime = 4
save_dir = '/images'
response = requests.post(camera_url, json=dict(exptime=exptime, base_dir=save_dir, iso=400))
```

From command line (via `httpie`):
```sh
http :8080/camera/0/startexposure exptime=4 base_dir=/images
```

## Related Issue
#1112 
#786 
#747

/gcbrun