### PR TITLE
Update cem40

### DIFF
--- a/src/panoptes/pocs/mount/ioptron/cem40.py
+++ b/src/panoptes/pocs/mount/ioptron/cem40.py
@@ -5,6 +5,7 @@ from enum import IntEnum
 
 from astropy import units as u
 from astropy.coordinates import SkyCoord
+from dateutil.parser import parse as parse_date
 from panoptes.utils.time import current_time
 from panoptes.utils import error as error
 from panoptes.pocs.mount.serial import AbstractSerialMount
@@ -188,7 +189,7 @@ class Mount(AbstractSerialMount):
         self.logger.info('Searching for the home position.')
         self.query('search_for_home')
 
-    def _set_initial_rates(self, alt_limit='+00', meridian_treatment='100'):
+    def _set_initial_rates(self, alt_limit='+30', meridian_treatment='015'):
         # Make sure we start at sidereal
         self.query('set_sidereal_tracking')
 
@@ -354,7 +355,10 @@ class Mount(AbstractSerialMount):
                                 self.state == MountState.TRACKING_PEC
             self._is_slewing = self.state == MountState.SLEWING
 
-        status['timestamp'] = self.query('get_local_time')
+        # Get offset in hours (as int) then parse rearranged time string.
+        ts = self.query('get_local_time')
+        offset = int(float(ts[:4]) / 60)
+        status['timestamp'] = parse_date(f'{ts[5:11]}T{ts[11:]}{offset}', yearfirst=True)
         status['tracking_rate_ra'] = self.tracking_rate
 
         return status

--- a/src/panoptes/pocs/mount/serial.py
+++ b/src/panoptes/pocs/mount/serial.py
@@ -32,7 +32,7 @@ class AbstractSerialMount(AbstractMount, ABC):
 
     @property
     def _port(self):
-        return self.serial.ser.port
+        return self.serial.port
 
     def connect(self):
         """Connects to the mount via the serial port (`self._port`)


### PR DESCRIPTION
* Fix the timestamp in the status call by parsing the date properly.
* Set the default meridian treatment to flip at 15 deg past meridian (`015`) and not go below 30 degrees alt.

Comes from #1167.

