### PR TITLE
Put the mount timestamp into local time.

### DIFF
--- a/resources/mounts/ioptron/v310.yaml
+++ b/resources/mounts/ioptron/v310.yaml
@@ -10,7 +10,7 @@ cmd_post: '#'
 get_status:
   cmd: GLS
   response: sTTTTTTTTTTTTTTTTnnnnnn
-get_local_time:
+get_timestamp:
   cmd: GUT
   response: sMMMnXXXXXXXXXXXXX
 

--- a/src/panoptes/pocs/mount/ioptron/cem40.py
+++ b/src/panoptes/pocs/mount/ioptron/cem40.py
@@ -359,20 +359,16 @@ class Mount(AbstractSerialMount):
                                 self.state == MountState.TRACKING_PEC
             self._is_slewing = self.state == MountState.SLEWING
 
-        # Get offset in hours (as int) then parse rearranged time string.
-        ts = self.query('get_local_time')
-
+        # Get and parse the time from the mount.
+        ts = self.query('get_timestamp')
         offset = int(ts[:4]) * u.minute
         now = ts[6:] * u.ms
         j2000 = Time(2000, format='jyear')
         daylight_savings = bool(ts[5])
-
         t0 = j2000 + now + offset
-        if daylight_savings:
-            t0 = t0 + 1 * u.hour
 
         status['time_local'] = t0.iso
-        status['daylight_savings'] = bool(ts[5])
+        status['daylight_savings'] = daylight_savings
         status['tracking_rate_ra'] = self.tracking_rate
 
         return status

--- a/src/panoptes/pocs/mount/ioptron/cem40.py
+++ b/src/panoptes/pocs/mount/ioptron/cem40.py
@@ -362,7 +362,7 @@ class Mount(AbstractSerialMount):
         # Get and parse the time from the mount.
         ts = self.query('get_timestamp')
         offset = int(ts[:4]) * u.minute
-        now = ts[6:] * u.ms
+        now = int(ts[6:]) * u.ms
         j2000 = Time(2000, format='jyear')
         daylight_savings = bool(ts[5])
         t0 = j2000 + now + offset

--- a/src/panoptes/pocs/mount/ioptron/cem40.py
+++ b/src/panoptes/pocs/mount/ioptron/cem40.py
@@ -364,7 +364,7 @@ class Mount(AbstractSerialMount):
         offset = int(ts[:4]) * u.minute
         now = int(ts[6:]) * u.ms
         j2000 = Time(2000, format='jyear')
-        daylight_savings = bool(ts[5])
+        daylight_savings = bool(int(ts[5]))
         t0 = j2000 + now + offset
 
         status['time_local'] = t0.iso


### PR DESCRIPTION
Correctly parse the timestamp from the CEM40 with 2021+ firmware.