### PR TITLE
Fix cloud logging 02

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -5,8 +5,9 @@ dependencies:
   - astropy
   - docopt
   - fastapi
-  - google-cloud-storage
   - google-cloud-firestore
+  - google-cloud-logging
+  - google-cloud-storage
   - gsutil
   - ipython
   - jupyterlab

--- a/src/panoptes/pocs/utils/cli/network.py
+++ b/src/panoptes/pocs/utils/cli/network.py
@@ -46,6 +46,7 @@ def get_key_cmd(unit_id: str = typer.Option(..., prompt=True),
         f.write(res.content.decode('utf-8'))
 
     # Store the path to the key in the GOOGLE_APPLICATION_CREDENTIALS env var in zshrc and bashrc.
+    # Also sets the UNIT_ID and PANID env vars (to the same thing).
     try:
         for rc_file in [Path('~/.zshrc').expanduser(), Path('~/.bashrc').expanduser()]:
             if not rc_file.exists():
@@ -53,6 +54,8 @@ def get_key_cmd(unit_id: str = typer.Option(..., prompt=True),
 
             with rc_file.open('a') as f:
                 f.write(f'\nexport GOOGLE_APPLICATION_CREDENTIALS="{save_path.absolute().as_posix()}"\n')
+                f.write(f'\nexport PANID="{unit_id}"\n')
+                f.write(f'\nexport UNIT_ID="{unit_id}"\n')
 
     except Exception as e:
         print(f'[red]Error writing to ~/.zshrc: {e}[/]')

--- a/src/panoptes/pocs/utils/logger.py
+++ b/src/panoptes/pocs/utils/logger.py
@@ -139,7 +139,7 @@ def get_logger(console_log_file='panoptes.log',
             LOGGER_INFO.handlers['archive'] = archive_id
 
     if cloud_client is not None and 'cloud' not in LOGGER_INFO.handlers:
-        unit_id = os.getenv('PANID', os.environ['USER'])
+        unit_id = os.getenv('UNIT_ID', os.environ['USER'])
         cloud_handler = CloudLoggingHandler(cloud_client, name='panoptes-units', labels={'unit_id': unit_id})
         cloud_id = loguru_logger.add(cloud_handler, level='DEBUG', format="{name} {function}:{line} {message}")
         LOGGER_INFO.handlers['cloud'] = cloud_id


### PR DESCRIPTION
* Use the `UNIT_ID` env var instead of `PANID`.
* When the user gets a download key they are "officially" that unit_id, so we write the env var at that point.