### PR TITLE
Easily create a full POCS simulator

### DIFF
--- a/notebooks/TestPOCS.ipynb
+++ b/notebooks/TestPOCS.ipynb
@@ -34,30 +34,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "0b8f187b-d6b4-4031-b75a-08071ec4bef7",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "from panoptes.pocs.core import POCS\n",
-    "from panoptes.pocs.observatory import Observatory\n",
-    "from panoptes.pocs.mount import create_mount_from_config\n",
-    "from panoptes.pocs.camera import create_cameras_from_config\n",
-    "from panoptes.pocs.scheduler import create_scheduler_from_config\n",
-    "from panoptes.utils.time import current_time\n",
-    "\n",
-    "\n",
-    "def create_pocs(simulators=None):\n",
-    "    scheduler = create_scheduler_from_config()\n",
-    "    mount = create_mount_from_config()\n",
-    "    cameras = create_cameras_from_config()\n",
-    "\n",
-    "    observatory = Observatory(cameras=cameras, mount=mount, scheduler=scheduler)\n",
-    "\n",
-    "    # Add simulators if necessary before running.\n",
-    "    pocs = POCS(observatory, simulators=simulators or list())\n",
-    "    return pocs\n"
-   ],
-   "outputs": []
+    "from panoptes.pocs.core import POCS"
+   ]
   },
   {
    "attachments": {},
@@ -72,13 +55,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "dab326ca-82af-499d-98de-95d745a4e9cf",
    "metadata": {},
-   "source": [
-    "pocs = create_pocs()"
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:41:37.732\u001b[0m \u001b[94m\u001b[1mscheduler_config: {'check_file': True, 'constraints': [{'name': 'panoptes.pocs.scheduler.constraint.Altitude'}, {'name': 'panoptes.pocs.scheduler.constraint.MoonAvoidance', 'options': {'separation': 15}}, {'name': 'panoptes.pocs.scheduler.constraint.Duration'}], 'fields_file': 'tess_sectors_north.yaml', 'iers_auto': True, 'iers_url': 'https://storage.googleapis.com/panoptes-assets/iers/ser7.dat', 'type': 'panoptes.pocs.scheduler.dispatch'}\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:41:37.737\u001b[0m \u001b[94m\u001b[1mGetting IERS data at iers_url='https://storage.googleapis.com/panoptes-assets/iers/ser7.dat'\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:41:37.771\u001b[0m \u001b[94m\u001b[1mSetting new observation to None\u001b[0m\n",
+      "\u001b[33m\u001b[1mW\u001b[0m \u001b[94m05-27 07:41:38.330\u001b[0m \u001b[33m\u001b[1mCurrent simulators: ['camera', 'dome', 'mount', 'night', 'power', 'sensors', 'theskyx', 'weather']\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:41:38.355\u001b[0m \u001b[94m\u001b[1mUsing simulator mount\u001b[0m\n",
+      "\u001b[36m\u001b[1mS\u001b[0m \u001b[94m05-27 07:41:38.356\u001b[0m \u001b[36m\u001b[1mPanoptes.Pocs.Mount.Simulator mount created\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:41:38.359\u001b[0m \u001b[94m\u001b[1mCam00 (SC3851) initialised\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:41:38.361\u001b[0m \u001b[94m\u001b[1mCam01 (SC9443) initialised\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:41:38.364\u001b[0m \u001b[94m\u001b[1mInitializing observatory\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:41:38.364\u001b[0m \u001b[94m\u001b[1mSetting up location\u001b[0m\n",
+      "\u001b[36m\u001b[1mS\u001b[0m \u001b[94m05-27 07:41:38.429\u001b[0m \u001b[36m\u001b[1mAdding  Mount Simulator /dev/FAKE\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:41:38.429\u001b[0m \u001b[94m\u001b[1mAdding cameras to the observatory: {'Cam00': <panoptes.pocs.camera.simulator.dslr.Camera object at 0x15a1843e0>, 'Cam01': <panoptes.pocs.camera.simulator.dslr.Camera object at 0x13faf6db0>}\u001b[0m\n",
+      "\u001b[36m\u001b[1mS\u001b[0m \u001b[94m05-27 07:41:38.429\u001b[0m \u001b[36m\u001b[1mAdding <panoptes.pocs.scheduler.dispatch.Scheduler object at 0x13b813f80>\u001b[0m\n",
+      "\u001b[36m\u001b[1mS\u001b[0m \u001b[94m05-27 07:41:38.431\u001b[0m \u001b[36m\u001b[1mObservatory initialized\u001b[0m\n",
+      "Running POCS with simulators: simulators=['camera', 'dome', 'mount', 'night', 'power', 'sensors', 'theskyx', 'weather']\n",
+      "\u001b[33m\u001b[1mW\u001b[0m \u001b[94m05-27 07:41:38.450\u001b[0m \u001b[33m\u001b[1mUsing simulators=['camera', 'dome', 'mount', 'night', 'power', 'sensors', 'theskyx', 'weather']\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:41:38.455\u001b[0m \u001b[94m\u001b[1mInitializing PANOPTES unit - Lappie PAN000 - Mauna Loa Observatory\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:41:38.456\u001b[0m \u001b[94m\u001b[1mMaking a POCS state machine from panoptes\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:41:38.456\u001b[0m \u001b[94m\u001b[1mLoading state table: panoptes\u001b[0m\n",
+      "\u001b[36m\u001b[1mS\u001b[0m \u001b[94m05-27 07:41:38.530\u001b[0m \u001b[36m\u001b[1mPAN000 says: Hi there!\u001b[0m\n"
+     ]
+    }
    ],
-   "outputs": []
+   "source": [
+    "pocs = POCS.from_config(simulators='all')"
+   ]
   },
   {
    "attachments": {},
@@ -91,13 +101,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "id": "c99bfe96-4c52-4f3b-974c-c0ef9bf85feb",
    "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:41:42.136\u001b[0m \u001b[94m\u001b[1m********************************************************************************\u001b[0m\n",
+      "\u001b[36m\u001b[1mS\u001b[0m \u001b[94m05-27 07:41:42.137\u001b[0m \u001b[36m\u001b[1mPAN000 says: Initializing the system! Woohoo!\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "pocs.initialize()"
-   ],
-   "outputs": []
+   ]
   },
   {
    "attachments": {},
@@ -118,14 +147,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "id": "d1e44dab-b621-4d5f-99b0-99d9c54572f9",
    "metadata": {},
+   "outputs": [],
    "source": [
     "# We don't want to type this out every time.\n",
     "mount = pocs.observatory.mount"
-   ],
-   "outputs": []
+   ]
   },
   {
    "attachments": {},
@@ -138,23 +167,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "id": "79488400-a48e-4798-b857-4bc461344cad",
    "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "mount.unpark()"
-   ],
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "id": "e9756656-b6ef-43c1-8d12-43aa89ea9766",
    "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[33m\u001b[1mW\u001b[0m \u001b[94m05-27 07:41:45.553\u001b[0m \u001b[33m\u001b[1mSearching for home position not supported.Please set the home position manually via the hand-controller.\u001b[0m\n"
+     ]
+    }
+   ],
    "source": [
     "mount.search_for_home()"
-   ],
-   "outputs": []
+   ]
   },
   {
    "attachments": {},
@@ -167,14 +215,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "id": "042c5df6-d656-4abf-be06-da3ddb230027",
    "metadata": {},
+   "outputs": [],
    "source": [
     "mount.move_direction(direction='east', seconds=1)\n",
     "mount.move_direction(direction='south', seconds=3)"
-   ],
-   "outputs": []
+   ]
   },
   {
    "attachments": {},
@@ -189,13 +237,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "id": "d657801c-ba74-45c6-a93b-5a7af7243841",
    "metadata": {},
+   "outputs": [],
    "source": [
     "mount.park()"
-   ],
-   "outputs": []
+   ]
   },
   {
    "attachments": {},
@@ -208,14 +256,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "id": "63168926-64c4-473f-83df-6379b8f4e7fa",
    "metadata": {},
+   "outputs": [],
    "source": [
     "mount.unpark()\n",
     "mount.slew_to_home()"
-   ],
-   "outputs": []
+   ]
   },
   {
    "attachments": {},
@@ -231,18 +279,26 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "befbac48-dd57-4003-8118-5cad4837e028",
+   "metadata": {},
+   "source": [
+    " > NOTE Camera simulators don't work here yet."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "7df0de6b-af02-4a82-b55a-ac0809e8c87c",
    "metadata": {},
+   "outputs": [],
    "source": [
     "# For a unique filename.\n",
     "now = current_time(flatten=True)\n",
     "\n",
     "for cam_name, cam in pocs.observatory.cameras.items():\n",
-    "    cam.take_exposure(seconds=2, filename=f'/home/panoptes/images/{cam_name}-test-{now}.cr2', blocking=True)"
-   ],
-   "outputs": []
+    "    # cam.take_exposure(seconds=2, filename=f'/home/panoptes/images/{cam_name}-test-{now}.cr2', blocking=True)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -256,13 +312,352 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "id": "8eacb871",
    "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.758\u001b[0m \u001b[94m\u001b[1mChecking Constraint: Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.758\u001b[0m \u001b[94m\u001b[1m\tBlaze Star\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.761\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 1.000\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.762\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.762\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC14_CAM01\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.765\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.000\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.765\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.766\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC14_CAM02\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.769\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.000\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.769\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.769\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC14_CAM03\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.773\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 1.000\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.773\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.774\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC14_CAM04\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.777\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 1.000\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.777\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.781\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC15_CAM01\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.792\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.000\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.793\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.793\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC15_CAM02\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.799\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.000\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.800\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.800\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC15_CAM03\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.804\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 1.000\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.804\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.804\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC15_CAM04\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.808\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 1.000\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.808\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.808\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC16_CAM01\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.812\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.000\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.812\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.812\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC16_CAM02\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.816\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.000\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.816\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.816\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC16_CAM03\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.819\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.000\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.820\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.820\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC16_CAM04\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.823\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.000\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.823\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.824\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC17_CAM01\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.827\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.000\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.827\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.827\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC17_CAM02\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.830\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.000\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.830\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.831\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC17_CAM03\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.834\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.000\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.834\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.834\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC17_CAM04\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.838\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.000\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.838\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.839\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC18_CAM01\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.842\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.000\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.843\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.843\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC18_CAM02\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.846\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.000\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.846\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.847\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC18_CAM03\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.850\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.000\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.850\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.850\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC18_CAM04\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.854\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.000\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.854\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.854\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC19_CAM01\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.857\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.000\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.858\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.858\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC19_CAM02\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.861\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.000\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.861\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.861\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC19_CAM03\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.865\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.000\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.865\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.865\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC19_CAM04\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.869\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.000\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.869\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.869\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC20_CAM01\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.872\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.000\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.873\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.873\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC20_CAM02\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.876\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.000\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.877\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.877\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC20_CAM03\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.881\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.000\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.881\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.881\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC20_CAM04\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.885\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.000\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.885\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.885\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC21_CAM01\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.888\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 1.000\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.888\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.889\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC21_CAM02\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.892\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 1.000\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.892\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.892\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC21_CAM03\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.896\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 1.000\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.897\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.897\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC21_CAM04\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.901\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.000\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.901\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.901\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC22_CAM01\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.904\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 1.000\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.905\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.905\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC22_CAM02\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.908\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 1.000\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.908\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.908\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC22_CAM03\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.912\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 1.000\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.912\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.912\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC22_CAM04\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.919\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.000\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.920\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.922\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC23_CAM01\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.932\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 1.000\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.933\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.933\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC23_CAM02\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.939\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 1.000\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.939\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.940\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC23_CAM03\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.943\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 1.000\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.943\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.944\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC23_CAM04\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.947\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.000\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.947\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.947\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC24_CAM01\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.950\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 1.000\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.951\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.951\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC24_CAM02\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.954\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 1.000\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.955\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.955\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC24_CAM03\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.958\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 1.000\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.958\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.959\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC24_CAM04\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.961\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.000\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.962\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.962\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC25_CAM01\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.965\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 1.000\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.966\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.966\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC25_CAM02\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.969\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 1.000\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.970\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.970\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC25_CAM03\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.973\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 1.000\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.973\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.974\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC25_CAM04\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.977\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.000\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.977\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.977\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC26_CAM01\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.980\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.000\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.981\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.981\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC26_CAM02\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.984\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.000\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.984\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.984\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC26_CAM03\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.988\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 1.000\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.988\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.988\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC26_CAM04\tCurrent score: 0.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.991\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.000\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.992\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Altitude\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.992\u001b[0m \u001b[94m\u001b[1mChecking Constraint: Moon Avoidance (15.0 deg)\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.992\u001b[0m \u001b[94m\u001b[1m\tBlaze Star\tCurrent score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.993\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.711\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.993\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.711\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.994\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC14_CAM03\tCurrent score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.995\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.457\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.995\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.457\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.996\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC14_CAM04\tCurrent score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.997\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.397\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.997\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.397\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.998\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC15_CAM03\tCurrent score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.999\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.474\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.999\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.474\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:17.999\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC15_CAM04\tCurrent score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.000\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.471\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.000\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.471\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.000\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC21_CAM01\tCurrent score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.001\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.371\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.001\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.371\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.002\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC21_CAM02\tCurrent score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.003\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.390\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.003\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.390\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.003\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC21_CAM03\tCurrent score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.004\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.427\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.004\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.427\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.005\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC22_CAM01\tCurrent score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.006\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.525\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.006\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.525\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.006\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC22_CAM02\tCurrent score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.007\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.509\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.007\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.509\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.007\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC22_CAM03\tCurrent score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.008\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.492\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.008\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.492\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.009\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC23_CAM01\tCurrent score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.009\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.671\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.010\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.671\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.010\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC23_CAM02\tCurrent score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.011\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.620\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.011\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.620\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.011\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC23_CAM03\tCurrent score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.012\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.551\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.012\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.551\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.012\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC24_CAM01\tCurrent score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.013\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.801\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.013\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.801\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.014\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC24_CAM02\tCurrent score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.014\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.705\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.015\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.705\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.015\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC24_CAM03\tCurrent score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.016\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.593\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.016\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.593\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.016\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC25_CAM01\tCurrent score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.017\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.875\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.017\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.875\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.017\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC25_CAM02\tCurrent score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.018\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.742\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.019\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.742\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.019\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC25_CAM03\tCurrent score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.020\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.609\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.020\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.609\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.020\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC26_CAM03\tCurrent score: 1.000\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.021\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.599\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.021\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.599\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.021\u001b[0m \u001b[94m\u001b[1mChecking Constraint: Duration above 30.0 deg\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.021\u001b[0m \u001b[94m\u001b[1m\tBlaze Star\tCurrent score: 1.711\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.066\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 1.000\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.066\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 2.711\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.066\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC14_CAM03\tCurrent score: 1.457\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.129\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 1.000\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.130\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 2.457\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.130\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC14_CAM04\tCurrent score: 1.397\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.173\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.228\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.173\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Duration above 30.0 deg\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.173\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC15_CAM03\tCurrent score: 1.474\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.216\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 1.000\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.217\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 2.474\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.217\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC15_CAM04\tCurrent score: 1.471\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.260\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.549\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.260\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 2.020\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.260\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC21_CAM01\tCurrent score: 1.371\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.301\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.052\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.302\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Duration above 30.0 deg\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.302\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC21_CAM02\tCurrent score: 1.390\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.346\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.181\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.346\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Duration above 30.0 deg\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.346\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC21_CAM03\tCurrent score: 1.427\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.391\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.451\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.392\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.878\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.392\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC22_CAM01\tCurrent score: 1.525\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.437\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.327\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.437\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.851\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.437\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC22_CAM02\tCurrent score: 1.509\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.481\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.482\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.481\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 1.991\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.481\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC22_CAM03\tCurrent score: 1.492\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.525\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.712\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.525\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Duration above 30.0 deg\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.526\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC23_CAM01\tCurrent score: 1.671\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.569\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.556\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.569\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 2.227\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.569\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC23_CAM02\tCurrent score: 1.620\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.614\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.710\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.615\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Duration above 30.0 deg\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.615\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC23_CAM03\tCurrent score: 1.551\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.657\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.887\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.658\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Duration above 30.0 deg\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.658\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC24_CAM01\tCurrent score: 1.801\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.701\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.767\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.701\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Duration above 30.0 deg\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.701\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC24_CAM02\tCurrent score: 1.705\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.743\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.909\tVeto: True\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.744\u001b[0m \u001b[94m\u001b[1m\t\tVetoed by Duration above 30.0 deg\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.744\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC24_CAM03\tCurrent score: 1.593\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.788\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 1.000\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.788\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 2.593\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.788\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC25_CAM01\tCurrent score: 1.875\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.831\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 0.983\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.831\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 2.858\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.832\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC25_CAM02\tCurrent score: 1.742\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.875\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 1.000\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.876\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 2.742\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.876\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC25_CAM03\tCurrent score: 1.609\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.919\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 1.000\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.919\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 2.609\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.919\u001b[0m \u001b[94m\u001b[1m\tTESS_SEC26_CAM03\tCurrent score: 1.599\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.963\u001b[0m \u001b[94m\u001b[1m\t\tConstraint Score: 1.000\tVeto: False\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.963\u001b[0m \u001b[94m\u001b[1m\t\tTotal score: 2.599\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.963\u001b[0m \u001b[94m\u001b[1mMultiplying final scores by priority\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.964\u001b[0m \u001b[94m\u001b[1mBlaze Star: 1000.00 *   2.71 = 2710.56\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.964\u001b[0m \u001b[94m\u001b[1mTESS_SEC14_CAM03:  100.00 *   2.46 =  245.68\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.964\u001b[0m \u001b[94m\u001b[1mTESS_SEC15_CAM03:  100.00 *   2.47 =  247.40\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.964\u001b[0m \u001b[94m\u001b[1mTESS_SEC15_CAM04:  100.00 *   2.02 =  202.00\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.965\u001b[0m \u001b[94m\u001b[1mTESS_SEC21_CAM03:  100.00 *   1.88 =  187.76\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.965\u001b[0m \u001b[94m\u001b[1mTESS_SEC22_CAM01:  100.00 *   1.85 =  185.14\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.965\u001b[0m \u001b[94m\u001b[1mTESS_SEC22_CAM02:  100.00 *   1.99 =  199.11\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.965\u001b[0m \u001b[94m\u001b[1mTESS_SEC23_CAM01:  100.00 *   2.23 =  222.72\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.965\u001b[0m \u001b[94m\u001b[1mTESS_SEC24_CAM03:  100.00 *   2.59 =  259.29\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.966\u001b[0m \u001b[94m\u001b[1mTESS_SEC25_CAM01:  100.00 *   2.86 =  285.78\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.966\u001b[0m \u001b[94m\u001b[1mTESS_SEC25_CAM02:  100.00 *   2.74 =  274.23\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.966\u001b[0m \u001b[94m\u001b[1mTESS_SEC25_CAM03:  100.00 *   2.61 =  260.91\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.966\u001b[0m \u001b[94m\u001b[1mTESS_SEC26_CAM03:  100.00 *   2.60 =  259.86\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.967\u001b[0m \u001b[94m\u001b[1mBest observation: Blaze Star\tScore: 2710.56\u001b[0m\n",
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:18.967\u001b[0m \u001b[94m\u001b[1mSetting new observation to Blaze Star: 30.0 s exposures in blocks of 5, minimum 10, priority 1000\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<panoptes.pocs.scheduler.observation.base.Observation at 0x15a2a15b0>"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "pocs.observatory.get_observation()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "9d3dbe12-81c7-44c4-ad4d-db91f9826036",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Blaze Star: 30.0 s exposures in blocks of 5, minimum 10, priority 1000\n"
+     ]
+    }
    ],
-   "outputs": []
+   "source": [
+    "print(pocs.observatory.current_observation)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -276,17 +671,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "id": "508d4980",
    "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[94m\u001b[1mI\u001b[0m \u001b[94m05-27 07:42:38.623\u001b[0m \u001b[94m\u001b[1mTarget Coordinates not set\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Make sure the mount is unparked\n",
     "pocs.observatory.mount.unpark()\n",
     "\n",
     "# Move to the target.\n",
     "pocs.observatory.mount.slew_to_target()"
-   ],
-   "outputs": []
+   ]
   }
  ],
  "metadata": {
@@ -305,7 +718,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,

--- a/src/panoptes/pocs/hardware.py
+++ b/src/panoptes/pocs/hardware.py
@@ -48,7 +48,7 @@ def get_all_names(all_names=None, without=None):
     return sorted([v for v in all_names if v not in without])
 
 
-def get_simulator_names(simulator=None, kwargs=None):
+def get_simulator_names(simulator: str | list | None = None, kwargs=None):
     """Returns the names of the simulators to be used in lieu of hardware drivers.
 
     Note that returning a list containing 'X' doesn't mean that the config calls for a driver
@@ -76,7 +76,7 @@ def get_simulator_names(simulator=None, kwargs=None):
     ['camera', 'dome', 'mount', 'night', 'power', 'sensors', 'theskyx', 'weather']
 
     Args:
-        simulator (list): An explicit list of names of hardware to be simulated
+        simulator (str|list|None): An explicit list of names of hardware to be simulated
             (i.e. hardware drivers to be replaced with simulators).
         kwargs: The kwargs passed in to the caller, which is inspected for an arg
             called 'simulator'.

--- a/tests/test_pocs.py
+++ b/tests/test_pocs.py
@@ -132,7 +132,8 @@ def test_observatory_cannot_observe(pocs):
     assert pocs.is_initialized
 
 
-def test_simple_simulator(pocs, caplog):
+def test_simple_simulator(caplog):
+    pocs = POCS.from_config(simulators='all')
     assert isinstance(pocs, POCS)
     pocs.set_config('simulator', 'all')
 


### PR DESCRIPTION
* Update the `from_config` classmethod so it works with `simulators='all'`
* Be default creates two DSLR simulators. Much could be improved.

Closes #1321 