### PR TITLE
Update install script

### DIFF
--- a/conf_files/pocs-supervisord.conf
+++ b/conf_files/pocs-supervisord.conf
@@ -1,0 +1,32 @@
+[program:pocs-config-server]
+user=panoptes
+directory=/home/panoptes
+command=/home/panoptes/conda/envs/conda-pocs/bin/panoptes-config-server --host 0.0.0.0 --port 6563 run --config-file /home/panoptes/conf_files/pocs.yaml
+stderr_logfile=/home/panoptes/logs/config-server.err.log
+stdout_logfile=/home/panoptes/logs/config-server.out.log
+autostart=true
+autorestart=true
+stopasgroup=true
+startretries=3
+
+[program:pocs-power-monitor]
+user=panoptes
+directory=/home/panoptes
+command=/home/panoptes/conda/envs/conda-pocs/bin/uvicorn --host 0.0.0.0 --port 6564 panoptes.pocs.utils.service.power:app
+stderr_logfile=/home/panoptes/logs/power-monitor.err.log
+stdout_logfile=/home/panoptes/logs/power-monitor.out.log
+autostart=true
+autorestart=true
+stopasgroup=true
+startretries=3
+
+[program:pocs-weather-report]
+user=panoptes
+directory=/home/panoptes
+command=/usr/bin/zsh -c "/home/panoptes/conda/envs/conda-pocs/bin/pocs sensor monitor weather --read-frequency 90"
+stderr_logfile=/home/panoptes/logs/weather-reader.err.log
+stdout_logfile=/home/panoptes/logs/weather-reader.out.log
+autostart=true
+autorestart=true
+stopasgroup=true
+startretries=3

--- a/scripts/install/install-pocs.sh
+++ b/scripts/install/install-pocs.sh
@@ -23,13 +23,8 @@ usage() {
 #
 #   * Create
 #   * Create the needed directory structure for POCS.
-#   * Install docker and tools on the host computer.
 #   * Fetch the docker images needed to run.
 #   * Source \${PANDIR}/env if it exists.
-#
-# Docker Images:
-#
-#   gcr.io/panoptes-exp/panoptes-pocs:develop
 #
 # The regular install is for running units.
 #
@@ -210,10 +205,10 @@ dependencies:
   - streamz
   - uvicorn[standard]
   - pip:
-      - "git+https://github.com/panoptes/POCS@${CODE_BRANCH}#egg=panoptes-pocs[google,focuser,sensors]"
-      - docker-compose
+      - -e "${PANDIR}[google,focuser,sensors]"
 EOF
 
+  cd "${PANDIR}"
   "${HOME}/conda/envs/${CONDA_ENV_NAME}/bin/mamba" env update -p "${HOME}/conda/envs/${CONDA_ENV_NAME}" -f environment.yaml
 }
 
@@ -346,16 +341,6 @@ function fix_time() {
   timedatectl
 }
 
-function setup_nfs_host() {
-  sudo apt-get install -y nfs-kernel-server
-  sudo mkdir -p "${HOME}/images"
-  ROUTER_IP=$(ip r | grep default | cut -d ' ' -f 3)
-  echo "${HOME}/images ${ROUTER_IP}/24 (rw,async,no_subtree_check)" | sudo tee -a /etc/exports
-
-  sudo exportfs -a
-  sudo systemctl restart nfs-kernel-server
-}
-
 function do_install() {
   clear
 
@@ -379,7 +364,6 @@ function do_install() {
   echo "PANDIR: ${PANDIR}"
   echo "HOST: ${HOST}"
   echo "Logfile: ${LOGFILE}"
-  #  echo "DOCKER_IMAGE: ${DOCKER_IMAGE}"
   echo "CODE_BRANCH: ${CODE_BRANCH}"
 
   fix_time
@@ -389,9 +373,9 @@ function do_install() {
     install_zsh
   fi
 
-  install_conda
-
   get_pocs_repo
+
+  install_conda
 
   make_directories
 

--- a/scripts/install/install-pocs.sh
+++ b/scripts/install/install-pocs.sh
@@ -71,7 +71,8 @@ USE_ZSH=false
 INSTALL_SERVICES=false
 DEFAULT_GROUPS="dialout,plugdev,input,sudo,docker"
 
-ROUTER_IP="${ROUTER_IP:-192.168.8.1}"
+# We use htpdate below so this just needs to be a public url w/ trusted time.
+TIME_SERVER="${TIME_SERVER:-google.com}"
 
 CONDA_URL="https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-$(uname -m).sh"
 CONDA_ENV_NAME=conda-pocs
@@ -88,8 +89,6 @@ function which_branch() {
 }
 
 function get_time_settings() {
-  read -rp "What is the IP address of your router (default: ${ROUTER_IP})? " USER_NTP_SERVER
-  ROUTER_IP="${USER_NTP_SERVER:-$ROUTER_IP}"
   sudo dpkg-reconfigure tzdata
 }
 
@@ -169,28 +168,6 @@ function system_deps() {
     ssh-keygen -t rsa -N "" -f "${HOME}/.ssh/id_rsa"
   fi
 
-}
-
-function get_or_build_docker_images() {
-  echo "Pulling POCS docker images from Google Cloud Registry (GCR)."
-
-  sudo docker pull "${DOCKER_IMAGE}:${CODE_BRANCH}"
-
-  if [[ $HOST == *-control-box ]]; then
-    # Copy the docker-compose file
-    sudo docker run --rm -it \
-      -v "${PANDIR}:/temp" \
-      "${DOCKER_IMAGE}:${CODE_BRANCH}" \
-      "cp /panoptes-pocs/docker/docker-compose.yaml /temp/docker-compose.yaml"
-    sudo chown "${PANUSER}:${PANUSER}" "${PANDIR}/docker-compose.yaml"
-
-    # Copy the config file
-    sudo docker run --rm -it \
-      -v "${PANDIR}:/temp" \
-      "${DOCKER_IMAGE}:${CODE_BRANCH}" \
-      "cp -rv /panoptes-pocs/conf_files/* /temp/conf_files/"
-    sudo chown -R "${PANUSER}:${PANUSER}" "${PANDIR}/conf_files/"
-  fi
 }
 
 function install_conda() {
@@ -350,19 +327,19 @@ EOT
 
 function fix_time() {
   echo "Syncing time."
-  DEBIAN_FRONTEND=noninteractive sudo apt-get install -y -qq ntpdate | sudo tee -a "${LOGFILE}"
+  DEBIAN_FRONTEND=noninteractive sudo apt-get install -y -qq htpdate | sudo tee -a "${LOGFILE}"
   sudo timedatectl set-ntp false
-  sudo ntpdate -s "${ROUTER_IP}"
+  sudo /usr/sbin/htpdate -as "${TIME_SERVER}"
   sudo timedatectl set-ntp true
 
   # Add crontab entries for reboot and every hour.
   (
     sudo crontab -l
-    echo "@reboot ntpdate -s ${ROUTER_IP}"
+    echo "@reboot /usr/sbin/htpdate -as ${TIME_SERVER}"
   ) | sudo crontab -
   (
     sudo crontab -l
-    echo "13 * * * * ntpdate -s ${ROUTER_IP}"
+    echo "13 * * * * /usr/sbin/htpdate -s ${TIME_SERVER}"
   ) | sudo crontab -
 
   # Show updated time.
@@ -372,6 +349,7 @@ function fix_time() {
 function setup_nfs_host() {
   sudo apt-get install -y nfs-kernel-server
   sudo mkdir -p "${HOME}/images"
+  ROUTER_IP=$(ip r | grep default | cut -d ' ' -f 3)
   echo "${HOME}/images ${ROUTER_IP}/24 (rw,async,no_subtree_check)" | sudo tee -a /etc/exports
 
   sudo exportfs -a
@@ -383,7 +361,7 @@ function do_install() {
 
   # Set up directory for log file.
   mkdir -p "${HOME}/logs"
-  echo "Starting POCS install at $(date)" >>"${LOGFILE}"  
+  echo "Starting POCS install at $(date)" >>"${LOGFILE}"
 
   name_me
 
@@ -404,12 +382,7 @@ function do_install() {
   #  echo "DOCKER_IMAGE: ${DOCKER_IMAGE}"
   echo "CODE_BRANCH: ${CODE_BRANCH}"
 
-  # Make sure the time setting is correct on RPi.
-  if [ "$(uname -m)" = "aarch64" ]; then
-    echo "ROUTER_IP: ${ROUTER_IP}"
-    fix_time
-  fi
-
+  fix_time
   system_deps
 
   if [[ "${USE_ZSH}" == true ]]; then
@@ -425,8 +398,6 @@ function do_install() {
   if [[ "${INSTALL_SERVICES}" == true ]]; then
     install_services
   fi
-
-  # get_or_build_docker_images
 
   echo "Please reboot your machine before using POCS."
 


### PR DESCRIPTION
* Install `supervisor` and use instead of `systemd` so `panoptes` user has better control of config file and control.
* Use `htpdate` instead of `ntpdate` and use google.com as the time server.
* Remove docker items.
* Install pocs from local repo.
* Remove unused nfs setup.

Comes from #1167 
Replaces and closes #1166 