### PR TITLE
Update metadata records format

### DIFF
--- a/src/panoptes/pocs/core.py
+++ b/src/panoptes/pocs/core.py
@@ -161,8 +161,8 @@ class POCS(PanStateMachine, PanBase):
     def status(self) -> dict:
         try:
             status = {
-                'from_state': self.state,
-                'to_state': self.next_state,
+                'state': self.state,
+                'next_state': self.next_state,
                 'system': {
                     'free_space': str(self._free_space),
                 },


### PR DESCRIPTION
* Store one top-level document called `metadata` for each unit, with the specific sub-collection stored as a key name.
* Also create a document in the `records` collection for just the collection.
