### PR TITLE
Send config to cloud 1256

### DIFF
--- a/src/panoptes/pocs/base.py
+++ b/src/panoptes/pocs/base.py
@@ -1,9 +1,9 @@
 import os
 
-from requests.exceptions import ConnectionError
-
 from panoptes.utils.config import client
 from panoptes.utils.database import PanDB
+from requests.exceptions import ConnectionError
+
 from panoptes.pocs import __version__
 from panoptes.pocs import hardware
 from panoptes.pocs.utils.logger import get_logger
@@ -39,6 +39,10 @@ class PanBase(object):
             db_type = kwargs.get('db_type', self.get_config('db.type', default='file'))
 
             PAN_DB_OBJ = PanDB(db_name=db_name, storage_dir=db_folder, db_type=db_type)
+
+            # Insert the current config into the DB since we just set it up. This will also
+            # send to the cloud (if enabled).
+            PAN_DB_OBJ.insert_current('config', self.get_config(), store_permanently=False)
 
         self.db = PAN_DB_OBJ
 

--- a/src/panoptes/pocs/utils/cli/config.py
+++ b/src/panoptes/pocs/utils/cli/config.py
@@ -79,6 +79,16 @@ def set_value(
     """Get an item from the config"""
     if server_running():
         metadata = host_info['config_server']
+        if value.startswith('\-'):
+            value = value[1:]
+        try:
+            value = int(value)
+        except ValueError:
+            try:
+                value = float(value)
+            except ValueError:
+                print(f'{value=} is not a number.')
+        print(f'{type(value)=} {value=}')
         item = set_config(key, value, host=metadata.host, port=metadata.port)
         print(item)
 
@@ -127,9 +137,9 @@ def setup():
                                   default=str(get_config('location.elevation')))
     if ' ft' in elevation:
         elevation = (elevation.replace(' ft', '') * u.imperial.foot).to(u.meter)
-    else:
-        elevation = u.Unit(elevation)
-    set_config('location.elevation', str(elevation))
+    elif elevation.endswith('m'):
+        elevation = str(u.Unit(elevation))
+    set_config('location.elevation', elevation)
 
     # Default timezone to UTC but try to probe OS.
     timezone = 'UTC'

--- a/src/panoptes/pocs/utils/cli/run.py
+++ b/src/panoptes/pocs/utils/cli/run.py
@@ -6,7 +6,7 @@ from typing import List
 
 import typer
 from panoptes.utils.time import current_time
-from panoptes.utils.utils import altaz_to_radec
+from panoptes.utils.utils import altaz_to_radec, listify
 from rich import print
 
 from panoptes.pocs.core import POCS
@@ -37,6 +37,8 @@ def get_pocs(context: typer.Context):
 
     # Change to home directory.
     os.chdir(os.path.expanduser('~'))
+
+    simulators = listify(simulators)
 
     if len(simulators) > 0:
         print(f'Running POCS with simulators: {simulators=}')


### PR DESCRIPTION
* Send config to db (and therefore firestore) the first time the db is set up.
* Better parsing of floats and ints from cli.
* Fix to `pocs run auto` for ensure `simulators` is always a list.

Closes #1256 