### PR TITLE
Fix remote weather stale reading

### DIFF
--- a/src/panoptes/pocs/core.py
+++ b/src/panoptes/pocs/core.py
@@ -468,7 +468,7 @@ class POCS(PanStateMachine, PanBase):
                 with suppress(KeyError):
                     is_safe = bool(record['data'][key])
 
-            timestamp = record['date'].replace(tzinfo=None)  # current_time is timezone naive
+            timestamp = record['data']['timestamp'].replace(tzinfo=None)  # current_time is timezone naive
             age = (current_time().datetime - timestamp).total_seconds()
 
             self.logger.debug(f"Weather Safety: {is_safe=} {age=:.0f}s [{timestamp:%c}]")

--- a/tests/test_pocs.py
+++ b/tests/test_pocs.py
@@ -188,7 +188,7 @@ def test_is_weather_safe_no_simulator(pocs):
     os.environ['POCSTIME'] = '2020-01-01 18:00:00'
 
     # Insert a dummy weather record
-    pocs.db.insert_current('weather', {'safe': True})
+    pocs.db.insert_current('weather', {'safe': True, "timestamp": '2020-01-01 18:00:00'})
     assert pocs.is_weather_safe() is True
 
     # Set a time 181 seconds later


### PR DESCRIPTION
The `is_weather_safe` method checks to see if the record is stale, but it is checking the date associated with the creation of the record, not the data associated with the values themselves. On systems using the remote weather reader these dates can differ. The correct date to read is that associated with the values themselves.

Closes #1332 