### PR TITLE
Adding cli option for slewing the mount to a target.

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -3,6 +3,7 @@ channels:
 dependencies:
   - astroplan
   - astropy
+  - astroquery
   - docopt
   - fastapi
   - google-cloud-firestore

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
     importlib-metadata; python_version<"3.8"
     astroplan
     astropy
+    astroquery
     certifi>=2023.7.22
     fastapi<0.106.0
     fastapi-utils

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
     certifi>=2023.7.22
     fastapi<0.106.0
     fastapi-utils
+    human-readable
     numpy>=1.24
     panoptes-utils[config]>=0.2.40
     pandas

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ install_requires =
     numpy>=1.24
     panoptes-utils[config]>=0.2.40
     pandas
+    pick
     Pillow>=10.0.1
     pyserial
     requests>=2.31.0

--- a/src/panoptes/pocs/utils/cli/mount.py
+++ b/src/panoptes/pocs/utils/cli/mount.py
@@ -181,6 +181,8 @@ def slew_to_target(
 
     # If not specified on the command line, ask for confirmation.
     if not confirm:
+        print('[red]¡ALERT! This command does not do any safety checking for weather, etc. '
+              'Please use with caution.[/red]')
         confirm = typer.confirm('Are you sure you want to slew to the target position?')
 
     if not confirm:


### PR DESCRIPTION
* Add a basic command to slew to target.
* Does some basic checking
* Will not power down or do safety check as of now.
* Loop while tracking and show status (needs to be improved).

```py
# Use the official name, e.g. this is the Blaze Star"
pocs mount slew-to-target --target "T Crb"

# Add the --comet flag to search for comets
pocs mount slew-to-target --target "C/2023 A3" --comet
```

The mount will slew and begin tracking. It is up to the user to hit `Ctrl-c` to cancel the tracking. The user will then be presented with an option of what to do next, either Home or Park.