### PR TITLE
Remove custom gphoto2 install

### DIFF
--- a/scripts/install/install-pocs.sh
+++ b/scripts/install/install-pocs.sh
@@ -85,6 +85,7 @@ function system_deps() {
     exiftool \
     fonts-powerline \
     gcc \
+    gphoto2 \
     htop \
     httpie \
     jo \
@@ -258,21 +259,17 @@ function do_install() {
   declare -x CMDS=(
     'fix_time'
     'system_deps'
-    'install_gphoto2'
     'install_arduino'
     'get_pocs_repo'
     'make_directories'
-    'write_udev_entries'
   )
 
   declare -x STEPS=(
     'Syncing time'
     'Installing system dependencies'
-    'Installing gphoto2'
     'Installing arduino-cli'
     'Getting POCS repo'
     'Making directories'
-    'Writing udev entries'
   )
 
   if [[ "${USE_ZSH}" == true ]]; then


### PR DESCRIPTION
This pull request includes changes to the `scripts/install/install-pocs.sh` script to update the installation process by modifying system dependencies and removing redundant installation steps.

Updates to system dependencies and installation steps:

* [`scripts/install/install-pocs.sh`](diffhunk://#diff-c8ab5a885ccd416735d07667d8868d1cad0ce999d76c9aebc94231c4a3d1a841R88): Added `gphoto2` to the list of system dependencies in the `system_deps` function.
* [`scripts/install/install-pocs.sh`](diffhunk://#diff-c8ab5a885ccd416735d07667d8868d1cad0ce999d76c9aebc94231c4a3d1a841L261-L275): Removed the `install_gphoto2` and `write_udev_entries` steps from the `do_install` function, as they are no longer needed. The `write_udev_entries` will happen as part of `pocs mount setup`.