### PR TITLE
Update panoptes-utils

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "GitPython",
     "human-readable",
     "numpy>=2",
-    "panoptes-utils[config]>=0.2.47",
+    "panoptes-utils[config]>=0.2.51",
     "pandas",
     "pick",
     "Pillow>=10.0.1",

--- a/src/panoptes/pocs/utils/coords.py
+++ b/src/panoptes/pocs/utils/coords.py
@@ -30,7 +30,7 @@ def get_target_coords(
 
     >>> get_target_coords("Andromeda Galaxy", obstime=Time("2020-01-01"), verbose=True)
     <SkyCoord (ICRS): (ra, dec) in deg
-        (10.6847083, 41.26875)>
+        (10.68470833, 41.26875)>
 
     >>> m = get_target_coords("Moon", obstime=Time("2020-01-01"))
     >>> isinstance(m, SkyCoord)


### PR DESCRIPTION
Updates to `panoptes-utils>=0.2.51`, which makes the config server fail to load if there is an error. 

Also in that release are new doc-strings and type-hints.

NOTICE: :warning: The config server will now fail to load if there is an error in your config file.