### PR TITLE
Mount setup improvements 1240

### DIFF
--- a/notebooks/TestPOCS.ipynb
+++ b/notebooks/TestPOCS.ipynb
@@ -37,7 +37,6 @@
    "execution_count": null,
    "id": "0b8f187b-d6b4-4031-b75a-08071ec4bef7",
    "metadata": {},
-   "outputs": [],
    "source": [
     "from panoptes.pocs.core import POCS\n",
     "from panoptes.pocs.observatory import Observatory\n",
@@ -57,7 +56,8 @@
     "    # Add simulators if necessary before running.\n",
     "    pocs = POCS(observatory, simulators=simulators or list())\n",
     "    return pocs\n"
-   ]
+   ],
+   "outputs": []
   },
   {
    "attachments": {},
@@ -75,10 +75,10 @@
    "execution_count": null,
    "id": "dab326ca-82af-499d-98de-95d745a4e9cf",
    "metadata": {},
-   "outputs": [],
    "source": [
     "pocs = create_pocs()"
-   ]
+   ],
+   "outputs": []
   },
   {
    "attachments": {},
@@ -94,10 +94,10 @@
    "execution_count": null,
    "id": "c99bfe96-4c52-4f3b-974c-c0ef9bf85feb",
    "metadata": {},
-   "outputs": [],
    "source": [
     "pocs.initialize()"
-   ]
+   ],
+   "outputs": []
   },
   {
    "attachments": {},
@@ -121,11 +121,11 @@
    "execution_count": null,
    "id": "d1e44dab-b621-4d5f-99b0-99d9c54572f9",
    "metadata": {},
-   "outputs": [],
    "source": [
     "# We don't want to type this out every time.\n",
     "mount = pocs.observatory.mount"
-   ]
+   ],
+   "outputs": []
   },
   {
    "attachments": {},
@@ -141,20 +141,20 @@
    "execution_count": null,
    "id": "79488400-a48e-4798-b857-4bc461344cad",
    "metadata": {},
-   "outputs": [],
    "source": [
     "mount.unpark()"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "e9756656-b6ef-43c1-8d12-43aa89ea9766",
    "metadata": {},
-   "outputs": [],
    "source": [
     "mount.search_for_home()"
-   ]
+   ],
+   "outputs": []
   },
   {
    "attachments": {},
@@ -170,11 +170,11 @@
    "execution_count": null,
    "id": "042c5df6-d656-4abf-be06-da3ddb230027",
    "metadata": {},
-   "outputs": [],
    "source": [
     "mount.move_direction(direction='east', seconds=1)\n",
     "mount.move_direction(direction='south', seconds=3)"
-   ]
+   ],
+   "outputs": []
   },
   {
    "attachments": {},
@@ -192,10 +192,10 @@
    "execution_count": null,
    "id": "d657801c-ba74-45c6-a93b-5a7af7243841",
    "metadata": {},
-   "outputs": [],
    "source": [
     "mount.park()"
-   ]
+   ],
+   "outputs": []
   },
   {
    "attachments": {},
@@ -211,11 +211,11 @@
    "execution_count": null,
    "id": "63168926-64c4-473f-83df-6379b8f4e7fa",
    "metadata": {},
-   "outputs": [],
    "source": [
     "mount.unpark()\n",
     "mount.slew_to_home()"
-   ]
+   ],
+   "outputs": []
   },
   {
    "attachments": {},
@@ -235,14 +235,14 @@
    "execution_count": null,
    "id": "7df0de6b-af02-4a82-b55a-ac0809e8c87c",
    "metadata": {},
-   "outputs": [],
    "source": [
     "# For a unique filename.\n",
     "now = current_time(flatten=True)\n",
     "\n",
     "for cam_name, cam in pocs.observatory.cameras.items():\n",
     "    cam.take_exposure(seconds=2, filename=f'/home/panoptes/images/{cam_name}-test-{now}.cr2', blocking=True)"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -259,10 +259,10 @@
    "execution_count": null,
    "id": "8eacb871",
    "metadata": {},
-   "outputs": [],
    "source": [
     "pocs.observatory.get_observation()"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -279,14 +279,14 @@
    "execution_count": null,
    "id": "508d4980",
    "metadata": {},
-   "outputs": [],
    "source": [
     "# Make sure the mount is unparked\n",
     "pocs.observatory.mount.unpark()\n",
     "\n",
     "# Move to the target.\n",
     "pocs.observatory.mount.slew_to_target()"
-   ]
+   ],
+   "outputs": []
   }
  ],
  "metadata": {

--- a/src/panoptes/pocs/utils/cli/mount.py
+++ b/src/panoptes/pocs/utils/cli/mount.py
@@ -21,7 +21,7 @@ def park_mount(
         ..., '--confirm',
         prompt='Are you sure you want to park the mount?',
         help='Confirm mount parking.'
-        )] = False
+    )] = False
 ):
     """Parks the mount.
 
@@ -44,7 +44,7 @@ def set_park_position(
         ..., '--confirm',
         prompt='Are you sure you want to set the park position?',
         help='Confirm setting the park position.'
-        )] = False
+    )] = False
 ):
     """Sets the park position.
 
@@ -100,7 +100,7 @@ def set_park_position(
             'Park position set. If the directions are correct but the mount is not parked in the correct position, '
             'then you may need to adjust the number of seconds the mount moves in each direction. If you are unsure, '
             'please ask the PANOPTES team for help.'
-            )
+        )
 
 
 @app.command(name='slew-home')
@@ -109,7 +109,7 @@ def search_for_home(
         ..., '--confirm',
         prompt='Are you sure you want to slew to the home position?',
         help='Confirm slew to home.'
-        )] = False
+    )] = False
 ):
     """Slews the mount home position.
 
@@ -133,7 +133,7 @@ def search_for_home(
         ..., '--confirm',
         prompt='Are you sure you want to search for home?',
         help='Confirm mount searching for home.'
-        )] = False
+    )] = False
 ):
     """Searches for the mount home position.
 
@@ -156,7 +156,7 @@ def setup_mount(
         ..., '--confirm',
         prompt='Are you sure you want to setup the mount?',
         help='Confirm mount setup.'
-        )] = False,
+    )] = False,
 ):
     """Sets up the mount port, type, and firmware."""
     if not confirm:
@@ -166,17 +166,14 @@ def setup_mount(
     # Baudrates to check.
     baudrates = [9600, 115200]
     
-    # Ports to ignore
-    ignore_ports = ['/dev/ioptron', '/dev/aag', '/dev/ttyACM0', '/dev/serial']
-    
     # Get all the serial ports.
     ports = get_serial_port_info()
     
     # Loop through all the ports and baudrates.
     for port in ports:
+        if 'ttyUSB' not in port.device:
+            continue
         for baudrate in baudrates:
-            if port.device in ignore_ports:
-                continue
             print(f"Trying {port.device=} at {baudrate=}...")
             device = SerialData(port=port.device, baudrate=baudrate, timeout=1)
             

--- a/src/panoptes/pocs/utils/cli/mount.py
+++ b/src/panoptes/pocs/utils/cli/mount.py
@@ -149,6 +149,9 @@ def setup_mount(
 
     # Baudrates to check.
     baudrates = [9600, 115200]
+    
+    # Ports to ignore
+    ignore_ports = ['/dev/serial', '/dev/aag', '/dev/ttyACM0']
 
     # Get all the serial ports.
     ports = get_serial_port_info()
@@ -156,7 +159,7 @@ def setup_mount(
     # Loop through all the ports and baudrates.
     for port in ports:
         for baudrate in baudrates:
-            if 'serial' in port.device:
+            if port.device in ignore_ports:
                 continue
             print(f"Trying {port.device=} at {baudrate=}...")
             device = SerialData(port=port.device, baudrate=baudrate, timeout=1)

--- a/src/panoptes/pocs/utils/cli/mount.py
+++ b/src/panoptes/pocs/utils/cli/mount.py
@@ -4,11 +4,11 @@ from pathlib import Path
 import serial
 import typer
 from panoptes.utils.config.client import set_config
+from panoptes.utils.rs232 import SerialData
+from panoptes.utils.serial.device import get_serial_port_info
 from rich import print
 from typing_extensions import Annotated
 
-from panoptes.utils.serial.device import get_serial_port_info
-from panoptes.utils.rs232 import SerialData
 from panoptes.pocs.mount import create_mount_from_config
 from panoptes.pocs.mount.ioptron import MountInfo
 
@@ -17,9 +17,12 @@ app = typer.Typer()
 
 @app.command(name='park')
 def park_mount(
-        confirm: Annotated[bool, typer.Option(..., '--confirm',
-                                              prompt='Are you sure you want to park the mount?',
-                                              help='Confirm mount parking.')] = False):
+    confirm: Annotated[bool, typer.Option(
+        ..., '--confirm',
+        prompt='Are you sure you want to park the mount?',
+        help='Confirm mount parking.'
+        )] = False
+):
     """Parks the mount.
 
     Warning: This will move the mount to the park position but will not do any safety
@@ -28,7 +31,7 @@ def park_mount(
     if not confirm:
         print('[red]Cancelled.[/red]')
         return typer.Abort()
-
+    
     mount = create_mount_from_config()
     mount.initialize()
     mount.unpark()
@@ -37,9 +40,12 @@ def park_mount(
 
 @app.command(name='set-park')
 def set_park_position(
-        confirm: Annotated[bool, typer.Option(..., '--confirm',
-                                              prompt='Are you sure you want to set the park position?',
-                                              help='Confirm setting the park position.')] = False):
+    confirm: Annotated[bool, typer.Option(
+        ..., '--confirm',
+        prompt='Are you sure you want to set the park position?',
+        help='Confirm setting the park position.'
+        )] = False
+):
     """Sets the park position.
 
     Warning: This will move the mount to the park position but will not do any safety
@@ -48,19 +54,19 @@ def set_park_position(
     if not confirm:
         print('[red]Cancelled.[/red]')
         return typer.Abort()
-
+    
     mount = create_mount_from_config()
     mount.initialize()
-
+    
     # Confirm that they have previously set the home position.
     if not typer.confirm('Have you previously set the home position?'):
         print('Please set the home position before setting the park position by running "pocs mount search-home".')
         return typer.Exit()
-
+    
     print(f'The mount will first park at the default position and then ask you to confirm the new park position.')
     mount.unpark()
     mount.park()
-
+    
     # Check if correct side of the pier (i.e. RA axis).
     if not typer.confirm('Is the mount on the correct side of the pier?'):
         # Switch the RA axis.
@@ -72,7 +78,7 @@ def set_park_position(
         mount.unpark()
         mount.slew_to_home(blocking=True)
         mount.park()
-
+    
     # Check to make sure cameras are facing down (i.e. Dec axis).
     if not typer.confirm('Are the cameras facing down?'):
         # Switch the DEC axis.
@@ -84,22 +90,27 @@ def set_park_position(
         mount.unpark()
         mount.slew_to_home(blocking=True)
         mount.park()
-
+    
     # Double-check the park position.
     if not typer.confirm('Is the mount parked in the correct position?'):
         # Give warning and bail out.
         print('[red]Sorry! Please try again or ask the PANOPTES team.[/red]')
     else:
-        print('Park position set. If the directions are correct but the mount is not parked in the correct position, '
-              'then you may need to adjust the number of seconds the mount moves in each direction. If you are unsure, '
-              'please ask the PANOPTES team for help.')
+        print(
+            'Park position set. If the directions are correct but the mount is not parked in the correct position, '
+            'then you may need to adjust the number of seconds the mount moves in each direction. If you are unsure, '
+            'please ask the PANOPTES team for help.'
+            )
 
 
 @app.command(name='slew-home')
 def search_for_home(
-        confirm: Annotated[bool, typer.Option(..., '--confirm',
-                                              prompt='Are you sure you want to slew to the home position?',
-                                              help='Confirm slew to home.')] = False):
+    confirm: Annotated[bool, typer.Option(
+        ..., '--confirm',
+        prompt='Are you sure you want to slew to the home position?',
+        help='Confirm slew to home.'
+        )] = False
+):
     """Slews the mount home position.
 
     Warning: This will move the mount to the home position but will not do any safety
@@ -108,7 +119,7 @@ def search_for_home(
     if not confirm:
         print('[red]Cancelled.[/red]')
         return typer.Abort()
-
+    
     mount = create_mount_from_config()
     mount.initialize()
     mount.unpark()
@@ -118,9 +129,12 @@ def search_for_home(
 
 @app.command(name='search-home')
 def search_for_home(
-        confirm: Annotated[bool, typer.Option(..., '--confirm',
-                                              prompt='Are you sure you want to search for home?',
-                                              help='Confirm mount searching for home.')] = False):
+    confirm: Annotated[bool, typer.Option(
+        ..., '--confirm',
+        prompt='Are you sure you want to search for home?',
+        help='Confirm mount searching for home.'
+        )] = False
+):
     """Searches for the mount home position.
 
     Warning: This will move the mount to the home position but will not do any safety
@@ -129,7 +143,7 @@ def search_for_home(
     if not confirm:
         print('[red]Cancelled.[/red]')
         return typer.Abort()
-
+    
     mount = create_mount_from_config()
     mount.initialize()
     mount.search_for_home()
@@ -138,24 +152,26 @@ def search_for_home(
 
 @app.command(name='setup')
 def setup_mount(
-        confirm: Annotated[bool, typer.Option(..., '--confirm',
-                                              prompt='Are you sure you want to setup the mount?',
-                                              help='Confirm mount setup.')] = False,
+    confirm: Annotated[bool, typer.Option(
+        ..., '--confirm',
+        prompt='Are you sure you want to setup the mount?',
+        help='Confirm mount setup.'
+        )] = False,
 ):
     """Sets up the mount port, type, and firmware."""
     if not confirm:
         print('[red]Cancelled.[/red]')
         return typer.Abort()
-
+    
     # Baudrates to check.
     baudrates = [9600, 115200]
     
     # Ports to ignore
-    ignore_ports = ['/dev/serial', '/dev/aag', '/dev/ttyACM0']
-
+    ignore_ports = ['/dev/ioptron', '/dev/aag', '/dev/ttyACM0', '/dev/serial']
+    
     # Get all the serial ports.
     ports = get_serial_port_info()
-
+    
     # Loop through all the ports and baudrates.
     for port in ports:
         for baudrate in baudrates:
@@ -163,7 +179,7 @@ def setup_mount(
                 continue
             print(f"Trying {port.device=} at {baudrate=}...")
             device = SerialData(port=port.device, baudrate=baudrate, timeout=1)
-
+            
             try:
                 device.write(':MountInfo#')
                 try:
@@ -171,12 +187,12 @@ def setup_mount(
                 except serial.SerialException:
                     print('\tDevice potentially being accessed by another process.')
                     continue
-
+                
                 if re.match(r'\d{4}', response):  # iOptron specific
                     mount_type = MountInfo(int(response[0:4]))
                     print(f'Found mount at {port.device=} at {baudrate=} with {response=}.')
                     print(f'It looks like an iOptron {mount_type.name}.')
-
+                    
                     # Get the mainboard and handcontroller firmware version.
                     device.write(':FW1#')
                     response = device.read()
@@ -185,7 +201,7 @@ def setup_mount(
                     print('Firmware:')
                     print(f'\tMainboard: {mainboard_fw}')
                     print(f'\tHandcontroller: {handcontroller_fw}')
-
+                    
                     # Get the RA and DEC firmware version.
                     device.write(':FW2#')
                     response = device.read()
@@ -193,10 +209,10 @@ def setup_mount(
                     dec_fw = int(response[6:-1])
                     print(f'\tRA: {ra_fw}')
                     print(f'\tDEC: {dec_fw}')
-
+                    
                     command_set = 'v310' if ra_fw >= 210101 and dec_fw >= 210101 else 'v250'
                     print(f'Suggested command set: {command_set}')
-
+                    
                     # Get info for writing udev entry.
                     try:
                         udev_str = (
@@ -207,20 +223,20 @@ def setup_mount(
                         )
                         if port.serial_number is not None:
                             udev_str += f'ATTRS{{serial}}=="{port.serial_number}", '
-
+                        
                         # The name we want it known by.    
                         udev_str += f'SYMLINK+="ioptron"'
-    
+                        
                         udev_fn = Path('91-panoptes.rules')
                         with udev_fn.open('w') as f:
                             f.write(udev_str)
-
+                        
                         print(f'Wrote udev entry to [green]{udev_fn}[/green].')
                         print('Run the following command and then reboot for changes to take effect:')
                         print(f'\t[green]cat {udev_fn} | sudo tee /etc/udev/rules.d/{udev_fn}[/green]')
                     except Exception:
                         pass
-
+                    
                     # Confirm the user wants to update the config.
                     if typer.confirm('Do you want to update the config?'):
                         print('Updating config.')
@@ -230,7 +246,7 @@ def setup_mount(
                         set_config('mount.model', mount_type.name.lower())
                         set_config('mount.driver', f'panoptes.pocs.mount.ioptron.{mount_type.name.lower()}')
                         set_config('mount.commands_file', f'ioptron/{command_set}')
-
+                    
                     return typer.Exit()
             except serial.SerialTimeoutException:
                 pass

--- a/src/panoptes/pocs/utils/service/weather.py
+++ b/src/panoptes/pocs/utils/service/weather.py
@@ -14,20 +14,20 @@ conf = get_config('environment.weather', {})
 async def startup():
     global weather_station
     global conf
-
+    
     print(f'Weather config: {conf}')
-
+    
     # Get list of possible ports for auto-detect or use the configured port.
     if conf.get('auto_detect', False) is True:
         ports = [p.device for p in get_comports()]
     else:
         ports = [conf['serial_port']]
-
+    
     # Try to connect to the weather station.
     for port in ports:
-        if 'ioptron' in port:
+        if 'ttyUSB' not in port:
             continue
-
+        
         conf['serial_port'] = port
         try:
             weather_station = WeatherStation(**conf)


### PR DESCRIPTION
For the `pocs mount setup` and the `pocs weather restart`, set the auto detection to ignore certain ports we know are not going to match.

In particular this skips the `/dev/ttyACM0` port, which is often the power board. On some systems when the auto detect probes the port it causes the arduino at that power to do a reset, which resets the trucker board, which powers down the system depending on how things are wired up.

Closes #1240