### PR TITLE
Add ZWO binning options

### DIFF
--- a/src/panoptes/pocs/camera/libasi.py
+++ b/src/panoptes/pocs/camera/libasi.py
@@ -773,7 +773,7 @@ class ErrorCode(enum.IntEnum):
     INVALID_ID = enum.auto()
     INVALID_CONTROL_TYPE = enum.auto()
     CAMERA_CLOSED = enum.auto()  # Camera didn't open
-    CAMERA_REMOVED = enum.auto()  # Failed to fine the camera, maybe it was removed
+    CAMERA_REMOVED = enum.auto()  # Failed to find the camera, maybe it was removed
     INVALID_PATH = enum.auto()  # Cannot find the path of the file
     INVALID_FILEFORMAT = enum.auto()
     INVALID_SIZE = enum.auto()  # Wrong video format size

--- a/src/panoptes/pocs/camera/zwo.py
+++ b/src/panoptes/pocs/camera/zwo.py
@@ -5,6 +5,7 @@ from astropy import units as u
 from astropy.io import fits
 from astropy.time import Time
 from contextlib import suppress
+from typing import Tuple
 
 from panoptes.pocs.camera.libasi import ASIDriver
 from panoptes.pocs.camera.sdk import AbstractSDKCamera
@@ -93,14 +94,14 @@ class Camera(AbstractSDKCamera):
         return roi_format
 
     @property
-    def image_type(self):
+    def image_type(self) -> str:
         """ Current camera image type, one of 'RAW8', 'RAW16', 'Y8', 'RGB24' """
         return self.roi.get('image_type')
 
     @image_type.setter
-    def image_type(self, new_image_type):
+    def image_type(self, new_image_type: str):
         if new_image_type not in self.properties['supported_video_format']:
-            msg = "Image type '{} not supported by {}".format(new_image_type, self.model)
+            msg = f"Image type '{new_image_type} not supported by {self.model}"
             self.logger.error(msg)
             raise ValueError(msg)
         roi_format = self.roi
@@ -108,14 +109,14 @@ class Camera(AbstractSDKCamera):
         self._driver.set_roi_format(self._handle, **roi_format)
 
     @property
-    def binning(self):
+    def binning(self) -> int:
         """ Current camera binning setting, either `1` (no binning) or `2` (binning). """
         return self.roi.get('binning')
 
     @binning.setter
-    def binning(self, new_binning):
+    def binning(self, new_binning: int):
         if new_binning not in self.properties['supported_bins']:
-            msg = "Binning '{}' not supported by {}".format(new_binning, self.model)
+            msg = f"Binning '{new_binning}' not supported by {self.model}"
             self.logger.error(msg)
             raise ValueError(msg)
         roi_format = self.roi
@@ -130,20 +131,20 @@ class Camera(AbstractSDKCamera):
             self.logger.error(f"Failed to set binning '{new_binning}': {e}")
 
     @property
-    def image_size(self):
+    def image_size(self) -> Tuple[u.Quantity, u.Quantity]:
         """ Current camera image size, either `(width, height)`."""
-        width = self.roi.get('width', None)
-        height = self.roi.get('height', None)
+        width = self.roi.get('width')
+        height = self.roi.get('height')
 
         return width, height
 
     @property
-    def width(self):
+    def width(self) -> u.Quantity:
         """Current image width"""
         return self.image_size[0]
 
     @property
-    def height(self):
+    def height(self) -> u.Quantity:
         """Current image height"""
         return self.image_size[1]
 

--- a/src/panoptes/pocs/camera/zwo.py
+++ b/src/panoptes/pocs/camera/zwo.py
@@ -86,12 +86,16 @@ class Camera(AbstractSDKCamera):
         super().__del__()
 
     # Properties
+    @property
+    def roi(self) -> dict:
+        """ Get the ROI of the camera, which includes the width, height, binning, and image_type."""
+        roi_format = self._driver.get_roi_format(self._handle)
+        return roi_format
 
     @property
     def image_type(self):
         """ Current camera image type, one of 'RAW8', 'RAW16', 'Y8', 'RGB24' """
-        roi_format = self._driver.get_roi_format(self._handle)
-        return roi_format['image_type']
+        return self.roi.get('image_type')
 
     @image_type.setter
     def image_type(self, new_image_type):
@@ -99,15 +103,14 @@ class Camera(AbstractSDKCamera):
             msg = "Image type '{} not supported by {}".format(new_image_type, self.model)
             self.logger.error(msg)
             raise ValueError(msg)
-        roi_format = self._driver.get_roi_format(self._handle)
+        roi_format = self.roi
         roi_format['image_type'] = new_image_type
         self._driver.set_roi_format(self._handle, **roi_format)
 
     @property
     def binning(self):
         """ Current camera binning setting, either `1` (no binning) or `2` (binning). """
-        roi_format = self._driver.get_roi_format(self._handle)
-        return roi_format['binning']
+        return self.roi.get('binning')
 
     @binning.setter
     def binning(self, new_binning):
@@ -115,7 +118,7 @@ class Camera(AbstractSDKCamera):
             msg = "Binning '{}' not supported by {}".format(new_binning, self.model)
             self.logger.error(msg)
             raise ValueError(msg)
-        roi_format = self._driver.get_roi_format(self._handle)
+        roi_format = self.roi
         roi_format['binning'] = new_binning
         roi_format['width'] = roi_format['width'] // new_binning
         roi_format['height'] = roi_format['height'] // new_binning

--- a/src/panoptes/pocs/camera/zwo.py
+++ b/src/panoptes/pocs/camera/zwo.py
@@ -120,8 +120,8 @@ class Camera(AbstractSDKCamera):
             raise ValueError(msg)
         roi_format = self.roi
         roi_format['binning'] = new_binning
-        roi_format['width'] = roi_format['width'] // new_binning
-        roi_format['height'] = roi_format['height'] // new_binning
+        roi_format['width'] = roi_format['width'].to_value() // new_binning
+        roi_format['height'] = roi_format['height'].to_value() // new_binning
         self.logger.debug(f'Setting binning to {new_binning}')
         self._driver.set_roi_format(self._handle, **roi_format)
 

--- a/src/panoptes/pocs/camera/zwo.py
+++ b/src/panoptes/pocs/camera/zwo.py
@@ -123,7 +123,11 @@ class Camera(AbstractSDKCamera):
         roi_format['width'] = roi_format['width'].to_value() // new_binning
         roi_format['height'] = roi_format['height'].to_value() // new_binning
         self.logger.debug(f'Setting binning to {new_binning}')
-        self._driver.set_roi_format(self._handle, **roi_format)
+
+        try:
+            self._driver.set_roi_format(self._handle, **roi_format)
+        except Exception as e:
+            self.logger.error(f"Failed to set binning '{new_binning}': {e}")
 
     @property
     def image_size(self):

--- a/src/panoptes/pocs/camera/zwo.py
+++ b/src/panoptes/pocs/camera/zwo.py
@@ -1,16 +1,15 @@
+import numpy as np
 import threading
 import time
-from contextlib import suppress
-
-import numpy as np
 from astropy import units as u
 from astropy.io import fits
 from astropy.time import Time
-from panoptes.utils import error
-from panoptes.utils.utils import get_quantity_value
+from contextlib import suppress
 
 from panoptes.pocs.camera.libasi import ASIDriver
 from panoptes.pocs.camera.sdk import AbstractSDKCamera
+from panoptes.utils import error
+from panoptes.utils.utils import get_quantity_value
 
 
 class Camera(AbstractSDKCamera):
@@ -106,7 +105,7 @@ class Camera(AbstractSDKCamera):
 
     @property
     def binning(self):
-        """ Current camera binning setting, one of '8', '16', '24' """
+        """ Current camera binning setting, either `1` (no binning) or `2` (binning). """
         roi_format = self._driver.get_roi_format(self._handle)
         return roi_format['binning']
 
@@ -118,6 +117,9 @@ class Camera(AbstractSDKCamera):
             raise ValueError(msg)
         roi_format = self._driver.get_roi_format(self._handle)
         roi_format['binning'] = new_binning
+        roi_format['width'] = roi_format['width'] // new_binning
+        roi_format['height'] = roi_format['height'] // new_binning
+        self.logger.debug(f'Setting binning to {new_binning}')
         self._driver.set_roi_format(self._handle, **roi_format)
 
     @property

--- a/src/panoptes/pocs/camera/zwo.py
+++ b/src/panoptes/pocs/camera/zwo.py
@@ -18,11 +18,11 @@ class Camera(AbstractSDKCamera):
     _assigned_cameras = set()  # Camera string IDs already in use.
 
     def __init__(self,
-                 name='ZWO ASI Camera',
-                 gain=100,
-                 image_type=None,
-                 bandwidthoverload=99,
-                 binning=1,
+                 name: str = 'ZWO ASI Camera',
+                 gain: int | None = 100,
+                 image_type: str | None = None,
+                 bandwidthoverload: float = 99,
+                 binning: int = 2,
                  *args, **kwargs
                  ):
         """
@@ -36,7 +36,7 @@ class Camera(AbstractSDKCamera):
                 or 'Y8'). Default is to use 'RAW16' if supported by the camera, otherwise
                 the camera's own default will be used.
             bandwidthoverload (int, optional): bandwidth overload setting in percent, default is 99.
-            binning (int, optional): binning factor to use for the camera, default is 1, i.e. no binning.
+            binning (int, optional): binning factor to use for the camera, default is 2, which is quad binning.
             *args, **kwargs: additional arguments to be passed to the parent classes.
 
         Notes:

--- a/src/panoptes/pocs/camera/zwo.py
+++ b/src/panoptes/pocs/camera/zwo.py
@@ -126,6 +126,24 @@ class Camera(AbstractSDKCamera):
         self._driver.set_roi_format(self._handle, **roi_format)
 
     @property
+    def image_size(self):
+        """ Current camera image size, either `(width, height)`."""
+        width = self.roi.get('width', None)
+        height = self.roi.get('height', None)
+
+        return width, height
+
+    @property
+    def width(self):
+        """Current image width"""
+        return self.image_size[0]
+
+    @property
+    def height(self):
+        """Current image height"""
+        return self.image_size[1]
+
+    @property
     def bit_depth(self):
         """ADC bit depth"""
         return self.properties['bit_depth']


### PR DESCRIPTION
* Add bin parameters to the zwo camera.
* Default to `2` for binning (i.e. quad binning - 2x2)
* Add property accessors for the ROI, and separate ones for the image size.

Closes #1340 