### PR TITLE
 Remove unused dependency: click

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,6 @@ install_requires =
     astroplan
     astropy
     certifi>=2023.7.22
-    click>=7.1.2
     fastapi
     fastapi-utils
     numpy>=1.22


### PR DESCRIPTION
## Summary

Hello @wtgee,

I hope you're doing well! I've just opened this pull request that proposes the removal of the unused `click` dependency from the `setup.cfg` configuration file. It's part of an ongoing research endeavor focusing on the identification and elimination of code bloat within software projects. Your insights on this would be really valuable.

## Rationale

The `click` package was added in 3247290bc, but upon analysis of the codebase, it was found that it is not currently being utilized within the project. Removing this unused dependency can reduce the overall footprint of the application, mitigate potential security risks, and simplify the dependency management process.

## Changes

- Removed the dependency to the `click`  PyPI package from the `setup.cfg` file.

## Impact

- Reduced package size: The removal of this unused dependency will lead to a decrease in the overall size of the installed packages.
- Simplified dependency tree: Fewer dependencies make the project easier to maintain and can speed up installation.
