### PR TITLE
Try to improve gphoto2 reads

### DIFF
--- a/src/panoptes/pocs/camera/gphoto/base.py
+++ b/src/panoptes/pocs/camera/gphoto/base.py
@@ -265,7 +265,7 @@ class AbstractGPhotoCamera(AbstractCamera, ABC):  # pragma: no cover
         self.logger.debug(f'Reading Canon DSLR exposure for {filename=}')
         try:
             self.logger.debug(f"Converting CR2 -> FITS: {filename}")
-            fits_path = cr2_utils.cr2_to_fits(filename, headers=headers, remopve_cr2=True)
+            fits_path = cr2_utils.cr2_to_fits(filename, headers=headers, remove_cr2=True)
         except TimeoutError:
             self.logger.error(f'Error processing exposure for {filename} on {self}')
         finally:


### PR DESCRIPTION
The output from the gphoto2 expose command was never being read. This essentially moves the blocking call up to `_poll_exposure` in the base by using the `get_command_result`.

Tested on PAN026, where it fixed the problem of multiple exposures failing.