### PR TITLE
Apply initial focus offset when initialising camera

### DIFF
--- a/src/panoptes/pocs/camera/camera.py
+++ b/src/panoptes/pocs/camera/camera.py
@@ -131,6 +131,15 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
                 # Keep a list of active subcomponents
                 self.subcomponents[attr_name] = subcomponent
 
+        # Apply the initial focus offset
+        # This is required so that the focuser initial position corresponds to focus_offset=0
+        if self.has_focuser and self.has_filterwheel:
+            current_filter = self.filterwheel.current_filter
+            focus_offset = self.filterwheel.focus_offsets.get(current_filter, 0)
+            self.logger.debug(f"Initial focus offset for {current_filter} filter: {focus_offset}")
+            if focus_offset:
+                self.focuser.move_by(focus_offset)
+
         self.logger.debug(f'Camera created: {self}')
 
     ############################################################################

--- a/src/panoptes/pocs/filterwheel/filterwheel.py
+++ b/src/panoptes/pocs/filterwheel/filterwheel.py
@@ -42,10 +42,10 @@ class AbstractFilterWheel(PanBase, metaclass=ABCMeta):
                  *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        if (focus_offsets is not None) and not isinstance(focus_offsets, abc.Mapping):
-            raise TypeError("focus_offsets should be a mapping (e.g. a dict),"
-                            f" got {type(focus_offsets)}.")
-        self._focus_offsets = focus_offsets
+        # Define the focus offsets
+        self.focus_offsets = {} if focus_offsets is None else focus_offsets
+        if not isinstance(self.focus_offsets, abc.Mapping):
+            raise TypeError(f"focus_offsets should be a mapping, got {type(focus_offsets)}.")
 
         self._model = model
         self._name = name
@@ -335,18 +335,18 @@ class AbstractFilterWheel(PanBase, metaclass=ABCMeta):
         Args:
             new_position (int or str): The new filter name or filter position.
         """
-        if self._focus_offsets is None:  # Nothing to do here
+        if self.focus_offsets is None:  # Nothing to do here
             self.logger.debug("Found no filter focus offsets to apply.")
             return
 
         new_filter = self.filter_name(new_position)
         try:
-            new_offset = self._focus_offsets[new_filter]
+            new_offset = self.focus_offsets[new_filter]
         except KeyError:
             self.logger.warning(f"No focus offset found for {new_filter} filter.")
             return
 
-        current_offset = self._focus_offsets.get(self.current_filter, 0)
+        current_offset = self.focus_offsets.get(self.current_filter, 0)
         focus_offset = new_offset - current_offset
 
         self.logger.debug(f"Applying focus position offset of {focus_offset} moving from filter "

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -764,10 +764,10 @@ def test_move_filterwheel_focus_offset(camera):
     if not camera.has_focuser:
         pytest.skip("Camera does not have a focuser.")
 
-    if camera.filterwheel._focus_offsets is None:
+    if camera.filterwheel.focus_offsets is None:
         offsets = {}
     else:
-        offsets = camera.filterwheel._focus_offsets
+        offsets = camera.filterwheel.focus_offsets
 
     camera.filterwheel.move_to("one", blocking=True)
 


### PR DESCRIPTION
Apply initial focus offset when initialising camera so that the focuser `initial_position` definition is defined for filters with `focus_offset=0`. This ensures the first coarse focus is done with the correct focus offset regardless of the current filter on camera initialisation.

## Related Issue
AstroHuntsman/huntsman-pocs#524

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)