### PR TITLE
Camera test fixes

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,6 +10,7 @@ LABEL repo="github.com/panoptes/POCS"
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+ENV PYTHONUNBUFFERED 1
 
 ARG userid=1000
 ENV USERID $userid

--- a/src/panoptes/pocs/camera/camera.py
+++ b/src/panoptes/pocs/camera/camera.py
@@ -116,22 +116,21 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         self.subcomponents = dict()
         for attr_name, class_path in self._SUBCOMPONENT_LIST.items():
             # Create the subcomponent as an attribute with default None.
-            self.logger.debug(f'Setting default attr_name={attr_name!r} to None')
+            self.logger.debug(f'Setting default {attr_name=!r} to None')
             setattr(self, attr_name, None)
 
             # If given subcomponent class (or dict), try to create instance.
             subcomponent = kwargs.get(attr_name)
             if subcomponent is not None:
-                self.logger.debug(f'Found subcomponent={subcomponent!r}, creating instance')
+                self.logger.debug(f'Creating {attr_name} with {subcomponent=!r}')
 
                 subcomponent = self._create_subcomponent(class_path, subcomponent)
-                self.logger.debug(
-                    f'Assigning subcomponent={subcomponent!r} to attr_name={attr_name!r}')
+                self.logger.debug(f'Assigning {attr_name=} with {subcomponent=!r}')
                 setattr(self, attr_name, subcomponent)
                 # Keep a list of active subcomponents
                 self.subcomponents[attr_name] = subcomponent
 
-        self.logger.debug(f'Camera created: {self}')
+        self.logger.info(f'Camera created: {self}')
 
     ############################################################################
     # Properties

--- a/src/panoptes/pocs/camera/gphoto/base.py
+++ b/src/panoptes/pocs/camera/gphoto/base.py
@@ -158,21 +158,6 @@ class AbstractGPhotoCamera(AbstractCamera):  # pragma: no cover
 
         return outs
 
-    def wait_for_command(self, timeout=10):
-        """ Wait for the given command to end
-
-        This method merely waits for a subprocess to complete but doesn't attempt to communicate
-        with the process (see `get_command_result` for that).
-        """
-        self.logger.debug(f"Waiting for proc {self._proc.pid}")
-
-        try:
-            self._proc.wait(timeout=timeout)
-        except subprocess.TimeoutExpired:
-            self.logger.warning(f"Timeout expired for PID {self._proc.pid}")
-
-        self._proc = None
-
     def set_property(self, prop, val):
         """ Set a property on the camera """
         set_cmd = ['--set-config', f'{prop}={val}']

--- a/src/panoptes/pocs/camera/sdk.py
+++ b/src/panoptes/pocs/camera/sdk.py
@@ -100,13 +100,13 @@ class AbstractSDKCamera(AbstractCamera):
         logger.debug(f"Connected {name} devices: {my_class._cameras}")
 
         if serial_number in my_class._cameras:
-            logger.debug(f"Found {name} with UID serial_number={serial_number!r} at {my_class._cameras[serial_number]}.")
+            logger.debug(f"Found {name} with {serial_number=!r} at {my_class._cameras[serial_number]}.")
         else:
             raise error.InvalidConfig(f"No config information found for "
                                       f"name={name!r} with serial_number={serial_number!r} in {my_class._cameras}")
 
         if serial_number in my_class._assigned_cameras:
-            raise error.PanError(f"{name} with UID serial_number={serial_number!r} already in use.")
+            raise error.PanError(f"{name} with UID {serial_number=!r} already in use.")
         else:
             my_class._assigned_cameras.add(serial_number)
 

--- a/src/panoptes/pocs/camera/sdk.py
+++ b/src/panoptes/pocs/camera/sdk.py
@@ -142,10 +142,10 @@ class AbstractSDKCamera(AbstractCamera):
     def __del__(self):
         """ Attempt some clean up. """
         if hasattr(self, 'uid'):
-            logger.trace(f'Removing {self.uid} from: {type(self)._assigned_cameras}')
+            logger.debug(f'Removing {self.uid} from: {type(self)._assigned_cameras}')
             type(self)._assigned_cameras.discard(self.uid)
 
-        logger.trace(f'Assigned cameras after removing: {type(self)._assigned_cameras}')
+        logger.debug(f'Assigned cameras after removing: {type(self)._assigned_cameras}')
 
     # Properties
 

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -5,6 +5,7 @@ FROM ${image_url}:${image_tag} AS pocs-base
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 ENV SHELL /bin/bash
+ENV PYTHONUNBUFFERED 1
 
 ENV POCS "/panoptes-pocs"
 

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -57,6 +57,7 @@ from loguru import logger
 def camera(request):
     logger.log('testing', f'Inside camera fixture: {request=!r}')
     CamClass = request.param[0]
+    logger.log('testing', f'Exisiting cameras: {CamClass._asigned_cameras=!r}')
     cam = None
     cam_model = None
     cam_params = None
@@ -70,13 +71,7 @@ def camera(request):
 
     if cam_params is not None:
         # Simulator
-        try:
-            cam = CamClass(**cam_params)
-        except error.PanError as e:
-            logger.log('testing', f'Problem creating camera fixture: {e!r}')
-            with suppress(AttributeError):
-                # Reset assigned cameras.
-                CamClass._assigned_cameras = set()
+        cam = CamClass(**cam_params)
     else:
         # Lookup real hardware device name in real life config server.
         for cam_config in get_config('cameras.devices'):

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -100,15 +100,18 @@ def camera(request):
     logger.log('testing', f'Yielding camera {cam=!r}')
     yield cam
 
-    logger.log('testing', f'Deleting camera {cam=!r}')
+    cam_uid = cam.uid
+
+    logger.log('testing', f'Deleting camera {cam=!r} with {cam_uid=}')
     del cam
 
     # simulator_sdk needs this explicitly removed for some reason.
     # SDK Camera class destructor *should* be doing this when the fixture goes out of scope.
     with suppress(AttributeError):
         logger.log('testing', f'Exisiting cameras: {CamClass._assigned_cameras=!r}')
-        CamClass._assigned_cameras.discard(camera.uid)
-        logger.log('testing', f'Exisiting cameras: {CamClass._assigned_cameras=!r}')
+        logger.log('testing', f'Has cam uid: {cam_uid in CamClass._assigned_cameras}')
+        CamClass._assigned_cameras.discard(cam_uid)
+        logger.log('testing', f'Exisiting cameras after removing: {CamClass._assigned_cameras=!r}')
 
 
 @pytest.fixture(scope='module')

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -58,7 +58,7 @@ def camera(request):
     logger.log('testing', f'Inside camera fixture: {request=!r}')
     CamClass = request.param[0]
     with suppress(AttributeError):
-        logger.log('testing', f'Exisiting cameras: {CamClass._asigned_cameras=!r}')
+        logger.log('testing', f'Exisiting cameras: {CamClass._assigned_cameras=!r}')
     cam = None
     cam_model = None
     cam_params = None

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -57,7 +57,8 @@ from loguru import logger
 def camera(request):
     logger.log('testing', f'Inside camera fixture: {request=!r}')
     CamClass = request.param[0]
-    logger.log('testing', f'Exisiting cameras: {CamClass._asigned_cameras=!r}')
+    with suppress(AttributeError):
+        logger.log('testing', f'Exisiting cameras: {CamClass._asigned_cameras=!r}')
     cam = None
     cam_model = None
     cam_params = None

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -58,7 +58,7 @@ def camera(request):
     logger.log('testing', f'Inside camera fixture: {request=!r}')
     CamClass = request.param[0]
     with suppress(AttributeError):
-        logger.log('testing', f'Exisiting cameras: {CamClass._assigned_cameras=!r}')
+        logger.log('testing', f'Existing cameras: {CamClass._assigned_cameras=!r}')
     cam = None
     cam_model = None
     cam_params = None
@@ -108,10 +108,10 @@ def camera(request):
     # simulator_sdk needs this explicitly removed for some reason.
     # SDK Camera class destructor *should* be doing this when the fixture goes out of scope.
     with suppress(AttributeError):
-        logger.log('testing', f'Exisiting cameras: {CamClass._assigned_cameras=!r}')
+        logger.log('testing', f'Existing cameras: {CamClass._assigned_cameras=!r}')
         logger.log('testing', f'Has cam uid: {cam_uid in CamClass._assigned_cameras}')
         CamClass._assigned_cameras.discard(cam_uid)
-        logger.log('testing', f'Exisiting cameras after removing: {CamClass._assigned_cameras=!r}')
+        logger.log('testing', f'Existing cameras after removing: {CamClass._assigned_cameras=!r}')
 
 
 @pytest.fixture(scope='module')
@@ -216,16 +216,10 @@ def test_sdk_already_in_use():
     with pytest.raises(error.PanError):
         SimSDKCamera(serial_number=serial_number)
 
-    # Explicitly delete camera to clear `_assigned_cameras`.
-    del sim_camera
-
 
 def test_sdk_camera_not_found():
     with pytest.raises(error.InvalidConfig):
         SimSDKCamera(serial_number='SSC404')
-
-    # Explicitly clear the assigned cameras after above error.
-    SimSDKCamera._assigned_cameras = set()
 
 
 # Hardware independent tests for SBIG camera
@@ -240,9 +234,6 @@ def test_sbig_driver_bad_path():
     """
     with pytest.raises(OSError):
         SBIGDriver(library_path='no_library_here')
-
-    # Explicitly clear the assigned cameras after above error.
-    SimSDKCamera._assigned_cameras = set()
 
 
 @pytest.mark.filterwarnings('ignore:Could not connect to SBIG Camera')

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -96,10 +96,19 @@ def camera(request):
 
     logger.log('testing', f'Making sure camera is ready from fixture {cam=!r}')
     assert cam.is_ready
+
     logger.log('testing', f'Yielding camera {cam=!r}')
     yield cam
+
     logger.log('testing', f'Deleting camera {cam=!r}')
     del cam
+
+    # simulator_sdk needs this explicitly removed for some reason.
+    # SDK Camera class destructor *should* be doing this when the fixture goes out of scope.
+    with suppress(AttributeError):
+        logger.log('testing', f'Exisiting cameras: {type(cam)._assigned_cameras=!r}')
+        type(cam)._assigned_cameras.discard(camera.uid)
+        logger.log('testing', f'Exisiting cameras: {type(cam)._assigned_cameras=!r}')
 
 
 @pytest.fixture(scope='module')

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -106,9 +106,9 @@ def camera(request):
     # simulator_sdk needs this explicitly removed for some reason.
     # SDK Camera class destructor *should* be doing this when the fixture goes out of scope.
     with suppress(AttributeError):
-        logger.log('testing', f'Exisiting cameras: {type(cam)._assigned_cameras=!r}')
-        type(cam)._assigned_cameras.discard(camera.uid)
-        logger.log('testing', f'Exisiting cameras: {type(cam)._assigned_cameras=!r}')
+        logger.log('testing', f'Exisiting cameras: {CamClass._assigned_cameras=!r}')
+        CamClass._assigned_cameras.discard(camera.uid)
+        logger.log('testing', f'Exisiting cameras: {CamClass._assigned_cameras=!r}')
 
 
 @pytest.fixture(scope='module')

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -55,6 +55,7 @@ from loguru import logger
     'zwo'
 ])
 def camera(request):
+    logger.log(f'Inside camera fixture: {request=!r}')
     CamClass = request.param[0]
     cam = None
     cam_model = None

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -88,8 +88,10 @@ def camera(request):
         assert cam.is_temperature_stable and cooling_timeout.expired() is False
 
     assert cam.is_ready
-    cam.logger.log('testing', f'Yielding camera {cam}')
+    cam.logger.log('testing', f'Yielding camera {cam=!r}')
     yield cam
+    cam.logger.log('testing', f'Deleting camera {cam=!r}')
+    del cam
 
 
 @pytest.fixture(scope='module')
@@ -259,7 +261,7 @@ def test_get_temp(camera):
     try:
         temperature = camera.temperature
     except NotImplementedError:
-        pytest.skip("Camera {} doesn't implement temperature info".format(camera.name))
+        pytest.skip(f"Camera {camera.name} doesn't implement temperature info")
     else:
         assert temperature is not None
 
@@ -274,13 +276,11 @@ def test_set_target_temperature(camera):
         camera.target_temperature = 10 * u.Celsius
         assert abs(camera.target_temperature - 10 * u.Celsius) < 0.5 * u.Celsius
     else:
-        pytest.skip("Camera {} doesn't implement temperature control".format(camera.name))
+        pytest.skip(f"Camera {camera.name} doesn't implement temperature control")
 
 
 def test_cooling_enabled(camera):
-    print('Some test output')
     assert camera.cooling_enabled == camera.is_cooled_camera
-    print('Some other output')
 
 
 def test_enable_cooling(camera):
@@ -288,7 +288,7 @@ def test_enable_cooling(camera):
         camera.cooling_enabled = True
         assert camera.cooling_enabled
     else:
-        pytest.skip("Camera {} doesn't implement control of cooling status".format(camera.name))
+        pytest.skip(f"Camera {camera.name} doesn't implement control of cooling status")
 
 
 def test_get_cooling_power(camera):
@@ -296,7 +296,7 @@ def test_get_cooling_power(camera):
         power = camera.cooling_power
         assert power is not None
     else:
-        pytest.skip("Camera {} doesn't implement cooling power readout".format(camera.name))
+        pytest.skip(f"Camera {camera.name} doesn't implement cooling power readout")
 
 
 def test_disable_cooling(camera):

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -32,6 +32,8 @@ from panoptes.pocs.camera import create_cameras_from_config
 from panoptes.utils.serializers import to_json
 from panoptes.utils.time import CountdownTimer
 
+from loguru import logger
+
 
 @pytest.fixture(scope='function', params=[
     pytest.param([SimCamera, dict()]),
@@ -63,6 +65,8 @@ def camera(request):
     else:
         cam_model = request.param[1]
 
+    logger.log('testing', f'Creating camera with {CamClass=} {cam_model=} {cam_params=!r}')
+
     if cam_params is not None:
         # Simulator
         cam = CamClass(**cam_params)
@@ -73,7 +77,7 @@ def camera(request):
                 cam = CamClass(**cam_config)
                 break
 
-    cam.logger.log('testing', f'Camera created: {cam!r}')
+    logger.log('testing', f'Camera created: {cam!r}')
 
     # Wait for cooled camera
     if cam.is_cooled_camera:

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -203,7 +203,7 @@ def test_sdk_camera_not_found():
         SimSDKCamera(serial_number='SSC404')
 
     # Explicitly clear the assigned cameras after above error.
-    # SimSDKCamera._assigned_cameras = set()
+    SimSDKCamera._assigned_cameras = set()
 
 
 # Hardware independent tests for SBIG camera
@@ -220,7 +220,7 @@ def test_sbig_driver_bad_path():
         SBIGDriver(library_path='no_library_here')
 
     # Explicitly clear the assigned cameras after above error.
-    # SimSDKCamera._assigned_cameras = set()
+    SimSDKCamera._assigned_cameras = set()
 
 
 @pytest.mark.filterwarnings('ignore:Could not connect to SBIG Camera')

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -55,7 +55,7 @@ from loguru import logger
     'zwo'
 ])
 def camera(request):
-    logger.log(f'Inside camera fixture: {request=!r}')
+    logger.log('testing', f'Inside camera fixture: {request=!r}')
     CamClass = request.param[0]
     cam = None
     cam_model = None


### PR DESCRIPTION
Fixing some of the camera creation for normal usage as well as in testing. This is an attempt to clean up some more hanging tests that go through #1141 and were appearing in #1137

## Description
* Changing camera fixture scope to `function`.
* Removing unused `wait_for_command`
* Rename some possibly conflicting variables.
* Adding extra logging statements

## Related Issue
#1141 