### PR TITLE
gphoto timeout duration fix

### DIFF
--- a/src/panoptes/pocs/camera/camera.py
+++ b/src/panoptes/pocs/camera/camera.py
@@ -554,7 +554,9 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         threading.excepthook = log_thread_error
 
         # The full timeout is the exposure time plus the readout time plus the timeout.
-        timeout_duration = seconds.to_value(u.second) + self.readout_time + timeout.to_value(u.second)
+        timeout_duration = (get_quantity_value(seconds, u.second) +
+                            get_quantity_value(self.readout_time, u.second) +
+                            get_quantity_value(timeout, u.second))
 
         # Start polling thread that will call camera type specific _readout method when done
         readout_thread = threading.Thread(name=f'{self.name}PollExposureThread',

--- a/src/panoptes/pocs/camera/camera.py
+++ b/src/panoptes/pocs/camera/camera.py
@@ -482,9 +482,15 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
                 `IMAGETYP` keyword entirely.
             blocking (bool, optional): If False (default) returns immediately after starting
                 the exposure, if True will block until it completes and file exists.
-            timeout (astropy.Quantity): The timeout to use for the exposure, default 10 seconds.
+            timeout (astropy.Quantity): The timeout to use for the exposure, default 10 seconds. The
+                timeout gets added to the `seconds` and the `self.readout_time` to get the total
+                timeout for the exposure. If the exposure takes longer than this then a
+                `panoptes.utils.error.Timeout` exception will be raised.
         Returns:
             threading.Thread: The readout thread, which joins when readout has finished.
+        Raises:
+            error.PanError: If camera is not connected.
+            error.Timeout: If the exposure takes longer than total `timeout` to complete.
         """
         self._exposure_error = None
         # Reset the readout

--- a/src/panoptes/pocs/camera/simulator/dslr.py
+++ b/src/panoptes/pocs/camera/simulator/dslr.py
@@ -58,6 +58,7 @@ class Camera(AbstractCamera):
     def _start_exposure(self, seconds=None, filename=None, dark=False, header=None, *args,
                         **kwargs):
         self._is_exposing_event.set()
+        seconds = kwargs.get('simulator_exptime', seconds)
         exposure_thread = Timer(interval=get_quantity_value(seconds, unit=u.second),
                                 function=self._end_exposure)
         exposure_thread.start()

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -496,10 +496,10 @@ def test_exposure_timeout(camera, tmpdir, caplog):
     # This should result in a timeout error in the poll thread, but the exception won't
     # be seen in the main thread. Can check for logged error though.
     camera._readout_time = 0.5 * u.second
-    readout_thread = camera.take_exposure(seconds=2.0, filename=fits_path, timeout=0.01)
+    readout_thread = camera.take_exposure(seconds=1.0, filename=fits_path, timeout=0.01)
 
     # Wait for it all to be over.
-    time.sleep(4)
+    time.sleep(5)
 
     # Should be an ERROR message in the log from the exposure timeout
     assert caplog.records[-1].levelname == "ERROR"

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -495,6 +495,7 @@ def test_exposure_timeout(camera, tmpdir, caplog):
     # Make timeout extremely short to force a timeout error
     # This should result in a timeout error in the poll thread, but the exception won't
     # be seen in the main thread. Can check for logged error though.
+    camera._readout_time = 0.5 * u.second
     readout_thread = camera.take_exposure(seconds=2.0, filename=fits_path, timeout=0.01)
 
     # Wait for it all to be over.

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -492,11 +492,11 @@ def test_exposure_timeout(camera, tmpdir, caplog):
     Tests response to an exposure timeout
     """
     fits_path = str(tmpdir.join('test_exposure_timeout.fits'))
-    # Make timeout extremely short to force a timeout error
-    # This should result in a timeout error in the poll thread, but the exception won't
-    # be seen in the main thread. Can check for logged error though.
-    camera._readout_time = 0.5 * u.second
-    readout_thread = camera.take_exposure(seconds=1.0, filename=fits_path, timeout=0.01)
+
+    # We set short exptime, readout, and timeout durations, but pass the `simulator_exptime` to our
+    # camera. This should cause the camera to timeout during the exposure.
+    camera._readout_time = 0.2 * u.second
+    readout_thread = camera.take_exposure(seconds=1.0, simulator_exptime=20, filename=fits_path, timeout=0.03)
 
     # Wait for it all to be over.
     time.sleep(5)


### PR DESCRIPTION
Make the timeout durations consistent. A default `timeout` had been added to the camera's `take_exposure` method, which was then being passed to the `_poll_exposure`. Previously `_poll_exposure` had a `timeout=None` default, so it would build a new timeout duration consisting of the exptime, readout time, and a "timeout" padding.  This change just builds that default in `take_exposure` and passes it to `_poll_exposure` but also uses the value to control the blocking in `take_exposure`.