### PR TITLE
Socket based mount support

### DIFF
--- a/src/panoptes/pocs/mount/__init__.py
+++ b/src/panoptes/pocs/mount/__init__.py
@@ -77,7 +77,7 @@ def create_mount_from_config(mount_info=None,
     try:
         port = mount_info['serial']['port']
         logger.info(f'Looking for {driver} on {port}.')
-        if (port is None or len(glob(port)) == 0) and not port.startwsith('socket'):
+        if (port is None or len(glob(port)) == 0) and not port.startswith('socket'):
             if port == 'loop://':
                 logger.warning('Using loop:// for mount connection.')
             else:

--- a/src/panoptes/pocs/mount/__init__.py
+++ b/src/panoptes/pocs/mount/__init__.py
@@ -77,7 +77,7 @@ def create_mount_from_config(mount_info=None,
     try:
         port = mount_info['serial']['port']
         logger.info(f'Looking for {driver} on {port}.')
-        if port is None or len(glob(port)) == 0:
+        if (port is None or len(glob(port)) == 0) and not port.startwsith('socket'):
             if port == 'loop://':
                 logger.warning('Using loop:// for mount connection.')
             else:


### PR DESCRIPTION
If creating the mount from config and the port begins with `socket`, don't use `glob` to search local ports to check for availability. This assumes the socket exists but doesn't check.

Closes #1328