### PR TITLE
Reset the current observation when getting a new observation.

### DIFF
--- a/src/panoptes/pocs/scheduler/dispatch.py
+++ b/src/panoptes/pocs/scheduler/dispatch.py
@@ -37,6 +37,9 @@ class Scheduler(BaseScheduler):
         valid_obs = {obs: 0.0 for obs in self.observations}
         best_obs = []
 
+        # Reset the current observation
+        self.current_observation = None
+
         self.set_common_properties(time)
 
         self.logger.info('Applying constraints to observations:')

--- a/src/panoptes/pocs/scheduler/dispatch.py
+++ b/src/panoptes/pocs/scheduler/dispatch.py
@@ -38,7 +38,11 @@ class Scheduler(BaseScheduler):
         best_obs = []
 
         # Reset the current observation
-        current_obs = self.observed_list[self.current_observation.seq_time]
+        if self.current_observation is not None:
+            current_obs = self.observed_list[self.current_observation.seq_time]
+        else:
+            current_obs = None
+
         self.current_observation = None
 
         self.set_common_properties(time)

--- a/src/panoptes/pocs/scheduler/scheduler.py
+++ b/src/panoptes/pocs/scheduler/scheduler.py
@@ -84,7 +84,7 @@ class BaseScheduler(PanBase):
         return len(self._observations.keys()) > 0
 
     @property
-    def current_observation(self):
+    def current_observation(self) -> Observation:
         """The observation that is currently selected by the scheduler
 
         Upon setting a new observation the `seq_time` is set to the current time
@@ -97,7 +97,7 @@ class BaseScheduler(PanBase):
         return self._current_observation
 
     @current_observation.setter
-    def current_observation(self, new_observation):
+    def current_observation(self, new_observation: Observation | None) -> None:
 
         if self.current_observation is None:
             # If we have no current observation but do have a new one, set seq_time


### PR DESCRIPTION
There is a small bug that occurs sometimes when getting a new observation that causes the old obseravtion information to be used. Resetting the `current_observation` at the start of `get_observation` should clean things up.