### PR TITLE
Long and short camera setup

### DIFF
--- a/src/panoptes/pocs/camera/__init__.py
+++ b/src/panoptes/pocs/camera/__init__.py
@@ -62,6 +62,7 @@ def create_cameras_from_config(config=None,
                                cameras=None,
                                auto_primary=True,
                                recreate_existing=False,
+                               setup_cameras=False,
                                *args, **kwargs
                                ):
     """Create camera object(s) based on the config.
@@ -80,6 +81,8 @@ def create_cameras_from_config(config=None,
             existing camera with the same `uid` is already assigned. Should currently
             only affect cameras that use the `sdk` (i.g. not DSLRs). Default False
             raises an exception if camera is already assigned.
+        setup_cameras (bool): If True, will call the `setup_camera` method on
+            each camera object after creation. Default False.
         *args (list): Passed to `get_config`.
         **kwargs (dict): Can pass a `cameras` object that overrides the info in
             the configuration file. Can also pass `auto_detect`(bool) to try and
@@ -160,6 +163,9 @@ def create_cameras_from_config(config=None,
             # We either got a class or a module.
             if callable(module):
                 camera_obj = module(**device_config)
+                if setup_cameras and hasattr(camera_obj, 'setup_camera'):
+                    logger.info(f'Setting up camera: {camera_obj}')
+                    camera_obj.setup_camera()
             else:
                 if hasattr(module, 'Camera'):
                     camera_obj = module.Camera(**device_config)

--- a/src/panoptes/pocs/camera/__init__.py
+++ b/src/panoptes/pocs/camera/__init__.py
@@ -62,7 +62,6 @@ def create_cameras_from_config(config=None,
                                cameras=None,
                                auto_primary=True,
                                recreate_existing=False,
-                               setup_cameras=False,
                                *args, **kwargs
                                ):
     """Create camera object(s) based on the config.
@@ -81,8 +80,6 @@ def create_cameras_from_config(config=None,
             existing camera with the same `uid` is already assigned. Should currently
             only affect cameras that use the `sdk` (i.g. not DSLRs). Default False
             raises an exception if camera is already assigned.
-        setup_cameras (bool): If True, will call the `setup_camera` method on
-            each camera object after creation. Default False.
         *args (list): Passed to `get_config`.
         **kwargs (dict): Can pass a `cameras` object that overrides the info in
             the configuration file. Can also pass `auto_detect`(bool) to try and
@@ -163,9 +160,6 @@ def create_cameras_from_config(config=None,
             # We either got a class or a module.
             if callable(module):
                 camera_obj = module(**device_config)
-                if setup_cameras and hasattr(camera_obj, 'setup_camera'):
-                    logger.info(f'Setting up camera: {camera_obj}')
-                    camera_obj.setup_camera()
             else:
                 if hasattr(module, 'Camera'):
                     camera_obj = module.Camera(**device_config)

--- a/src/panoptes/pocs/camera/gphoto/canon.py
+++ b/src/panoptes/pocs/camera/gphoto/canon.py
@@ -26,13 +26,7 @@ class Camera(AbstractGPhotoCamera):
         super().__init__(*args, **kwargs)
         self.logger.debug("Creating Canon DSLR GPhoto2 camera")
 
-        # Get serial number
-        _serial_number = self.get_property('serialnumber')
-        if not _serial_number:
-            raise error.CameraNotFound(f"Camera not responding: {self}")
-
-        self._serial_number = _serial_number
-        self._connected = True
+        self.connect()
 
         if setup_properties:
             self.setup_camera()
@@ -44,6 +38,19 @@ class Camera(AbstractGPhotoCamera):
     @property
     def egain(self):
         return 1.5 * (u.electron / u.adu)
+
+    def connect(self):
+        """Connect to the camera.
+
+        This will attempt to connect to the camera using gphoto2.
+        """
+        # Get serial number
+        _serial_number = self.get_property('serialnumber')
+        if not _serial_number:
+            raise error.CameraNotFound(f"Camera not responding: {self}")
+
+        self._serial_number = _serial_number
+        self._connected = True
 
     def setup_camera(self):
         """Set up the camera.

--- a/src/panoptes/pocs/camera/gphoto/canon.py
+++ b/src/panoptes/pocs/camera/gphoto/canon.py
@@ -9,7 +9,7 @@ from panoptes.pocs.camera.gphoto.base import AbstractGPhotoCamera
 class Camera(AbstractGPhotoCamera):
 
     def __init__(
-        self, readout_time: float = 1.0, file_extension: str = 'cr2', connect: bool = True,
+        self, readout_time: float = 1.0, file_extension: str = 'cr2', setup_properties: bool = False,
         *args, **kwargs
     ):
         """Create a camera object for a Canon EOS DSLR.
@@ -18,30 +18,13 @@ class Camera(AbstractGPhotoCamera):
             readout (float): The time it takes to read out the file from the
                 camera, default 1.0 second.
             file_extension (str): The file extension to use, default `cr2`.
-            connect (bool): Connect to camera on startup, default True.
+            setup_properties (bool): If True, will call `setup_camera()` to set
+                properties on the camera.
         """
         kwargs['readout_time'] = readout_time
         kwargs['file_extension'] = file_extension
         super().__init__(*args, **kwargs)
         self.logger.debug("Creating Canon DSLR GPhoto2 camera")
-
-        if connect:
-            self.connect()
-
-    @property
-    def bit_depth(self):
-        return 12 * u.bit
-
-    @property
-    def egain(self):
-        return 1.5 * (u.electron / u.adu)
-
-    def connect(self):
-        """Connect to Canon DSLR.
-
-        Gets the serial number from the camera and sets various settings.
-        """
-        self.logger.debug('Connecting to Canon gphoto2 camera')
 
         # Get serial number
         _serial_number = self.get_property('serialnumber')
@@ -50,6 +33,17 @@ class Camera(AbstractGPhotoCamera):
 
         self._serial_number = _serial_number
         self._connected = True
+
+        if setup_properties:
+            self.setup_camera()
+
+    @property
+    def bit_depth(self):
+        return 12 * u.bit
+
+    @property
+    def egain(self):
+        return 1.5 * (u.electron / u.adu)
 
     def setup_camera(self):
         """Set up the camera.

--- a/src/panoptes/pocs/camera/gphoto/canon.py
+++ b/src/panoptes/pocs/camera/gphoto/canon.py
@@ -9,8 +9,8 @@ from panoptes.pocs.camera.gphoto.base import AbstractGPhotoCamera
 class Camera(AbstractGPhotoCamera):
 
     def __init__(
-            self, readout_time: float = 1.0, file_extension: str = 'cr2', connect: bool = True,
-            *args, **kwargs
+        self, readout_time: float = 1.0, file_extension: str = 'cr2', connect: bool = True,
+        *args, **kwargs
     ):
         """Create a camera object for a Canon EOS DSLR.
 
@@ -49,7 +49,14 @@ class Camera(AbstractGPhotoCamera):
             raise error.CameraNotFound(f"Camera not responding: {self}")
 
         self._serial_number = _serial_number
+        self._connected = True
 
+    def setup_camera(self):
+        """Set up the camera.
+
+        Usually called as part of an initial setup, this will set properties
+        on the canon cameras that should persist across power cycles.
+        """
         # Properties to be set upon init.
         owner_name = 'PANOPTES'
         artist_name = self.get_config('pan_id', default=owner_name)
@@ -74,16 +81,14 @@ class Camera(AbstractGPhotoCamera):
 
         self.model = self.get_property('model')
 
-        self._connected = True
-
     def _start_exposure(
-            self,
-            seconds=None,
-            filename=None,
-            dark=False,
-            header=None,
-            iso=100,
-            *args, **kwargs
+        self,
+        seconds=None,
+        filename=None,
+        dark=False,
+        header=None,
+        iso=100,
+        *args, **kwargs
     ):
         """Start the exposure.
 

--- a/src/panoptes/pocs/camera/simulator/dslr.py
+++ b/src/panoptes/pocs/camera/simulator/dslr.py
@@ -5,10 +5,11 @@ from threading import Timer
 import numpy as np
 from astropy import units as u
 from astropy.io import fits
-from panoptes.pocs.camera import AbstractCamera
 from panoptes.utils.images import fits as fits_utils
 from panoptes.utils.time import CountdownTimer
 from panoptes.utils.utils import get_quantity_value
+
+from panoptes.pocs.camera import AbstractCamera
 
 
 class Camera(AbstractCamera):
@@ -40,6 +41,14 @@ class Camera(AbstractCamera):
         self._connected = True
         self.logger.debug(f'{self.name} connected')
 
+    def setup_camera(self):
+        """Set up the camera simulator.
+
+        This is a no-op for the simulator.
+        """
+        self.logger.debug(f'Setting up camera simulator {self.name}')
+        pass
+
     def take_observation(self, observation, headers=None, filename=None, *args, **kwargs):
 
         exptime = kwargs.get('exptime', observation.exptime.value)
@@ -47,20 +56,25 @@ class Camera(AbstractCamera):
             kwargs['exptime'] = 1
             self.logger.debug("Trimming camera simulator exposure to 1 s")
 
-        return super().take_observation(observation,
-                                        headers,
-                                        filename,
-                                        **kwargs)
+        return super().take_observation(
+            observation,
+            headers,
+            filename,
+            **kwargs
+            )
 
     def _end_exposure(self):
         self._is_exposing_event.clear()
 
     def _start_exposure(self, seconds=None, filename=None, dark=False, header=None, *args,
-                        **kwargs):
+                        **kwargs
+                        ):
         self._is_exposing_event.set()
         seconds = kwargs.get('simulator_exptime', seconds)
-        exposure_thread = Timer(interval=get_quantity_value(seconds, unit=u.second),
-                                function=self._end_exposure)
+        exposure_thread = Timer(
+            interval=get_quantity_value(seconds, unit=u.second),
+            function=self._end_exposure
+            )
         exposure_thread.start()
         readout_args = (filename, header)
         return readout_args
@@ -74,9 +88,11 @@ class Camera(AbstractCamera):
 
         if header.get('IMAGETYP') == 'Dark Frame':
             # Replace example data with a bunch of random numbers
-            fake_data = np.random.randint(low=975, high=1026,
-                                          size=fake_data.shape,
-                                          dtype=fake_data.dtype)
+            fake_data = np.random.randint(
+                low=975, high=1026,
+                size=fake_data.shape,
+                dtype=fake_data.dtype
+                )
         self.logger.debug(f'Writing filename={filename!r} for {self}')
         self.write_fits(fake_data, header, filename)
         self.logger.debug(f'Finished writing {filename=}')

--- a/src/panoptes/pocs/camera/simulator/dslr.py
+++ b/src/panoptes/pocs/camera/simulator/dslr.py
@@ -26,20 +26,14 @@ class Camera(AbstractCamera):
         kwargs['timeout'] = kwargs.get('timeout', 1.5 * u.second)
         kwargs['readout_time'] = kwargs.get('readout_time', 1.0 * u.second)
         super().__init__(name=name, *args, **kwargs)
-        self.connect()
-        self.logger.info(f"{self} initialised")
-
-    def connect(self):
-        """ Connect to camera simulator
-
-        The simulator merely marks the `connected` property.
-        """
         # Create a random serial number if one hasn't been specified
         if self._serial_number == 'XXXXXX':
             self._serial_number = 'SC{:04d}'.format(random.randint(0, 9999))
 
         self._connected = True
         self.logger.debug(f'{self.name} connected')
+        self.setup_camera()
+        self.logger.info(f"{self} initialised")
 
     def setup_camera(self):
         """Set up the camera simulator.
@@ -61,7 +55,7 @@ class Camera(AbstractCamera):
             headers,
             filename,
             **kwargs
-            )
+        )
 
     def _end_exposure(self):
         self._is_exposing_event.clear()
@@ -74,7 +68,7 @@ class Camera(AbstractCamera):
         exposure_thread = Timer(
             interval=get_quantity_value(seconds, unit=u.second),
             function=self._end_exposure
-            )
+        )
         exposure_thread.start()
         readout_args = (filename, header)
         return readout_args
@@ -92,7 +86,7 @@ class Camera(AbstractCamera):
                 low=975, high=1026,
                 size=fake_data.shape,
                 dtype=fake_data.dtype
-                )
+            )
         self.logger.debug(f'Writing filename={filename!r} for {self}')
         self.write_fits(fake_data, header, filename)
         self.logger.debug(f'Finished writing {filename=}')

--- a/src/panoptes/pocs/camera/simulator/dslr.py
+++ b/src/panoptes/pocs/camera/simulator/dslr.py
@@ -30,10 +30,18 @@ class Camera(AbstractCamera):
         if self._serial_number == 'XXXXXX':
             self._serial_number = 'SC{:04d}'.format(random.randint(0, 9999))
 
-        self._connected = True
+        self.connect()
         self.logger.debug(f'{self.name} connected')
         self.setup_camera()
         self.logger.info(f"{self} initialised")
+
+    def connect(self):
+        """Connect to the camera simulator.
+
+        This is a no-op for the simulator.
+        """
+        self.logger.debug(f'Connecting to camera simulator {self.name}')
+        self._connected = True
 
     def setup_camera(self):
         """Set up the camera simulator.

--- a/src/panoptes/pocs/utils/cli/camera.py
+++ b/src/panoptes/pocs/utils/cli/camera.py
@@ -91,10 +91,18 @@ def setup_cameras(
 
     # Now create the cameras from the config, calling the `setup_camera` method if available.
     print('Now creating the cameras from the config and setting them up.')
-    cameras = create_cameras_from_config(setup_cameras=True)
+    cameras = create_cameras_from_config()
     if len(cameras) == 0:
         print('No cameras found after setup, exiting.')
         return
+    else:
+        # Call setup_properties on each of the cameras
+        for cam_name, cam in cameras.items():
+            try:
+                print(f'Setting up camera: {cam_name}')
+                cam.setup_camera()
+            except AttributeError:
+                print(f'Camera {cam_name} does not have a setup_camera method, skipping.')
 
     print('Now creating the cameras from the config and taking a test picture with each.')
     images = take_pictures(num_images=1, exptime=1.0, output_dir='/home/panoptes/images/test')

--- a/src/panoptes/pocs/utils/cli/camera.py
+++ b/src/panoptes/pocs/utils/cli/camera.py
@@ -89,6 +89,13 @@ def setup_cameras(
     # Turn off the autodetect
     set_config('cameras.defaults.auto_detect', False)
 
+    # Now create the cameras from the config, calling the `setup_camera` method if available.
+    print('Now creating the cameras from the config and setting them up.')
+    cameras = create_cameras_from_config(setup_cameras=True)
+    if len(cameras) == 0:
+        print('No cameras found after setup, exiting.')
+        return
+
     print('Now creating the cameras from the config and taking a test picture with each.')
     images = take_pictures(num_images=1, exptime=1.0, output_dir='/home/panoptes/images/test')
 

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -248,9 +248,6 @@ def test_init(camera):
         # Successfully initialised SBIG cameras should also have a valid 'handle'
         assert camera._handle != INVALID_HANDLE_VALUE
 
-    if hasattr(camera, 'setup_camera'):
-        camera.setup_camera()
-
 
 def test_uid(camera):
     # Camera uid should be a string (or maybe an int?) of non-zero length. Assert True

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -1,58 +1,55 @@
+import glob
 import os
 import time
-import glob
-from ctypes.util import find_library
 from contextlib import suppress
+from ctypes.util import find_library
 
-import pytest
 import astropy.units as u
-from astropy.io import fits
+import pytest
 import requests
+from astropy.io import fits
+from panoptes.utils import error
+from panoptes.utils.config.client import get_config, set_config
+from panoptes.utils.error import NotFound
+from panoptes.utils.images import fits as fits_utils
+from panoptes.utils.serializers import to_json
+from panoptes.utils.time import CountdownTimer
 
-from panoptes.pocs.camera.simulator.dslr import Camera as SimCamera
-from panoptes.pocs.camera.simulator.ccd import Camera as SimSDKCamera
+from panoptes.pocs.camera import AbstractCamera, create_cameras_from_config
+from panoptes.pocs.camera.fli import Camera as FLICamera
 from panoptes.pocs.camera.sbig import Camera as SBIGCamera
 from panoptes.pocs.camera.sbigudrv import INVALID_HANDLE_VALUE, SBIGDriver
-from panoptes.pocs.camera.fli import Camera as FLICamera
+from panoptes.pocs.camera.simulator.ccd import Camera as SimSDKCamera
+from panoptes.pocs.camera.simulator.dslr import Camera as SimCamera
 from panoptes.pocs.camera.zwo import Camera as ZWOCamera
-from panoptes.pocs.camera import AbstractCamera
-
 from panoptes.pocs.focuser.simulator import Focuser
 from panoptes.pocs.scheduler.field import Field
 from panoptes.pocs.scheduler.observation.base import Observation
 from panoptes.pocs.scheduler.observation.bias import BiasObservation
 from panoptes.pocs.scheduler.observation.dark import DarkObservation
 
-from panoptes.utils.error import NotFound
-from panoptes.utils.images import fits as fits_utils
-from panoptes.utils import error
-from panoptes.utils.config.client import get_config
-from panoptes.utils.config.client import set_config
 
-from panoptes.pocs.camera import create_cameras_from_config
-from panoptes.utils.serializers import to_json
-from panoptes.utils.time import CountdownTimer
-
-
-@pytest.fixture(scope='module', params=[
-    pytest.param([SimCamera, dict()]),
-    pytest.param([SimCamera, get_config('cameras.devices[0]')]),
-    pytest.param([SimCamera, get_config('cameras.devices[1]')]),
-    pytest.param([SimCamera, get_config('cameras.devices[2]')]),
-    pytest.param([SimSDKCamera, get_config('cameras.devices[3]')]),
-    pytest.param([SBIGCamera, 'sbig'], marks=[pytest.mark.with_camera]),
-    pytest.param([FLICamera, 'fli'], marks=[pytest.mark.with_camera]),
-    pytest.param([ZWOCamera, 'zwo'], marks=[pytest.mark.with_camera]),
-], ids=[
-    'dslr',
-    'dslr.00',
-    'dslr.focuser.cooling.00',
-    'dslr.filterwheel.cooling.00',
-    'ccd.filterwheel.cooling.00',
-    'sbig',
-    'fli',
-    'zwo'
-])
+@pytest.fixture(
+    scope='module', params=[
+        pytest.param([SimCamera, dict()]),
+        pytest.param([SimCamera, get_config('cameras.devices[0]')]),
+        pytest.param([SimCamera, get_config('cameras.devices[1]')]),
+        pytest.param([SimCamera, get_config('cameras.devices[2]')]),
+        pytest.param([SimSDKCamera, get_config('cameras.devices[3]')]),
+        pytest.param([SBIGCamera, 'sbig'], marks=[pytest.mark.with_camera]),
+        pytest.param([FLICamera, 'fli'], marks=[pytest.mark.with_camera]),
+        pytest.param([ZWOCamera, 'zwo'], marks=[pytest.mark.with_camera]),
+    ], ids=[
+        'dslr',
+        'dslr.00',
+        'dslr.focuser.cooling.00',
+        'dslr.filterwheel.cooling.00',
+        'ccd.filterwheel.cooling.00',
+        'sbig',
+        'fli',
+        'zwo'
+    ]
+    )
 def camera(request) -> AbstractCamera:
     CamClass = request.param[0]
     cam_params = request.param[1]
@@ -78,8 +75,10 @@ def camera(request) -> AbstractCamera:
         # Wait for cooling
         cooling_timeout = CountdownTimer(60)  # Should never have to wait this long.
         while not camera.is_temperature_stable and not cooling_timeout.expired():
-            camera.logger.log('testing',
-                              f'Still waiting for cooling: {cooling_timeout.time_left()}')
+            camera.logger.log(
+                'testing',
+                f'Still waiting for cooling: {cooling_timeout.time_left()}'
+                )
             cooling_timeout.sleep(max_sleep=2)
         assert camera.is_temperature_stable and cooling_timeout.expired() is False
 
@@ -111,19 +110,22 @@ def patterns(camera, images_dir):
 
 def reset_conf(config_host, config_port):
     url = f'http://{config_host}:{config_port}/reset-config'
-    response = requests.post(url,
-                             data=to_json({'reset': True}),
-                             headers={'Content-Type': 'application/json'}
-                             )
+    response = requests.post(
+        url,
+        data=to_json({'reset': True}),
+        headers={'Content-Type': 'application/json'}
+        )
     assert response.ok
 
 
 def test_create_cameras_from_config_no_autodetect(config_host, config_port):
     set_config('cameras.auto_detect', False)
-    set_config('cameras.devices', [
-        dict(model='canon_gphoto2', port='/dev/fake01'),
-        dict(model='canon_gphoto2', port='/dev/fake02'),
-    ])
+    set_config(
+        'cameras.devices', [
+            dict(model='canon_gphoto2', port='/dev/fake01'),
+            dict(model='canon_gphoto2', port='/dev/fake02'),
+        ]
+        )
 
     with pytest.raises(error.CameraNotFound):
         create_cameras_from_config()
@@ -141,8 +143,10 @@ def test_create_cameras_from_config_autodetect(config_host, config_port):
 # Hardware independent tests, mostly use simulator:
 
 def test_sim_create_focuser():
-    sim_camera = SimCamera(focuser={'model': 'panoptes.pocs.focuser.simulator.Focuser',
-                                    'focus_port': '/dev/ttyFAKE'})
+    sim_camera = SimCamera(
+        focuser={'model': 'panoptes.pocs.focuser.simulator.Focuser',
+                 'focus_port': '/dev/ttyFAKE'}
+        )
     assert isinstance(sim_camera.focuser, Focuser)
 
 
@@ -243,6 +247,9 @@ def test_init(camera):
     if isinstance(camera, SBIGCamera):
         # Successfully initialised SBIG cameras should also have a valid 'handle'
         assert camera._handle != INVALID_HANDLE_VALUE
+
+    if hasattr(camera, 'setup_camera'):
+        camera.setup_camera()
 
 
 def test_uid(camera):
@@ -521,8 +528,10 @@ def test_observation(camera, images_dir):
     while camera.is_observing:
         camera.logger.trace(f'Waiting for observation event from inside test.')
         time.sleep(1)
-    observation_pattern = os.path.join(images_dir, 'TestObservation',
-                                       camera.uid, observation.seq_time, '*.fits*')
+    observation_pattern = os.path.join(
+        images_dir, 'TestObservation',
+        camera.uid, observation.seq_time, '*.fits*'
+        )
     assert len(glob.glob(observation_pattern)) == 1
 
 
@@ -534,8 +543,10 @@ def test_observation_headers_and_blocking(camera, images_dir):
     observation = Observation(field, exptime=1.5 * u.second)
     observation.seq_time = '19991231T235559'
     camera.take_observation(observation, headers={'field_name': 'TESTVALUE'}, blocking=True)
-    observation_pattern = os.path.join(images_dir, 'TestObservation',
-                                       camera.uid, observation.seq_time, '*.fits*')
+    observation_pattern = os.path.join(
+        images_dir, 'TestObservation',
+        camera.uid, observation.seq_time, '*.fits*'
+        )
     image_files = glob.glob(observation_pattern)
     assert len(image_files) == 1
     camera.logger.debug(f'{image_files=}')
@@ -552,8 +563,10 @@ def test_observation_nofilter(camera, images_dir):
     observation = Observation(field, exptime=1.5 * u.second, filter_name=None)
     observation.seq_time = '19991231T235159'
     camera.take_observation(observation, blocking=True)
-    observation_pattern = os.path.join(images_dir, 'TestObservation',
-                                       camera.uid, observation.seq_time, '*.fits*')
+    observation_pattern = os.path.join(
+        images_dir, 'TestObservation',
+        camera.uid, observation.seq_time, '*.fits*'
+        )
     assert len(glob.glob(observation_pattern)) == 1
 
 
@@ -570,8 +583,10 @@ def test_observation_dark(camera, images_dir):
     while camera.is_observing:
         camera.logger.trace(f'Waiting for observation event from inside test. {camera.is_observing}')
         time.sleep(1)
-    observation_pattern = os.path.join(images_dir, 'dark',
-                                       camera.uid, observation.seq_time, '*.fits*')
+    observation_pattern = os.path.join(
+        images_dir, 'dark',
+        camera.uid, observation.seq_time, '*.fits*'
+        )
     assert len(glob.glob(observation_pattern)) == 1
 
 
@@ -588,8 +603,10 @@ def test_observation_bias(camera, images_dir):
     while camera.is_observing:
         camera.logger.trace(f'Waiting for observation event from inside test.')
         time.sleep(1)
-    observation_pattern = os.path.join(images_dir, 'bias',
-                                       camera.uid, observation.seq_time, '*.fits*')
+    observation_pattern = os.path.join(
+        images_dir, 'bias',
+        camera.uid, observation.seq_time, '*.fits*'
+        )
     assert len(glob.glob(observation_pattern)) == 1
 
 


### PR DESCRIPTION
* Add a `setup_camera` option to the canon gphoto2 cameras that will set up all the properties. Those properties should persist across a power-cycle so don't need to be called every time.
* Add a `setup_cameras=False` param to the `create_cameras_from_config` that will call the `setup_camera` method if True and the cam has the method.
* Call with `setup_cameras=True` from the `pocs cameras setup` command.

Closes #1295 
Taken from #1314 