### PR TITLE
Better iOptron mount init

### DIFF
--- a/src/panoptes/pocs/mount/ioptron/base.py
+++ b/src/panoptes/pocs/mount/ioptron/base.py
@@ -79,7 +79,9 @@ class Mount(AbstractSerialMount):
                     raise error.MountNotFound('Problem initializing mount - version numbers do not match')
 
             actual_mount_info = self.query('mount_info')
-            expected_mount_info = self.commands.get('mount_info').get('response')
+
+            # Use the expected mount info if provided otherwise the command set default.
+            expected_mount_info = self.mount_version or self.commands.get('mount_info').get('response')
 
             self._is_initialized = False
 
@@ -180,7 +182,7 @@ class Mount(AbstractSerialMount):
         # Convert limit to a string with sign if a number.
         if isinstance(alt_limit, float):
             alt_limit = int(alt_limit)
-        
+
         if isinstance(alt_limit, int):
             alt_limit = f'{alt_limit:+d}'
 

--- a/src/panoptes/pocs/mount/ioptron/cem40.py
+++ b/src/panoptes/pocs/mount/ioptron/cem40.py
@@ -8,7 +8,7 @@ class Mount(BaseMount):
     def __init__(self, location, mount_version='0040', *args, **kwargs):
         self._mount_version = mount_version
         super(Mount, self).__init__(location, *args, **kwargs)
-        self.logger.success('iOptron CEM40 mount created')
+        self.logger.success('iOptron mount created')
 
     def search_for_home(self):
         """Search for the home position.

--- a/src/panoptes/pocs/mount/ioptron/hae16.py
+++ b/src/panoptes/pocs/mount/ioptron/hae16.py
@@ -5,4 +5,3 @@ class Mount(BaseMount):
 
     def __init__(self, location, mount_version='0012', *args, **kwargs):
         super(Mount, self).__init__(location, mount_version=mount_version, *args, **kwargs)
-        self.logger.success('iOptron HAE16 mount created')

--- a/src/panoptes/pocs/mount/ioptron/hae16.py
+++ b/src/panoptes/pocs/mount/ioptron/hae16.py
@@ -4,6 +4,5 @@ from panoptes.pocs.mount.ioptron.cem40 import Mount as BaseMount
 class Mount(BaseMount):
 
     def __init__(self, location, mount_version='0012', *args, **kwargs):
-        self._mount_version = mount_version
-        super(Mount, self).__init__(location, *args, **kwargs)
+        super(Mount, self).__init__(location, mount_version=mount_version, *args, **kwargs)
         self.logger.success('iOptron HAE16 mount created')

--- a/src/panoptes/pocs/mount/mount.py
+++ b/src/panoptes/pocs/mount/mount.py
@@ -51,6 +51,8 @@ class AbstractMount(PanBase):
         self._setup_commands(commands)
         self.logger.debug("Mount commands set up")
 
+        self._mount_version = None
+
         # Set the initial location
         self._location = location
 
@@ -219,6 +221,11 @@ class AbstractMount(PanBase):
     def tracking_rate(self, value):
         """ Set the tracking rate """
         self._tracking_rate = value
+
+    @property
+    def mount_version(self):
+        """ str: Mount version """
+        return self._mount_version
 
     def get_target_coordinates(self):
         """ Gets the RA and Dec for the mount's current target. This does NOT necessarily


### PR DESCRIPTION
* Use the value from the `mount_version` rather than the serial commands file, which can be used for multiple versions.

