### PR TITLE
Lock FastAPI version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     astroplan
     astropy
     certifi>=2023.7.22
-    fastapi
+    fastapi<0.106.0
     fastapi-utils
     numpy>=1.22
     panoptes-utils[config]>=0.2.40


### PR DESCRIPTION
* Breaking changes (coupled with `pydantic` updates). Hold the version for now until can investigate more.

Blocked by #1223 