### PR TITLE
Fastapi deprecation 1208

### DIFF
--- a/src/panoptes/pocs/sensor/power.py
+++ b/src/panoptes/pocs/sensor/power.py
@@ -174,6 +174,9 @@ class PowerBoard(PanBase):
     @property
     def status(self):
         readings = self.readings
+        if not readings:
+            self.logger.info('No readings available. If the system just started, please wait a moment.')
+            return {}
         status = {
             r.name: dict(label=r.label, state=r.state.name, reading=readings[r.label])
             for r in self.relays

--- a/src/panoptes/pocs/utils/cli/weather.py
+++ b/src/panoptes/pocs/utils/cli/weather.py
@@ -1,22 +1,44 @@
 import subprocess
+from dataclasses import dataclass
 
 import requests
 import typer
 from rich import print
 
+
+@dataclass
+class HostInfo:
+    host: str = 'localhost'
+    port: str = '6566'
+
+    @property
+    def url(self):
+        return f'http://{self.host}:{self.port}'
+
+
 app = typer.Typer()
 
 
+@app.callback()
+def common(context: typer.Context,
+           host: str = typer.Option('localhost', help='Weather station host address.'),
+           port: str = typer.Option('6566', help='Weather station port.'),
+           ):
+    context.obj = HostInfo(host=host, port=port)
+
+
 @app.command(name='status', help='Get the status of the weather station.')
-def status(page='status', base_url='http://localhost:6566'):
+def status(context: typer.Context, page='status'):
     """Get the status of the weather station."""
-    print(get_page(page, base_url))
+    url = context.obj.url
+    print(get_page(page, url))
 
 
 @app.command(name='config', help='Get the configuration of the weather station.')
-def config(page='config', base_url='http://localhost:6566'):
+def config(context: typer.Context, page='config'):
     """Get the configuration of the weather station."""
-    print(get_page(page, base_url))
+    url = context.obj.url
+    print(get_page(page, url))
 
 
 def get_page(page, base_url):

--- a/src/panoptes/pocs/utils/service/power.py
+++ b/src/panoptes/pocs/utils/service/power.py
@@ -27,7 +27,7 @@ repeat_interval: int = 60
 
 
 @asynccontextmanager
-def lifespan(app: FastAPI):
+async def lifespan(app: FastAPI):
     """Context manager for the lifespan of the app."""
     power_board = PowerBoard(**conf)
     power_board.logger.info(f'Power board setup: {power_board}')

--- a/src/panoptes/pocs/utils/service/power.py
+++ b/src/panoptes/pocs/utils/service/power.py
@@ -21,46 +21,39 @@ class RelayCommand(BaseModel):
     command: RelayAction
 
 
-objects: dict = {}
+power_board: PowerBoard | None = None
+conf: dict = get_config('environment.power', {})
+repeat_interval: int = 60
 
 
 @asynccontextmanager
 def lifespan(app: FastAPI):
     """Context manager for the lifespan of the app."""
-    conf: dict = get_config('environment.power', {})
-    repeat_interval = conf.get('record_interval', repeat_interval)
-    power_board: PowerBoard = PowerBoard(**conf)
+    power_board = PowerBoard(**conf)
     power_board.logger.info(f'Power board setup: {power_board}')
-
-    objects['power_board'] = power_board
-    objects['repeat_interval'] = repeat_interval
-    objects['conf'] = conf
 
     yield
     power_board.logger.info('Shutting down power board')
 
 
-app = FastAPI()
+app = FastAPI(lifespan=lifespan)
 
 
 @repeat_every(seconds=60, wait_first=True)
 def record_readings():
     """Record the current readings in the db."""
-    power_board = objects['power_board']
     return power_board.record(collection_name='power')
 
 
 @app.get('/')
 async def root():
     """Returns the power board status."""
-    power_board = objects['power_board']
     return power_board.status
 
 
 @app.get('/readings')
 async def readings():
     """Return the current readings as a dict."""
-    power_board = objects['power_board']
     return power_board.to_dataframe().to_dict()
 
 
@@ -73,7 +66,7 @@ def control_relay(relay_command: RelayCommand):
 @app.get('/relay/{relay}/control/{command}')
 def control_relay_url(relay: Union[int, str], command: str = 'turn_on'):
     """Control a relay via a GET request"""
-    return do_command(RelayCommand(relay=relay, command=command))
+    return do_command(RelayCommand(relay=relay, command=RelayAction(command)))
 
 
 def do_command(relay_command: RelayCommand):
@@ -82,7 +75,6 @@ def do_command(relay_command: RelayCommand):
     This function performs the actual relay control and is used by both request
     types.
     """
-    power_board = objects['power_board']
     relay_id = relay_command.relay
     try:
         relay = power_board.relay_labels[relay_id]

--- a/src/panoptes/pocs/utils/service/power.py
+++ b/src/panoptes/pocs/utils/service/power.py
@@ -23,13 +23,16 @@ class RelayCommand(BaseModel):
 
 power_board: PowerBoard
 conf: dict
+repeat_interval: int = 60
 
 
 @asynccontextmanager
 def lifespan(app: FastAPI):
     global conf
+    global repeat_interval
     global power_board
     conf = get_config('environment.power', {})
+    repeat_interval = conf.get('record_interval', repeat_interval)
     power_board = PowerBoard(**conf)
     power_board.logger.info(f'Power board setup: {power_board}')
     yield
@@ -39,7 +42,7 @@ def lifespan(app: FastAPI):
 app = FastAPI()
 
 
-@repeat_every(seconds=conf.get('record_interval', 60), wait_first=True)
+@repeat_every(seconds=repeat_interval, wait_first=True)
 def record_readings():
     """Record the current readings in the db."""
     global power_board

--- a/src/panoptes/pocs/utils/service/power.py
+++ b/src/panoptes/pocs/utils/service/power.py
@@ -53,7 +53,8 @@ async def lifespan(app: FastAPI):
     power_thread.start()
 
     yield
-    power_board.logger.info('Shutting down power board')
+    power_board.logger.info('Shutting down power board, please wait.')
+    power_thread.join()
 
 
 app = FastAPI(lifespan=lifespan)

--- a/src/panoptes/pocs/utils/service/power.py
+++ b/src/panoptes/pocs/utils/service/power.py
@@ -26,7 +26,10 @@ app_objects = {}
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """Context manager for the lifespan of the app."""
+    """Context manager for the lifespan of the app.
+
+    This will connect to the power board and record readings at a regular interval.
+    """
     conf: dict = get_config('environment.power', {})
     power_board = PowerBoard(**conf)
     power_board.logger.info(f'Power board setup: {power_board}')

--- a/src/panoptes/pocs/utils/service/power.py
+++ b/src/panoptes/pocs/utils/service/power.py
@@ -45,7 +45,6 @@ async def lifespan(app: FastAPI):
         while True:
             time.sleep(record_interval)
             power_board.record(collection_name='power')
-            power_board.logger.debug('Recorded power reading')
 
     # Create a thread to record the readings at an interval.
     power_thread = Thread(target=record_readings)

--- a/src/panoptes/pocs/utils/service/weather.py
+++ b/src/panoptes/pocs/utils/service/weather.py
@@ -75,6 +75,6 @@ async def status():
 
 
 @app.get('/config')
-async def get_config():
+async def get_ws_config():
     """Returns the power board status."""
     return app_objects['weather_station']

--- a/src/panoptes/pocs/utils/service/weather.py
+++ b/src/panoptes/pocs/utils/service/weather.py
@@ -68,7 +68,7 @@ async def lifespan(app: FastAPI):
         raise RuntimeError('Could not connect to weather station.')
 
     yield
-    print('Shutting down weather station')
+    weather_station.logger.info('Shutting down weather station')
 
 
 app = FastAPI(lifespan=lifespan)

--- a/src/panoptes/pocs/utils/service/weather.py
+++ b/src/panoptes/pocs/utils/service/weather.py
@@ -33,6 +33,8 @@ async def lifespan(app: FastAPI):
     with suppress(FileNotFoundError):
         ioptron_port = os.readlink('/dev/ioptron')
 
+    weather_thread: Thread = None
+
     # Try to connect to the weather station.
     for port in ports:
         if 'ttyUSB' not in port:
@@ -68,7 +70,8 @@ async def lifespan(app: FastAPI):
         raise RuntimeError('Could not connect to weather station.')
 
     yield
-    weather_station.logger.info('Shutting down weather station')
+    weather_station.logger.info('Shutting down weather station, please wait')
+    weather_thread.join()
 
 
 app = FastAPI(lifespan=lifespan)

--- a/src/panoptes/pocs/utils/service/weather.py
+++ b/src/panoptes/pocs/utils/service/weather.py
@@ -55,7 +55,6 @@ async def lifespan(app: FastAPI):
                 while True:
                     time.sleep(record_interval)
                     weather_station.record()
-                    weather_station.logger.debug('Recorded weather reading')
 
             # Create a thread to record the readings at an interval
             weather_thread = Thread(target=record_readings)

--- a/src/panoptes/pocs/utils/service/weather.py
+++ b/src/panoptes/pocs/utils/service/weather.py
@@ -58,7 +58,6 @@ async def lifespan(app: FastAPI):
 app = FastAPI(lifespan=lifespan)
 
 
-@app.on_event('startup')
 @repeat_every(seconds=60, wait_first=True)
 def record_readings():
     """Record the current readings in the db."""


### PR DESCRIPTION
Update the services using FastAPI (power, weather) to properly use lifespan events instead of the deprecated startup/shutdown events. This was originally in #1208 but got clobbered.

This also adds host info to the weather cli for remote weather reading.

Tested on PAN015