### PR TITLE
Better metadata key names for firestore

### DIFF
--- a/conf_files/pocs.yaml
+++ b/conf_files/pocs.yaml
@@ -22,7 +22,8 @@ location:
   flat_horizon: -6 deg # Flats when sun between this and focus horizon.
   focus_horizon: -12 deg # Dark enough to focus on stars.
   observe_horizon: -18 deg # Sun below this limit to observe.
-  obstructions: [ ]
+  obstructions:
+    -
   timezone: US/Hawaii
   gmt_offset: -600 # Offset in minutes from GMT during.
 


### PR DESCRIPTION
Store the current metadata in the unit document itself, so we can just watch that for constant updates. The record itself is stored in the subcollection called `metadata` still, but should maybe just go directly to bq.