### PR TITLE
Update environment and testing

### DIFF
--- a/.github/workflows/pythontest.yaml
+++ b/.github/workflows/pythontest.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.8 ]
+        python-version: [ "3.10" ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -22,11 +22,11 @@ jobs:
           # exit-zero treats all errors as warnings.
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=100 --statistics
   test:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [ 3.8 ]
+        os: [ ubuntu-latest ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,14 +18,13 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3 :: Only
     Topic :: Scientific/Engineering :: Astronomy
     Topic :: Scientific/Engineering :: Physics
 
 [options]
 zip_safe = False
-packages = find:
 include_package_data = True
 package_dir =
     =src
@@ -40,7 +39,8 @@ install_requires =
     astroplan
     astropy
     fastapi
-    panoptes-utils[config]>=0.2.33
+    panoptes-utils[config]>=0.2.35
+    pandas
     Pillow>=8.3.2
     pyserial
     requests
@@ -49,7 +49,7 @@ install_requires =
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
-python_requires = >=3.8
+python_requires = >=3.9
 
 [options.packages.find]
 where = src

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-    Setup file for pocs.
+    Setup file for utils.
     Use setup.cfg to configure your project.
 
     This file was generated with PyScaffold 3.2.3.
@@ -10,7 +10,7 @@
 import sys
 
 from pkg_resources import VersionConflict, require
-from setuptools import setup
+from setuptools import setup, find_namespace_packages
 
 try:
     require('setuptools>=38.3')
@@ -18,6 +18,5 @@ except VersionConflict:
     print("Error: version of setuptools is too old (<38.3)!")
     sys.exit(1)
 
-
 if __name__ == "__main__":
-    setup(use_pyscaffold=True)
+    setup(use_pyscaffold=True, packages=find_namespace_packages(where='src'))

--- a/tests/testing.yaml
+++ b/tests/testing.yaml
@@ -31,7 +31,7 @@ location:
   gmt_offset: -600 # Offset in minutes from GMT during.
   # standard time (not daylight saving).
 directories:
-  base: /panoptes-pocs
+  base: .
   images: images
   data: data
   resources: resources/


### PR DESCRIPTION
* **Minimum python bumped to 3.9**
* Fix namespace to work with pep 420 and with pyscaffold.
* Uses `panoptes-utils>=0.2.35`
* Missing `pandas` dependency
* GHA testing runs on matrix of python versions.
* Fix testing config file.