### PR TITLE
Mount-setup-cli-improvements

### DIFF
--- a/src/panoptes/pocs/utils/cli/mount.py
+++ b/src/panoptes/pocs/utils/cli/mount.py
@@ -208,7 +208,7 @@ def setup_mount(
 
                         print(f'Wrote udev entry to [green]{udev_fn}[/green].')
                         print('Run the following command and then reboot for changes to take effect:')
-                        print(f'\t[green]cat {udev_fn} | sudo tee -a /etc/udev/rules.d/{udev_fn}[/green]')
+                        print(f'\t[green]cat {udev_fn} | sudo tee /etc/udev/rules.d/{udev_fn}[/green]')
                     except Exception:
                         pass
 

--- a/src/panoptes/pocs/utils/cli/mount.py
+++ b/src/panoptes/pocs/utils/cli/mount.py
@@ -196,12 +196,18 @@ def setup_mount(
 
                     # Get info for writing udev entry.
                     try:
-                        udev_str = (f'ACTION=="add", '
-                                    f'SUBSYSTEM=="tty", '
-                                    f'ATTRS{{idVendor}}=="{port.vid:04x}", '
-                                    f'ATTRS{{idProduct}}=="{port.pid:04x}", '
-                                    f'ATTRS{{serial}}=="{port.serial_number}", '
-                                    f'SYMLINK+="ioptron"')
+                        udev_str = (
+                            f'ACTION=="add", '
+                            f'SUBSYSTEM=="tty", '
+                            f'ATTRS{{idVendor}}=="{port.vid:04x}", '
+                            f'ATTRS{{idProduct}}=="{port.pid:04x}", '
+                        )
+                        if port.serial_number is not None:
+                            udev_str += f'ATTRS{{serial}}=="{port.serial_number}", '
+
+                        # The name we want it known by.    
+                        udev_str += f'SYMLINK+="ioptron"'
+    
                         udev_fn = Path('91-panoptes.rules')
                         with udev_fn.open('w') as f:
                             f.write(udev_str)


### PR DESCRIPTION
A few improvements to the mount setup cli commands based on user feedback.

* Don't append the udev entry, instead just clobber. Appending was creating problems when the command was run multiple times.
* Don't add udev serial entry if serial number not detected.