### PR TITLE
Fix unit typo in `Camera.process_exposure`

### DIFF
--- a/src/panoptes/pocs/camera/camera.py
+++ b/src/panoptes/pocs/camera/camera.py
@@ -622,7 +622,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
             except Exception as e:  # pragma: no cover
                 self.logger.warning(f'Problem with extracting pretty image: {e!r}')
 
-        metadata['exptime'] = get_quantity_value(metadata['exptime'], unit='seconds')
+        metadata['exptime'] = get_quantity_value(metadata['exptime'], unit='second')
 
         if record_observations:
             self.logger.debug(f"Adding current observation to db: {image_id}")


### PR DESCRIPTION
Fixes typo in `Camera.process_exposure`. Causing `huntsman-pocs` tests to fail and error messages on Huntsman.

## Related Issue
#1138 

## How Has This Been Tested?
Unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

