### PR TITLE
Fix hanging tests.

### DIFF
--- a/src/panoptes/pocs/camera/camera.py
+++ b/src/panoptes/pocs/camera/camera.py
@@ -333,7 +333,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
                 self.logger.warning(f"Camera {self} not ready: {sub_name} not ready.")
 
         # Make sure there isn't an exposure already in progress.
-        if not current_readiness['not_exposing']:
+        if not current_readiness.get('not_exposing', True):
             self.logger.warning(f"Camera {self} not ready: exposure already in progress.")
 
         return all(current_readiness.values())

--- a/src/panoptes/pocs/camera/sdk.py
+++ b/src/panoptes/pocs/camera/sdk.py
@@ -142,10 +142,10 @@ class AbstractSDKCamera(AbstractCamera):
     def __del__(self):
         """ Attempt some clean up. """
         if hasattr(self, 'uid'):
-            logger.trace(f'Removing {self.uid} from {type(self)._assigned_cameras}')
+            logger.trace(f'Removing {self.uid} from: {type(self)._assigned_cameras}')
             type(self)._assigned_cameras.discard(self.uid)
 
-        logger.trace(f'Assigned cameras after removing {type(self)._assigned_cameras}')
+        logger.trace(f'Assigned cameras after removing: {type(self)._assigned_cameras}')
 
     # Properties
 

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -194,6 +194,9 @@ def test_sdk_already_in_use():
     with pytest.raises(error.PanError):
         SimSDKCamera(serial_number=serial_number)
 
+    # Explicitly delete camera to clear `_assigned_cameras`.
+    del sim_camera
+
 
 def test_sdk_camera_not_found():
     with pytest.raises(error.InvalidConfig):

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -30,6 +30,7 @@ from panoptes.utils.config.client import set_config
 
 from panoptes.pocs.camera import create_cameras_from_config
 from panoptes.utils.serializers import to_json
+from panoptes.utils.time import CountdownTimer
 
 
 @pytest.fixture(scope='module', params=[
@@ -67,13 +68,19 @@ def camera(request):
                 camera = CamClass(**cam_config)
                 break
 
+    camera.logger.log('testing', f'Camera created: {camera!r}')
+
     # Wait for cooled camera
     if camera.is_cooled_camera:
+        camera.logger.log('testing', f'Cooled camera needs to wait for cooling.')
         assert not camera.is_temperature_stable
         # Wait for cooling
-        while not camera.is_temperature_stable:
-            time.sleep(2)
-        assert camera.is_temperature_stable
+        cooling_timeout = CountdownTimer(60)  # Should never have to wait this long.
+        while not camera.is_temperature_stable and not cooling_timeout.expired():
+            camera.logger.log('testing',
+                              f'Still waiting for cooling: {cooling_timeout.time_left()}')
+            cooling_timeout.sleep(max_sleep=2)
+        assert camera.is_temperature_stable and cooling_timeout.expired() is False
 
     assert camera.is_ready
     camera.logger.debug(f'Yielding camera {camera}')
@@ -580,7 +587,6 @@ def test_observation_bias(camera, images_dir):
 
 
 def test_autofocus_coarse(camera, patterns, counter):
-
     if not camera.has_focuser:
         pytest.skip("Camera does not have a focuser")
 

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -40,7 +40,7 @@ def mount():
     return create_mount_simulator()
 
 
-@pytest.fixture
+@pytest.fixture(scope='function')
 def observatory(mount, cameras, images_dir):
     """Return a valid Observatory instance with a specific config."""
 


### PR DESCRIPTION
This attempts to fix the two areas where tests seem to be hanging the most, as outlined in #1123.


## Description
* Change the `observatory` fixture to a function scope.
* Adds a `CountdownTimer` to the creation of test cameras to time out and fail after 60 seconds.
* Adds more logging to diagnose where creation problems are.
* Adds a small fix to ensure `readiness` property reads correctly (although this shouldn't be needed).
* Explicitly clean up lingering camera from duplicate test.

## Related Issue
Closes #1123 

