### PR TITLE
call to `_start_exposure()` does not correctly unpack kwargs

### DIFF
--- a/src/panoptes/pocs/camera/camera.py
+++ b/src/panoptes/pocs/camera/camera.py
@@ -519,7 +519,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
             # Camera type specific exposure set up and start
             self._is_exposing_event.set()
             readout_args = self._start_exposure(seconds=seconds, filename=filename, dark=dark,
-                                                header=header, *args, *kwargs)
+                                                header=header, *args, **kwargs)
         except Exception as err:
             err = error.PanError(f"Error starting exposure on {self}: {err!r}")
             self._exposure_error = repr(err)


### PR DESCRIPTION
## Description
Noticed a small typo in the `panoptes.pocs.camera.AbstractCamera` class in the `take_exposure()` method, missing an extra `*` when passing kwargs into to the call to `_start_exposure()` .

## Related Issue
closes #1155

## How Has This Been Tested?
This error was noticed due a failing unit test

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
