### PR TITLE
Fix simulator config when using auto run.

### DIFF
--- a/.github/workflows/pythontest.yaml
+++ b/.github/workflows/pythontest.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Install
         run: pip install ".[google,focuser,sensors,testing]"
       - name: Test
-        run: pytest
+        run: pytest -s
       - uses: codecov/codecov-action@v4
         with:
           name: Upload to codecov.io

--- a/.github/workflows/pythontest.yaml
+++ b/.github/workflows/pythontest.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Install
         run: pip install ".[google,focuser,sensors,testing]"
       - name: Test
-        run: pytest -s
+        run: pytest -sx tests/test_pocs.py
       - uses: codecov/codecov-action@v4
         with:
           name: Upload to codecov.io

--- a/.github/workflows/pythontest.yaml
+++ b/.github/workflows/pythontest.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Install
         run: pip install ".[google,focuser,sensors,testing]"
       - name: Test
-        run: pytest -sx tests/test_pocs.py
+        run: pytest -sx --tb=short --disable-warnings --maxfail=1
       - uses: codecov/codecov-action@v4
         with:
           name: Upload to codecov.io

--- a/src/panoptes/pocs/core.py
+++ b/src/panoptes/pocs/core.py
@@ -52,9 +52,10 @@ class POCS(PanStateMachine, PanBase):
         # Explicitly call the base class.
         PanBase.__init__(self, *args, **kwargs)
 
-        if simulators:
-            self.logger.warning(f'Using simulators={simulators!r}')
-            self.set_config('simulator', simulators)
+        simulators = self.set_config('simulator', simulators)
+        if simulators and len(simulators) > 0:
+            print(f'Running POCS with simulators: {simulators=}')
+            self.logger.warning(f'Using {simulators=}')
 
         assert isinstance(observatory, Observatory)
 

--- a/src/panoptes/pocs/core.py
+++ b/src/panoptes/pocs/core.py
@@ -52,7 +52,7 @@ class POCS(PanStateMachine, PanBase):
         # Explicitly call the base class.
         PanBase.__init__(self, *args, **kwargs)
 
-        simulators = self.set_config('simulator', simulators)
+        simulators = self.set_config('simulator', simulators)['simulator']
         if simulators and len(simulators) > 0:
             print(f'Running POCS with simulators: {simulators=}')
             self.logger.warning(f'Using {simulators=}')

--- a/src/panoptes/pocs/mount/mount.py
+++ b/src/panoptes/pocs/mount/mount.py
@@ -116,7 +116,7 @@ class AbstractMount(PanBase):
 
     @property
     def status(self):
-        self.logger.info('Getting mount status')
+        self.logger.trace('Getting mount status')
         status = {}
         try:
             status['tracking_rate'] = self.tracking_rate
@@ -125,21 +125,21 @@ class AbstractMount(PanBase):
             status['movement_speed'] = self.movement_speed
 
             current_coord = self.get_current_coordinates()
-            self.logger.info(f'{current_coord=}')
+            self.logger.trace(f'{current_coord=}')
             if current_coord is not None:
-                self.logger.info('Getting current_ra and current_dec')
+                self.logger.trace('Getting current_ra and current_dec')
                 status['current_ra'] = get_quantity_value(current_coord.ra, unit='degree')
                 status['current_dec'] = get_quantity_value(current_coord.dec, unit='degree')
 
             if self.has_target:
                 target_coord = self.get_target_coordinates()
-                self.logger.info(f'{target_coord=}')
+                self.logger.trace(f'{target_coord=}')
                 status['mount_target_ra'] = get_quantity_value(target_coord.ra, unit='degree')
                 status['mount_target_dec'] = get_quantity_value(target_coord.dec, unit='degree')
         except Exception as e:
-            self.logger.debug(f'Problem getting mount status: {e!r}')
+            self.logger.trace(f'Problem getting mount status: {e!r}')
 
-        self.logger.info('Updating status with _update_status')
+        self.logger.trace('Updating status with _update_status')
         status.update(self._update_status())
         return status
 

--- a/src/panoptes/pocs/mount/mount.py
+++ b/src/panoptes/pocs/mount/mount.py
@@ -116,6 +116,7 @@ class AbstractMount(PanBase):
 
     @property
     def status(self):
+        self.logger.info('Getting mount status')
         status = {}
         try:
             status['tracking_rate'] = self.tracking_rate
@@ -124,17 +125,21 @@ class AbstractMount(PanBase):
             status['movement_speed'] = self.movement_speed
 
             current_coord = self.get_current_coordinates()
+            self.logger.info(f'{current_coord=}')
             if current_coord is not None:
+                self.logger.info('Getting current_ra and current_dec')
                 status['current_ra'] = get_quantity_value(current_coord.ra, unit='degree')
                 status['current_dec'] = get_quantity_value(current_coord.dec, unit='degree')
 
             if self.has_target:
                 target_coord = self.get_target_coordinates()
+                self.logger.info(f'{target_coord=}')
                 status['mount_target_ra'] = get_quantity_value(target_coord.ra, unit='degree')
                 status['mount_target_dec'] = get_quantity_value(target_coord.dec, unit='degree')
         except Exception as e:
             self.logger.debug(f'Problem getting mount status: {e!r}')
 
+        self.logger.info('Updating status with _update_status')
         status.update(self._update_status())
         return status
 
@@ -263,8 +268,6 @@ class AbstractMount(PanBase):
         Returns:
             astropy.coordinates.SkyCoord
         """
-        # self.logger.debug('Getting current mount coordinates')
-
         mount_coords = self.query('get_coordinates')
 
         # Turn the mount coordinates into a SkyCoord

--- a/src/panoptes/pocs/mount/mount.py
+++ b/src/panoptes/pocs/mount/mount.py
@@ -116,7 +116,6 @@ class AbstractMount(PanBase):
 
     @property
     def status(self):
-        self.logger.info('Getting mount status')
         status = {}
         try:
             status['tracking_rate'] = self.tracking_rate
@@ -125,21 +124,17 @@ class AbstractMount(PanBase):
             status['movement_speed'] = self.movement_speed
 
             current_coord = self.get_current_coordinates()
-            self.logger.info(f'{current_coord=}')
             if current_coord is not None:
-                self.logger.info('Getting current_ra and current_dec')
                 status['current_ra'] = get_quantity_value(current_coord.ra, unit='degree')
                 status['current_dec'] = get_quantity_value(current_coord.dec, unit='degree')
 
             if self.has_target:
                 target_coord = self.get_target_coordinates()
-                self.logger.info(f'{target_coord=}')
                 status['mount_target_ra'] = get_quantity_value(target_coord.ra, unit='degree')
                 status['mount_target_dec'] = get_quantity_value(target_coord.dec, unit='degree')
         except Exception as e:
             self.logger.debug(f'Problem getting mount status: {e!r}')
 
-        self.logger.info('Updating status with _update_status')
         status.update(self._update_status())
         return status
 
@@ -268,6 +263,8 @@ class AbstractMount(PanBase):
         Returns:
             astropy.coordinates.SkyCoord
         """
+        # self.logger.debug('Getting current mount coordinates')
+
         mount_coords = self.query('get_coordinates')
 
         # Turn the mount coordinates into a SkyCoord

--- a/src/panoptes/pocs/observatory.py
+++ b/src/panoptes/pocs/observatory.py
@@ -289,10 +289,14 @@ class Observatory(PanBase):
         try:
             if self.mount and self.mount.is_initialized:
                 status['mount'] = self.mount.status
+                self.logger.info('Getting mount current coordinates')
                 current_coords = self.mount.get_current_coordinates()
-                status['mount']['current_ha'] = get_quantity_value(
-                    self.observer.target_hour_angle(now, current_coords), unit='degree'
-                )
+                self.logger.debug(f"Current coordinates: {current_coords!r}")
+                self.logger.info('Getting mount current HA')
+                if current_coords:
+                    status['mount']['current_ha'] = get_quantity_value(
+                        self.observer.target_hour_angle(now, current_coords), unit='degree'
+                    )
                 if self.mount.has_target:
                     target_coords = self.mount.get_target_coordinates()
                     target_ha = self.observer.target_hour_angle(now, target_coords)

--- a/src/panoptes/pocs/observatory.py
+++ b/src/panoptes/pocs/observatory.py
@@ -289,14 +289,10 @@ class Observatory(PanBase):
         try:
             if self.mount and self.mount.is_initialized:
                 status['mount'] = self.mount.status
-                self.logger.info('Getting mount current coordinates')
                 current_coords = self.mount.get_current_coordinates()
-                self.logger.debug(f"Current coordinates: {current_coords!r}")
-                self.logger.info('Getting mount current HA')
-                if current_coords:
-                    status['mount']['current_ha'] = get_quantity_value(
-                        self.observer.target_hour_angle(now, current_coords), unit='degree'
-                    )
+                status['mount']['current_ha'] = get_quantity_value(
+                    self.observer.target_hour_angle(now, current_coords), unit='degree'
+                )
                 if self.mount.has_target:
                     target_coords = self.mount.get_target_coordinates()
                     target_ha = self.observer.target_hour_angle(now, target_coords)

--- a/src/panoptes/pocs/utils/cli/run.py
+++ b/src/panoptes/pocs/utils/cli/run.py
@@ -42,9 +42,6 @@ def get_pocs(context: typer.Context):
 
     simulators = listify(simulators)
 
-    if len(simulators) > 0:
-        print(f'Running POCS with simulators: {simulators=}')
-
     print(
         '[green]Running POCS automatically![/green]\n'
         '[bold green]Press Ctrl-c to quit.[/bold green]'

--- a/tests/test_pocs.py
+++ b/tests/test_pocs.py
@@ -471,7 +471,7 @@ def test_run_power_down_interrupt(observatory,
 
     observatory.logger.info('start_pocs ENTER')
     # Remove weather simulator, else it would always be safe.
-    simulators = hardware.get_all_names()
+    simulators = hardware.get_simulator_names('all')
     observatory.logger.warning(f'Using simulators: {simulators}')
     pocs = POCS(observatory, simulators=simulators)
     pocs.set_config('wait_delay', 5)  # Check safety every 5 seconds.

--- a/tests/test_pocs.py
+++ b/tests/test_pocs.py
@@ -471,7 +471,7 @@ def test_run_power_down_interrupt(observatory,
 
     observatory.logger.info('start_pocs ENTER')
     # Remove weather simulator, else it would always be safe.
-    simulators = hardware.get_all_names(without=['night', 'weather'])
+    simulators = hardware.get_all_names()
     observatory.logger.warning(f'Using simulators: {simulators}')
     pocs = POCS(observatory, simulators=simulators)
     pocs.set_config('wait_delay', 5)  # Check safety every 5 seconds.

--- a/tests/test_pocs.py
+++ b/tests/test_pocs.py
@@ -83,7 +83,7 @@ def dome():
 def pocs(observatory, config_host, config_port):
     os.environ['POCSTIME'] = '2020-01-01 08:00:00'
 
-    pocs = POCS(observatory, run_once=True, simulators=['power', 'weather'])
+    pocs = POCS(observatory, run_once=True, simulators=['power'])
     yield pocs
     pocs.power_down()
     reset_conf(config_host, config_port)
@@ -349,7 +349,7 @@ def test_run_wait_until_safe(observatory, valid_observation_day, pocstime_day, p
     pocs.initialize()
     pocs.logger.info('Starting observatory run')
 
-    # Not dark and unit is is connected but not set.
+    # Not dark and unit is connected but not set.
     assert not pocs.is_dark()
     assert pocs.is_initialized
     assert pocs.connected

--- a/tests/test_pocs.py
+++ b/tests/test_pocs.py
@@ -83,7 +83,7 @@ def dome():
 def pocs(observatory, config_host, config_port):
     os.environ['POCSTIME'] = '2020-01-01 08:00:00'
 
-    pocs = POCS(observatory, run_once=True, simulators=['power'])
+    pocs = POCS(observatory, run_once=True, simulators=['power', 'weather'])
     yield pocs
     pocs.power_down()
     reset_conf(config_host, config_port)

--- a/tests/test_pocs.py
+++ b/tests/test_pocs.py
@@ -336,9 +336,7 @@ def test_run_wait_until_safe(observatory, valid_observation_day, pocstime_day, p
     os.environ['POCSTIME'] = pocstime_day
 
     # Remove weather simulator, else it would always be safe.
-    observatory.set_config('simulator', hardware.get_all_names(without=['night']))
-
-    pocs = POCS(observatory)
+    pocs = POCS(observatory, run_once=True, simulators=hardware.get_all_names(without=['night']))
     pocs.set_config('wait_delay', 5)  # Check safety every 5 seconds.
 
     pocs.observatory.scheduler.clear_available_observations()
@@ -378,8 +376,8 @@ def test_run_wait_until_safe(observatory, valid_observation_day, pocstime_day, p
     os.environ['POCSTIME'] = pocstime_night
     assert pocs.is_dark()
 
-    pocs.logger.warning('Waiting to get to slewing state...')
     while pocs.next_state != 'slewing':
+        pocs.logger.warning('Waiting to get to slewing state...')
         time.sleep(1)
 
     pocs.logger.warning('Stopping states via pocs.DO_STATES')

--- a/tests/test_pocs.py
+++ b/tests/test_pocs.py
@@ -401,7 +401,9 @@ def test_unsafe_park(observatory, valid_observation, pocstime_night):
     os.environ['POCSTIME'] = pocstime_night
 
     # Remove weather simulator, else it would always be safe.
-    pocs = POCS(observatory, run_once=True, simulators=hardware.get_all_names(without=['night', 'weather']))
+    simulators = hardware.get_all_names(without=['night', 'weather'])
+    observatory.logger.warning(f'Using simulators: {simulators}')
+    pocs = POCS(observatory, run_once=True, simulators=simulators)
     pocs.set_config('wait_delay', 5)  # Check safety every 5 seconds.
 
     pocs.observatory.scheduler.clear_available_observations()

--- a/tests/test_pocs.py
+++ b/tests/test_pocs.py
@@ -469,9 +469,7 @@ def test_run_power_down_interrupt(observatory,
 
     observatory.logger.info('start_pocs ENTER')
     # Remove weather simulator, else it would always be safe.
-    observatory.set_config('simulator', 'all')
-
-    pocs = POCS(observatory)
+    pocs = POCS(observatory, simulators=hardware.get_all_names())
     pocs.set_config('wait_delay', 5)  # Check safety every 5 seconds.
 
     pocs.observatory.scheduler.clear_available_observations()

--- a/tests/test_pocs.py
+++ b/tests/test_pocs.py
@@ -494,8 +494,7 @@ def test_run_power_down_interrupt(observatory,
     pocs_thread.start()
 
     while pocs.next_state != 'slewing':
-        pocs.logger.debug(
-            f'Waiting to get to slewing state. Currently next_state={pocs.next_state}')
+        pocs.logger.debug(f'Waiting to get to slewing state. Currently next_state={pocs.next_state}')
         time.sleep(1)
 
     pocs.logger.warning('Stopping states via pocs.DO_STATES')

--- a/tests/test_pocs.py
+++ b/tests/test_pocs.py
@@ -401,9 +401,7 @@ def test_unsafe_park(observatory, valid_observation, pocstime_night):
     os.environ['POCSTIME'] = pocstime_night
 
     # Remove weather simulator, else it would always be safe.
-    observatory.set_config('simulator', hardware.get_all_names(without=['night', 'weather']))
-
-    pocs = POCS(observatory)
+    pocs = POCS(observatory, run_once=True, simulators=hardware.get_all_names(without=['night', 'weather']))
     pocs.set_config('wait_delay', 5)  # Check safety every 5 seconds.
 
     pocs.observatory.scheduler.clear_available_observations()
@@ -416,7 +414,7 @@ def test_unsafe_park(observatory, valid_observation, pocstime_night):
     pocs.initialize()
     pocs.logger.info('Starting observatory run')
 
-    # Weather is bad and unit is is connected but not set.
+    # Weather is bad and unit is connected but not set.
     assert pocs.is_safe()
     assert pocs.is_initialized
     assert pocs.connected

--- a/tests/test_pocs.py
+++ b/tests/test_pocs.py
@@ -471,7 +471,9 @@ def test_run_power_down_interrupt(observatory,
 
     observatory.logger.info('start_pocs ENTER')
     # Remove weather simulator, else it would always be safe.
-    pocs = POCS(observatory, simulators=hardware.get_all_names())
+    simulators = hardware.get_all_names(without=['night', 'weather'])
+    observatory.logger.warning(f'Using simulators: {simulators}')
+    pocs = POCS(observatory, simulators=simulators)
     pocs.set_config('wait_delay', 5)  # Check safety every 5 seconds.
 
     pocs.observatory.scheduler.clear_available_observations()


### PR DESCRIPTION
The `simulator` config item should be set even when it is empty, which will clear any previous runs. Also be more explicit in the logging and printing.

Fixes #1285 
