### PR TITLE
Fix incorrect package name in install script

### DIFF
--- a/scripts/install/install-pocs.sh
+++ b/scripts/install/install-pocs.sh
@@ -77,7 +77,7 @@ function system_deps() {
 
   sudo apt-get -y -qq install \
     ack \
-    astrometry-net \
+    astrometry.net \
     astrometry-data-tycho2-10-19 \
     byobu \
     curl \


### PR DESCRIPTION
Incorrect package name was causing other dependencies to not install.

Closes #1212