### PR TITLE
Weather params from config

### DIFF
--- a/conf_files/pocs.yaml
+++ b/conf_files/pocs.yaml
@@ -132,6 +132,19 @@ environment:
         default_state: on
   weather:
     auto_detect: True
+    safety_delay: 15  # minutes from bad reading until safe again
+    capture_delay: 60  # seconds between taking measurements
+    num_readings: 5  # number of readings to average for each measurement
+    thresholds:
+      cloudy: -25  # Cloudy threshold in delta degrees C
+      very_cloudy: -15  # Very cloudy threshold in delta degrees C
+      windy: 50  # Windy threshold in km/h
+      very_windy: 75  # Very windy threshold in km/h
+      gusty: 100  # Gusty threshold in km/h
+      very_gusty: 125  # Very gusty threshold in km/h
+      wet: 2200  # Ohms of resistance in rain sensor (lower is wetter)
+      rainy: 1800  # Ohms of resistance in rain sensor (lower is wetter)
+
 
 ########################## Observations ########################################
 # An observation folder contains a contiguous sequence of images of a target/field

--- a/src/panoptes/pocs/sensor/weather.py
+++ b/src/panoptes/pocs/sensor/weather.py
@@ -23,12 +23,18 @@ class WeatherStation(PanBase):
         """
         super().__init__(*args, **kwargs)
 
-        self.port = port or self.get_config('environment.weather.port', '/dev/ttyUSB0')
+        conf = self.get_config('environment.weather', {})
+
+        # Update with passed parameters.
+        conf.update(kwargs)
+        conf.pop('auto_detect', None)
+
+        self.port = port or conf.get('port', '/dev/ttyUSB0')
         self.name = name
         self.collection_name = db_collection
 
         self.logger.debug(f'Setting up weather station connection for {name=} on {self.port}')
-        self.weather_station = CloudSensor(serial_port=self.port, **kwargs)
+        self.weather_station = CloudSensor(serial_port=self.port, **conf)
 
         self.logger.debug(f'Weather station config: {self.weather_station.config}')
         self.logger.info(f'{self.weather_station} initialized')

--- a/src/panoptes/pocs/sensor/weather.py
+++ b/src/panoptes/pocs/sensor/weather.py
@@ -28,8 +28,9 @@ class WeatherStation(PanBase):
         self.collection_name = db_collection
 
         self.logger.debug(f'Setting up weather station connection for {name=} on {self.port}')
-        self.weather_station = CloudSensor(serial_port=self.port)
+        self.weather_station = CloudSensor(serial_port=self.port, **kwargs)
 
+        self.logger.debug(f'Weather station config: {self.weather_station.config}')
         self.logger.info(f'{self.weather_station} initialized')
 
     @property

--- a/src/panoptes/pocs/utils/service/weather.py
+++ b/src/panoptes/pocs/utils/service/weather.py
@@ -7,6 +7,7 @@ from panoptes.pocs.sensor.weather import WeatherStation
 
 app = FastAPI()
 weather_station: WeatherStation
+capture_delay: int = 60  # seconds
 
 
 @app.on_event('startup')
@@ -15,6 +16,10 @@ async def startup():
 
     conf = get_config('environment.weather', {})
     print(f'Weather config: {conf}')
+
+    # Update the capture_delay from the config.
+    global capture_delay
+    capture_delay = conf.get('capture_delay', capture_delay)
 
     # Get list of possible ports for auto-detect or use the configured port.
     if conf.get('auto_detect', False) is True:
@@ -38,7 +43,7 @@ async def startup():
 
 
 @app.on_event('startup')
-@repeat_every(seconds=60, wait_first=True)
+@repeat_every(seconds=capture_delay, wait_first=True)
 def record_readings():
     """Record the current readings in the db."""
     global weather_station

--- a/src/panoptes/pocs/utils/service/weather.py
+++ b/src/panoptes/pocs/utils/service/weather.py
@@ -14,6 +14,7 @@ async def startup():
     global weather_station
 
     conf = get_config('environment.weather', {})
+    print(f'Weather config: {conf}')
 
     # Get list of possible ports for auto-detect or use the configured port.
     if conf.get('auto_detect', False) is True:

--- a/src/panoptes/pocs/utils/service/weather.py
+++ b/src/panoptes/pocs/utils/service/weather.py
@@ -7,19 +7,15 @@ from panoptes.pocs.sensor.weather import WeatherStation
 
 app = FastAPI()
 weather_station: WeatherStation
-capture_delay: int = 60  # seconds
+conf = get_config('environment.weather', {})
 
 
 @app.on_event('startup')
 async def startup():
     global weather_station
+    global conf
 
-    conf = get_config('environment.weather', {})
     print(f'Weather config: {conf}')
-
-    # Update the capture_delay from the config.
-    global capture_delay
-    capture_delay = conf.get('capture_delay', capture_delay)
 
     # Get list of possible ports for auto-detect or use the configured port.
     if conf.get('auto_detect', False) is True:
@@ -43,13 +39,12 @@ async def startup():
 
 
 @app.on_event('startup')
-@repeat_every(seconds=capture_delay, wait_first=True)
+@repeat_every(seconds=conf.get('capture_delay', 60), wait_first=True)
 def record_readings():
     """Record the current readings in the db."""
     global weather_station
     reading = weather_station.record()
     print(f'Recorded weather reading: {reading}')
-    print(f'Next reading in {capture_delay} seconds')
     return reading
 
 

--- a/src/panoptes/pocs/utils/service/weather.py
+++ b/src/panoptes/pocs/utils/service/weather.py
@@ -57,4 +57,4 @@ def record_readings():
 async def root():
     """Returns the power board status."""
     global weather_station
-    return weather_station.status
+    return dict(status=weather_station.status, config=weather_station.weather_station.config)

--- a/src/panoptes/pocs/utils/service/weather.py
+++ b/src/panoptes/pocs/utils/service/weather.py
@@ -47,7 +47,10 @@ async def startup():
 def record_readings():
     """Record the current readings in the db."""
     global weather_station
-    return weather_station.record()
+    reading = weather_station.record()
+    print(f'Recorded weather reading: {reading}')
+    print(f'Next reading in {capture_delay} seconds')
+    return reading
 
 
 @app.get('/')


### PR DESCRIPTION
* Pass the kwargs from the weather sensor to the underlying CloudSensor class.
* Adding weather configs to the `pocs.yaml` and updating the service and sensor to use.

Weather params:

```yaml
  weather:
    auto_detect: True
    safety_delay: 15  # minutes from bad reading until safe again
    capture_delay: 60  # seconds between taking measurements
    num_readings: 5  # number of readings to average for each measurement
    thresholds:
      cloudy: -25  # Cloudy threshold in delta degrees C
      very_cloudy: -15  # Very cloudy threshold in delta degrees C
      windy: 50  # Windy threshold in km/h
      very_windy: 75  # Very windy threshold in km/h
      gusty: 100  # Gusty threshold in km/h
      very_gusty: 125  # Very gusty threshold in km/h
      wet: 2200  # Ohms of resistance in rain sensor (lower is wetter)
      rainy: 1800  # Ohms of resistance in rain sensor (lower is wetter)
```