### PR TITLE
Make iOptron mounts use horizon information from the config

### DIFF
--- a/src/panoptes/pocs/mount/ioptron/base.py
+++ b/src/panoptes/pocs/mount/ioptron/base.py
@@ -223,8 +223,9 @@ class Mount(AbstractSerialMount):
         if isinstance(alt_limit, u.Quantity):
             alt_limit = alt_limit.to(u.deg).value
 
-        # Convert limit to a string with sign.
-        alt_limit = f'{alt_limit:+d}'
+        # Convert limit to a string with sign if a number.
+        if isinstance(alt_limit, (int, float)):
+            alt_limit = f'{alt_limit:+d}'
 
         self.logger.debug(f'Setting altitude limit to {alt_limit}')
         self.query('set_altitude_limit', alt_limit)

--- a/src/panoptes/pocs/mount/ioptron/base.py
+++ b/src/panoptes/pocs/mount/ioptron/base.py
@@ -178,7 +178,10 @@ class Mount(AbstractSerialMount):
             alt_limit = alt_limit.to(u.deg).value
 
         # Convert limit to a string with sign if a number.
-        if isinstance(alt_limit, (int, float)):
+        if isinstance(alt_limit, float):
+            alt_limit = int(alt_limit)
+        
+        if isinstance(alt_limit, int):
             alt_limit = f'{alt_limit:+d}'
 
         self.logger.debug(f'Setting altitude limit to {alt_limit}')

--- a/src/panoptes/pocs/mount/ioptron/base.py
+++ b/src/panoptes/pocs/mount/ioptron/base.py
@@ -213,9 +213,18 @@ class Mount(AbstractSerialMount):
             self.query('set_local_time', now.datetime.strftime("%H%M%S"))
             self.query('set_local_date', now.datetime.strftime("%y%m%d"))
 
-    def _set_initial_rates(self, alt_limit='+30', meridian_treatment='015'):
+    def _set_initial_rates(self, alt_limit: float | str | None = None, meridian_treatment='015'):
         # Make sure we start at sidereal.
         self.query('set_sidereal_tracking')
+
+        if alt_limit is None:
+            alt_limit = self.get_config('location.horizon', default=30 * u.degree)
+
+        if isinstance(alt_limit, u.Quantity):
+            alt_limit = alt_limit.to(u.deg).value
+
+        # Convert limit to a string with sign.
+        alt_limit = f'{alt_limit:+d}'
 
         self.logger.debug(f'Setting altitude limit to {alt_limit}')
         self.query('set_altitude_limit', alt_limit)


### PR DESCRIPTION
The iOptron mounts had a hard-coded value of `+30` for the horizion limit, which could be in conflict with the scheduler, which properly uses the horzion limit from the config.

This PR changes the iOptron mounts to use the config.

Closes #1302