### PR TITLE
DSLR Camera Initialization

### DIFF
--- a/src/panoptes/pocs/camera/gphoto/base.py
+++ b/src/panoptes/pocs/camera/gphoto/base.py
@@ -89,6 +89,7 @@ class AbstractGPhotoCamera(AbstractCamera, ABC):  # pragma: no cover
                     stderr=subprocess.PIPE,
                     universal_newlines=True,
                 )
+                self.logger.debug(f'Started command on proc={self._command_proc.pid}')
             except OSError as e:
                 raise error.InvalidCommand(f"Can't send command to gphoto2. {e} \t {run_cmd}")
             except ValueError as e:
@@ -143,7 +144,7 @@ class AbstractGPhotoCamera(AbstractCamera, ABC):  # pragma: no cover
         if is_index:
             set_cmd = ['--set-config-index', f'{prop}={val}']
         elif is_value:
-            set_cmd = ['--set-config-value', f'{prop}="{val}"']
+            set_cmd = ['--set-config-value', f'{prop}={val}']
         else:
             set_cmd = ['--set-config', f'{prop}="{val}"']
 

--- a/src/panoptes/pocs/camera/gphoto/canon.py
+++ b/src/panoptes/pocs/camera/gphoto/canon.py
@@ -59,10 +59,10 @@ class Camera(AbstractGPhotoCamera):
             'artist': artist_name,
             'copyright': copy_right,
             'ownername': owner_name,
-            'autoexposuremode': 'Manual',
             'drivemode': 'Single',
             'focusmode': 'Manual',
             'imageformat': 'RAW',
+            # 'autoexposuremode': 'Manual',  # Need physical toggle.
             # 'imageformatsd': 'RAW',  # We shouldn't need to set this.
             'capturetarget': 'Internal RAM',
             'reviewtime': 'None',

--- a/src/panoptes/pocs/camera/gphoto/canon.py
+++ b/src/panoptes/pocs/camera/gphoto/canon.py
@@ -56,9 +56,6 @@ class Camera(AbstractGPhotoCamera):
         copy_right = f'{owner_name}_{current_time().datetime:%Y}'
 
         prop2value = {
-            'artist': artist_name,
-            'copyright': copy_right,
-            'ownername': owner_name,
             'drivemode': 'Single',
             'focusmode': 'Manual',
             'imageformat': 'RAW',
@@ -68,6 +65,9 @@ class Camera(AbstractGPhotoCamera):
             'reviewtime': 'None',
             'iso': 100,
             'shutterspeed': 'bulb',
+            'artist': artist_name,
+            'copyright': copy_right,
+            'ownername': owner_name,
         }
 
         self.set_properties(prop2value=prop2value)


### PR DESCRIPTION
* When setting default properties of the Canon camera, use the values rather than the index settings, which seem to be more consistent across models.
* Don't double quote the radio option values.

Closes #1251 