### PR TITLE
Update and dependencies 1318

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "certifi>=2023.7.22",
     "fastapi<0.106.0",
     "fastapi-utils",
+    "GitPython",
     "human-readable",
     "numpy>=2",
     "panoptes-utils[config]>=0.2.47",
@@ -72,7 +73,7 @@ google = [
     "google-cloud-logging",
     "google-cloud-storage",
     "gsutil",
-    "protobuf==4.23.0",
+    "protobuf",
     "rsa",
 ]
 testing = [
@@ -89,23 +90,7 @@ weather = [
     "panoptes-aag",
 ]
 all = [
-    "coverage",
-    "google-cloud-firestore",
-    "google-cloud-logging",
-    "google-cloud-storage",
-    "gsutil",
-    "matplotlib",
-    "panoptes-aag",
-    "protobuf==4.23.0",
-    "pycodestyle",
-    "pytest",
-    "pytest-cov",
-    "pytest-doctestplus",
-    "pytest-loguru",
-    "pytest-remotedata>=0.3.1",
-    "responses",
-    "rsa",
-    "scipy>=1.10.0",
+    "panoptes-pocs[focuser,google,testing,weather]"
 ]
 
 [tool.hatch.version]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ google = [
     "google-cloud-logging",
     "google-cloud-storage",
     "gsutil",
-    "protobuf",
+    "protobuf==4.23.0",
     "rsa",
 ]
 testing = [

--- a/src/panoptes/pocs/utils/cli/main.py
+++ b/src/panoptes/pocs/utils/cli/main.py
@@ -1,15 +1,12 @@
-import typer
+import os
+import subprocess
+import sys
 
-from panoptes.pocs.utils.cli import config
-from panoptes.pocs.utils.cli import sensor
-from panoptes.pocs.utils.cli import network
-from panoptes.pocs.utils.cli import mount
-from panoptes.pocs.utils.cli import camera
-from panoptes.pocs.utils.cli import notebook
-from panoptes.pocs.utils.cli import power
-from panoptes.pocs.utils.cli import run
-from panoptes.pocs.utils.cli import weather
+import typer
+from git import GitCommandError, Repo
 from rich import print
+
+from panoptes.pocs.utils.cli import camera, config, mount, network, notebook, power, run, sensor, weather
 
 app = typer.Typer()
 state = {"verbose": False}
@@ -23,6 +20,8 @@ app.add_typer(power.app, name="power", help="Interact with power relays.")
 app.add_typer(run.app, name="run", help="Run POCS!")
 app.add_typer(sensor.app, name="sensor", help="Interact with system sensors.")
 app.add_typer(weather.app, name="weather", help="Interact with weather station service.")
+
+REPO_PATH = os.path.dirname(os.path.abspath(__file__))
 
 
 @app.callback()
@@ -41,6 +40,130 @@ def main(
     )
     if verbose:
         print(f"Command options from main: {context.params!r}")
+
+
+@app.command(name='update')
+def update_repo(
+    update_messages_dir: str = 'updates'
+):
+    """Update POCS.
+
+    This will pull the latest changes from github and show any relevant messages.
+    """
+    new_commits = None
+
+    project_root = find_project_root()
+    print(f"Updating {project_root}")
+    repo = Repo(project_root)
+
+    try:
+        origin = repo.remotes.origin
+        origin.fetch()
+
+        # If local dir is dirty, stash changes.
+        if repo.is_dirty():
+            print("Stashing local changes...")
+            repo.git.stash("push")
+
+        # Get the current commit and the latest remote commit
+        current_commit = repo.head.commit
+        latest_remote_commit = repo.active_branch.tracking_branch().commit
+
+        print(f"Current commit {current_commit}")
+        print(f"Latest commit {latest_remote_commit}")
+
+        if current_commit == latest_remote_commit:
+            print("Project is already up to date. No action needed.")
+            return
+
+        # Find the commits between the current state and the remote
+        new_commits = list(repo.iter_commits(f'{current_commit}...{latest_remote_commit}'))
+        print(f"New commit {new_commits}")
+
+        print("Updates found. Pulling latest changes...")
+        origin.pull()
+        print("Successfully pulled the latest changes.")
+
+        if new_commits:
+            print(f"Updating new commits...{new_commits}")
+
+    except GitCommandError as e:
+        print(f"Failed to pull the latest changes: {e}")
+        typer.Abort(e)
+    except Exception as e:
+        print(f"Error: {e}")
+        typer.Abort(e)
+    finally:
+        # Apply stashed changes
+        if repo.git.stash("list"):
+            repo.git.stash("pop")
+
+    # Sync dependencies with the new pyproject.toml
+    print("Syncing dependencies with hatch...")
+    run_hatch_command(['run', 'pocs', 'show-messages'])
+
+    print("\n[green]Update process complete![/green]")
+
+
+@app.command(name="show-messages")
+def show_messages(
+    last_commit: str = None
+):
+    """Shows any important update messages."""
+    print("Important messages:")
+
+
+def run_hatch_command(command: list):
+    """
+    Runs a hatch command using subprocess and handles potential errors.
+    """
+    try:
+        process = subprocess.run(
+            ['hatch'] + command,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=120
+        )
+        print(process.stdout)
+    except subprocess.CalledProcessError as e:
+        print(f"Error executing hatch command: {e.stderr}", file=sys.stderr)
+        raise
+    except FileNotFoundError:
+        print("Hatch is not installed or not in PATH.", file=sys.stderr)
+        raise
+
+
+def find_project_root(start_path=None):
+    """
+    Finds the project root by searching for a 'pyproject.toml' file
+    or a '.git' directory.
+
+    Args:
+        start_path (str, optional): The directory to start the search from.
+                                    Defaults to the current working directory.
+
+    Returns:
+        str: The absolute path to the project root, or None if not found.
+    """
+    if start_path is None:
+        # Start from the directory of the currently executing script
+        start_path = os.path.abspath(os.path.dirname(__file__))
+
+    current_path = start_path
+
+    while True:
+        # Check for common project root markers
+        if any(os.path.exists(os.path.join(current_path, marker)) for marker in ['pyproject.toml', '.git', 'setup.py']):
+            return current_path
+
+        parent_path = os.path.dirname(current_path)
+
+        # If we've reached the root of the file system, stop
+        if parent_path == current_path:
+            return None
+
+        current_path = parent_path
 
 
 if __name__ == "__main__":

--- a/src/panoptes/pocs/utils/cli/main.py
+++ b/src/panoptes/pocs/utils/cli/main.py
@@ -4,6 +4,10 @@ import sys
 
 import typer
 from git import GitCommandError, Repo
+from rich import print
+from rich.panel import Panel
+from rich.progress import Progress, SpinnerColumn, TextColumn
+
 from panoptes.pocs.utils.cli import (
     camera,
     config,
@@ -15,9 +19,6 @@ from panoptes.pocs.utils.cli import (
     sensor,
     weather,
 )
-from rich import print
-from rich.panel import Panel
-from rich.progress import Progress, SpinnerColumn, TextColumn
 
 app = typer.Typer()
 state = {"verbose": False}


### PR DESCRIPTION
Adds a `pocs update` command that will fetch the latest changes from github, sync the dependencies (using `hatch`) and show any relevant messsages to the user. 

Closes #1318 

Messages are shown to the user by adding a notice as follows:

NOTICE: Now you can easily update POCS by calling `pocs update`. Give it a try! 🎉 