### PR TITLE
cli command for getting an image upload key

### DIFF
--- a/conf_files/pocs.yaml
+++ b/conf_files/pocs.yaml
@@ -157,7 +157,7 @@ observations:
   make_pretty_images: True
   keep_jpgs: True
   plate_solve: True
-  upload_image_immediately: True
+  upload_image: False
 
 ######################## Google Network ########################################
 # By default all images are stored on googlecloud servers and we also
@@ -170,10 +170,9 @@ observations:
 #   service_account_key: Location of the JSON service account key.
 ################################################################################
 panoptes_network:
-  image_storage: False
   use_firestore: False
   service_account_key: # Location of JSON account key
-  project_id: panoptes-exp
+  project_id: panoptes-project-01
   buckets:
     upload: panoptes-images-incoming
 

--- a/src/panoptes/pocs/observatory.py
+++ b/src/panoptes/pocs/observatory.py
@@ -424,7 +424,7 @@ class Observatory(PanBase):
                             record_observations: Optional[bool] = None,
                             make_pretty_images: Optional[bool] = None,
                             plate_solve: Optional[bool] = None,
-                            upload_image_immediately: Optional[bool] = None,
+                            upload_image: Optional[bool] = None,
                             ):
         """Process an individual observation.
 
@@ -438,8 +438,7 @@ class Observatory(PanBase):
                 If None (default), checks the `observations.make_pretty_images`
                 config-server key.
             plate_solve (bool or None): If images should be plate solved, default None for config.
-            upload_image_immediately (bool or None): If images should be uploaded (in a separate
-                process).
+            upload_image (bool or None): If images should be uploaded (in a separate process).
         """
         for cam_name in self.cameras.keys():
             try:
@@ -506,8 +505,7 @@ class Observatory(PanBase):
                 except Exception as e:  # pragma: no cover
                     self.logger.warning(f'Problem with extracting pretty image: {e!r}')
 
-            if upload_image_immediately or self.get_config('observations.upload_image_immediately',
-                                                           default=False):
+            if upload_image or self.get_config('observations.upload_image', default=False):
                 self.logger.debug(f"Uploading current observation: {image_id}")
                 try:
                     self.upload_exposure(exposure_info=exposure)

--- a/src/panoptes/pocs/utils/cli/main.py
+++ b/src/panoptes/pocs/utils/cli/main.py
@@ -2,7 +2,7 @@ import typer
 
 from panoptes.pocs.utils.cli import config
 from panoptes.pocs.utils.cli import sensor
-from panoptes.pocs.utils.cli import image
+from panoptes.pocs.utils.cli import network
 from panoptes.pocs.utils.cli import mount
 from panoptes.pocs.utils.cli import notebook
 from panoptes.pocs.utils.cli import power
@@ -14,7 +14,7 @@ app = typer.Typer()
 state = {'verbose': False}
 
 app.add_typer(config.app, name="config", help='Interact with the config server.')
-app.add_typer(image.app, name="image", help='Interact with images.')
+app.add_typer(network.app, name="network", help='Interact with panoptes network.')
 app.add_typer(mount.app, name="mount", help='Simple mount controls.')
 app.add_typer(notebook.app, name="notebook", help='Start Jupyter notebook environment.')
 app.add_typer(power.app, name="power", help='Interact with power relays.')

--- a/src/panoptes/pocs/utils/cli/network.py
+++ b/src/panoptes/pocs/utils/cli/network.py
@@ -1,15 +1,64 @@
 from pathlib import Path
 from typing import List
 
+import os
+import stat
+import requests
 import typer
 from google.cloud import storage
 from rich import print
 
 from panoptes.pocs.utils.cloud import upload_image
+from panoptes.utils.config.client import set_config
 
 app = typer.Typer()
 upload_app = typer.Typer()
 app.add_typer(upload_app, name='upload')
+
+
+@app.command('get-key')
+def get_key_cmd(secret_password: str,
+                save_dir: Path = Path('~/keys').expanduser(),
+                url: str = 'https://us-central1-project-panoptes-01.cloudfunctions.net/get-upload-key'
+                ):
+    """Get a service account key for image uploading.
+
+    Note: You must know the `secret_password` to get the key.
+    """
+    save_dir.mkdir(parents=True, exist_ok=True)
+    save_path = save_dir / 'panoptes-upload-key.json'
+    if save_path.exists():
+        print(f'[red]Key already exists at {save_path}[/]')
+        return
+
+    # Make a request for the key.
+    res = requests.post(url, json=dict(pwd=secret_password))
+    if not res.ok:
+        print(f'[red]Error getting key: {res.text}[/]')
+        return
+
+    # Save the response content as the key.
+    with open(save_path, 'w') as f:
+        f.write(res.content.decode('utf-8'))
+
+    # Change file permissions so only the owner can read/write.
+    os.chmod(save_path, stat.S_IRUSR | stat.S_IWUSR)
+    print(f'Key saved to [blue]{save_path.absolute().as_posix()}[/]')
+
+    # Update the config entries.
+    try:
+        response = set_config('panoptes_network.service_account_key', save_path.absolute().as_posix())
+        if response is None:
+            raise ValueError('No response from config server')
+
+        response = set_config('observations.upload_image', True)
+        if response is None:
+            raise ValueError('No response from config server')
+
+        print(f'Service account key added to config and image uploading turned on.')
+
+    except Exception as e:
+        print(f'[red]Error updating config: {e}[/]')
 
 
 @upload_app.command('image')


### PR DESCRIPTION
* Change the `image` to `network`.
  * The upload commands are now a subcommand, i.e. `pocs network upload image`. 
  * See `pocs network upload --help` for details.
* Added a `pocs network get-key` commands for getting a service account key. The command will prompt for a password, which must be obtained from a team member. If correct password is given, generates a service account key and downloads it to `~/keys` by default (use `--save-dir` to change), setting proper permissions. Also updates the config server (if it is running) to set `observations.upload_image = True`.
* Consistent use of config entries for uploading images.

