### PR TITLE
Update observing methods

### DIFF
--- a/src/panoptes/pocs/core.py
+++ b/src/panoptes/pocs/core.py
@@ -1,6 +1,7 @@
 import os
 from contextlib import suppress
 from multiprocessing import Process
+from typing import Optional
 
 from astropy import units as u
 from panoptes.pocs.base import PanBase
@@ -260,7 +261,9 @@ class POCS(PanStateMachine, PanBase):
         self.logger.debug("Resetting observing run attempts")
         self._obs_run_retries = self.get_config('pocs.RETRY_ATTEMPTS', default=3)
 
-    def observe_target(self, observation: Observation | None, park_if_unsafe: bool = True):
+    def observe_target(self,
+                       observation: Optional[Observation] = None,
+                       park_if_unsafe: bool = True):
         """Observe something! 🔭🌠
 
         Note: This is a long-running blocking method.

--- a/src/panoptes/pocs/state/states/default/observing.py
+++ b/src/panoptes/pocs/state/states/default/observing.py
@@ -1,5 +1,3 @@
-from multiprocessing import Process
-
 from panoptes.utils import error
 
 
@@ -14,20 +12,12 @@ def on_enter(event_data):
     pocs.next_state = 'parking'
 
     try:
-        # Do the observing, once per exptime (usually only one unless a compound observation).
-        for _ in current_obs.exptimes:
-            pocs.observatory.observe(blocking=True)
-            pocs.say(f"Finished observing! I'll start processing that in the background.")
-
-            # Do processing in background.
-            process_proc = Process(target=pocs.observatory.process_observation)
-            process_proc.start()
-            pocs.logger.debug(f'Processing for {current_obs} started on {process_proc.pid=}')
+        pocs.observe_target()
     except (error.Timeout, error.CameraNotFound):
         pocs.logger.warning("Timeout waiting for images. Something wrong with cameras, parking.")
     except Exception as e:
         pocs.logger.warning(f"Problem with imaging: {e!r}")
         pocs.say("Hmm, I'm not sure what happened with that exposure.")
     else:
-        pocs.logger.debug('Finished with observing, going to analyze')
         pocs.next_state = 'analyzing'
+        pocs.logger.debug('Finished with observing, going to {pocs.next_state}')

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -315,7 +315,7 @@ def test_observe(observatory):
     assert len(observatory.scheduler.observed_list) == 1
 
     assert observatory.current_observation.current_exp_num == 0
-    observatory.observe()
+    observatory.take_observation()
     assert observatory.current_observation.current_exp_num == 1
 
 


### PR DESCRIPTION
* Changes `observatory.observe` to `observatory.take_observation` to have more descriptive name and not interfere with potential state action names.
* `take_observation` will now remove cameras if they are stuck and try to continue observing until no cameras are left.
* Created high-level `pocs.observe_target`, which loops over the exptimes in the observation and sets up processing threads when done with each exposure. This replaces what was in the `observing` state and moves it to a `pocs` method. This allows the mount to stay on a target for the length of the observation without moving between states during each exposures, which helps cadence.
* ~~Relies on python 3.10 from #1174~~

Comes from #1167 