### PR TITLE
Fix wait test

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ package_dir =
 install_requires =
     importlib-metadata; python_version<"3.8"
     astroplan
-    astropy
+    astropy>=7.0
     astroquery
     certifi>=2023.7.22
     fastapi<0.106.0

--- a/src/panoptes/pocs/observatory.py
+++ b/src/panoptes/pocs/observatory.py
@@ -8,10 +8,9 @@ import numpy as np
 from astropy import units as u
 from astropy.coordinates import get_body
 from astropy.io.fits import setval
-from panoptes.utils import error
-from panoptes.utils import images as img_utils
+from panoptes.utils import error, images as img_utils
 from panoptes.utils.images import fits as fits_utils
-from panoptes.utils.time import current_time, CountdownTimer, flatten_time
+from panoptes.utils.time import CountdownTimer, current_time, flatten_time
 from panoptes.utils.utils import get_quantity_value
 
 import panoptes.pocs.camera.fli
@@ -290,9 +289,10 @@ class Observatory(PanBase):
             if self.mount and self.mount.is_initialized:
                 status['mount'] = self.mount.status
                 current_coords = self.mount.get_current_coordinates()
-                status['mount']['current_ha'] = get_quantity_value(
-                    self.observer.target_hour_angle(now, current_coords), unit='degree'
-                )
+                if current_coords:
+                    status['mount']['current_ha'] = get_quantity_value(
+                        self.observer.target_hour_angle(now, current_coords), unit='degree'
+                    )
                 if self.mount.has_target:
                     target_coords = self.mount.get_target_coordinates()
                     target_ha = self.observer.target_hour_angle(now, target_coords)

--- a/tests/test_pocs.py
+++ b/tests/test_pocs.py
@@ -98,7 +98,7 @@ def pocs_with_dome(pocs, dome):
     pocs.power_down()
 
 
-# An observation that is valid during the day
+# An observation that is valid at night
 @pytest.fixture(scope='module')
 def valid_observation():
     return {"field": {'name': 'TEST TARGET',
@@ -109,7 +109,7 @@ def valid_observation():
                             'exp_set_size': 2}}
 
 
-# An observation that is valid at night
+# An observation that is valid during the day
 @pytest.fixture(scope='module')
 def valid_observation_day():
     return {"field": {'name': 'TEST TARGET',
@@ -332,7 +332,7 @@ def test_pocs_park_to_ready_without_observations(pocs):
     assert pocs.is_safe() is False
 
 
-def test_run_wait_until_safe(observatory, valid_observation_day, pocstime_day, pocstime_night):
+def test_run_wait_until_safe(observatory, valid_observation, pocstime_day, pocstime_night):
     os.environ['POCSTIME'] = pocstime_day
 
     # Remove weather simulator, else it would always be safe.
@@ -340,7 +340,7 @@ def test_run_wait_until_safe(observatory, valid_observation_day, pocstime_day, p
     pocs.set_config('wait_delay', 5)  # Check safety every 5 seconds.
 
     pocs.observatory.scheduler.clear_available_observations()
-    pocs.observatory.scheduler.add_observation(valid_observation_day)
+    pocs.observatory.scheduler.add_observation(valid_observation)
 
     assert pocs.connected is True
     assert pocs.is_initialized is False
@@ -375,13 +375,17 @@ def test_run_wait_until_safe(observatory, valid_observation_day, pocstime_day, p
     # Wait to pretend we're waiting for horizon
     pocs.logger.info('Waiting for dark for 5 seconds')
     time.sleep(5)
+    pocs.logger.info(f'Setting time to {pocstime_night}')
     os.environ['POCSTIME'] = pocstime_night
     pocs.logger.info('Check if dark, should be True')
     assert pocs.is_dark()
 
+    # Interrupt the daytime wait timer.
+    pocs.interrupted = True
+
     pocs.logger.info('Checking if POCS has started slewing')
     while pocs.next_state != 'slewing':
-        pocs.logger.warning('Waiting to get to slewing state...')
+        pocs.logger.warning(f'Waiting to get to slewing state... {pocs.state=} {pocs.next_state=}')
         time.sleep(1)
 
     pocs.logger.warning('Stopping states via pocs.DO_STATES')


### PR DESCRIPTION
The tests last report

```
tests/test_pocs.py::test_pocs_park_to_ready_without_observations PASSED  [ 96%]
```

but have been hanging on `test_run_wait_until_safe`.

This PR changes a few things:

* Fixing the wait test by properly interrupting the daytime sleeper and giving a valid nighttime target.
* Only report mount HA status if we have current coords. 
* Require astropy>7