### PR TITLE
Camera determines default exptime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@
 - ZWO cameras now have a `fix_bit_padding` option: `True` means restore raw data to native
       resolution of camera, `False` (default) will keep the data driver-padded 16-bits.
 
+### Changed
+
+- Observation exposure time defaults: when `exptime` is not specified in field files, observations now use the 
+  `cameras.defaults.exptime` configuration value instead of a hardcoded 120 seconds. This allows setting 
+  camera-specific defaults (e.g., 30s for ZWO cameras, 120s for DSLRs) in the config without needing to 
+  specify exposure time for every field. The fallback remains 120 seconds if not configured. #XXXX
+
 ## 0.8.0 - 2026-02-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@
 - Observation exposure time defaults: when `exptime` is not specified in field files, observations now use the 
   `cameras.defaults.exptime` configuration value instead of a hardcoded 120 seconds. This allows setting 
   camera-specific defaults (e.g., 30s for ZWO cameras, 120s for DSLRs) in the config without needing to 
-  specify exposure time for every field. The fallback remains 120 seconds if not configured. #XXXX
+  specify exposure time for every field. The fallback remains 120 seconds if not configured.
+- `pocs camera setup` now automatically sets `cameras.defaults.exptime` to 1 second when ZWO cameras are detected,
+  optimizing the default for faster-readout CCD cameras.
 
 ## 0.8.0 - 2026-02-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
   specify exposure time for every field. The fallback remains 120 seconds if not configured.
 - `pocs camera setup` now automatically sets `cameras.defaults.exptime` to 1 second when ZWO cameras are detected,
   optimizing the default for faster-readout CCD cameras.
+- `CompoundObservation` now raises a clear `ValueError` if instantiated without an `exptime` parameter, 
+  since it requires a sequence of exposure times to cycle through.
+- `DarkObservation` now explicitly passes the first exposure time to the parent `Observation` class,
+  ensuring consistent behavior with the new default exptime logic.
 
 ## 0.8.0 - 2026-02-17
 

--- a/conf_files/fields/README.md
+++ b/conf_files/fields/README.md
@@ -34,7 +34,10 @@ Each field configuration file is a YAML list where each item defines:
 ### `observation` section
 
 - **priority** (optional, default: 100): Higher priority targets are observed first
-- **exptime** (optional, default: 120): Exposure time in seconds
+- **exptime** (optional): Exposure time in seconds. If not specified, uses the value 
+  from `cameras.defaults.exptime` in the configuration file (default: 120 seconds). 
+  This allows you to set camera-specific defaults (e.g., 30s for ZWO cameras, 120s for DSLRs) 
+  without needing to specify exposure time for every field.
 - **min_nexp** (optional, default: 60): Minimum number of exposures to take
 - **exp_set_size** (optional, default: 10): Number of exposures per set
 - **filter_name** (optional): Filter to use for this observation

--- a/conf_files/fields/simple.yaml
+++ b/conf_files/fields/simple.yaml
@@ -1,4 +1,10 @@
 ---
+# Example field configurations for POCS scheduler
+#
+# Note: If 'exptime' is not specified in the observation section,
+# the default exposure time from 'cameras.defaults.exptime' in the
+# configuration will be used (default: 120 seconds).
+#
 - field:
     name: "Blaze Star"
     position: 239.876deg +25.916deg

--- a/conf_files/pocs.yaml
+++ b/conf_files/pocs.yaml
@@ -94,6 +94,8 @@ cameras:
     keep_jpgs: True
     readout_time: 5.0  # seconds
     timeout: 60  # seconds
+    exptime: 120  # Default exposure time in seconds (used when not specified in field files)
+                  # For ZWO cameras, you may want to use shorter exposures, e.g., 30 seconds
     filter_type: RGGB
     file_extension: cr2
     endpoint:  # Used for remote cameras

--- a/src/panoptes/pocs/scheduler/observation/base.py
+++ b/src/panoptes/pocs/scheduler/observation/base.py
@@ -96,8 +96,6 @@ class Observation(PanBase):
         if exptime is None:
             exptime = self.get_config("cameras.defaults.exptime", default=120)
 
-        # At this point exptime is guaranteed to be a number (not None)
-        assert exptime is not None
         exptime = get_quantity_value(exptime, u.second) * u.second
 
         if not isinstance(field, Field):

--- a/src/panoptes/pocs/scheduler/observation/base.py
+++ b/src/panoptes/pocs/scheduler/observation/base.py
@@ -41,7 +41,7 @@ class Observation(PanBase):
     def __init__(
         self,
         field: Field,
-        exptime: float | None = None,
+        exptime: float | u.Quantity | None = None,
         min_nexp: int = 60,
         exp_set_size: int = 10,
         priority: int | float = 100,

--- a/src/panoptes/pocs/scheduler/observation/base.py
+++ b/src/panoptes/pocs/scheduler/observation/base.py
@@ -10,7 +10,6 @@ from contextlib import suppress
 from pathlib import Path
 
 from astropy import units as u
-from astropy.units import s as Second
 from panoptes.utils import error
 from panoptes.utils.library import load_module
 from panoptes.utils.utils import get_quantity_value, listify
@@ -42,7 +41,7 @@ class Observation(PanBase):
     def __init__(
         self,
         field: Field,
-        exptime: Second = 120 * u.second,
+        exptime: float | None = None,
         min_nexp: int = 60,
         exp_set_size: int = 10,
         priority: int | float = 100,
@@ -72,8 +71,10 @@ class Observation(PanBase):
             field to be captured
 
         Keyword Arguments:
-            exptime {u.second} -- Exposure time for individual exposures
-                (default: {120 * u.second})
+            exptime {u.second | float | None} -- Exposure time for individual exposures
+                (can be a float in seconds or an astropy Quantity with time units).
+                If None, will use the value from config at 'cameras.defaults.exptime',
+                or fall back to 120 seconds. (default: {None})
             min_nexp {int} -- The minimum number of exposures to be taken for a
                 given field (default: 60)
             exp_set_size {int} -- Number of exposures to take per set
@@ -91,6 +92,12 @@ class Observation(PanBase):
         """
         super().__init__(*args, **kwargs)
 
+        # If exptime is None, get the default from camera config.
+        if exptime is None:
+            exptime = self.get_config("cameras.defaults.exptime", default=120)
+
+        # At this point exptime is guaranteed to be a number (not None)
+        assert exptime is not None
         exptime = get_quantity_value(exptime, u.second) * u.second
 
         if not isinstance(field, Field):

--- a/src/panoptes/pocs/scheduler/observation/compound.py
+++ b/src/panoptes/pocs/scheduler/observation/compound.py
@@ -11,7 +11,19 @@ class Observation(BaseObservation):
     """An observation that consists of different combinations of exptimes."""
 
     def __init__(self, *args, **kwargs):
-        """Accept a list of exptimes."""
+        """Accept a list of exptimes.
+
+        Note: CompoundObservation requires an explicit exptime parameter (or list of exptimes).
+        Unlike the base Observation class, it cannot use the camera config default because
+        it needs a sequence of exposure times to cycle through.
+        """
+        # Get exptime from kwargs, raise clear error if not provided
+        if "exptime" not in kwargs:
+            raise ValueError(
+                "CompoundObservation requires an 'exptime' parameter. "
+                "Provide a single value or a list of exposure times to cycle through."
+            )
+
         # Save all the exptimes.
         self._exptimes = listify(kwargs["exptime"])
 

--- a/src/panoptes/pocs/scheduler/observation/dark.py
+++ b/src/panoptes/pocs/scheduler/observation/dark.py
@@ -30,11 +30,17 @@ class DarkObservation(Observation):
             exptimes = self.get_config("calibs.dark.exposure_times")
         self._exptimes = exptimes
 
-        # Create the observation
+        # Create the observation - use first exptime for initialization
         min_nexp = len(self._exptimes)
         exp_set_size = min_nexp
         field = Field("Dark", position=position)
-        super().__init__(field=field, min_nexp=min_nexp, exp_set_size=exp_set_size, dark=True)
+        super().__init__(
+            field=field,
+            exptime=self._exptimes[0],  # Pass first exptime to parent
+            min_nexp=min_nexp,
+            exp_set_size=exp_set_size,
+            dark=True,
+        )
 
         # Specify directory root for file storage
         self._directory = os.path.join(self._image_dir, "dark")

--- a/src/panoptes/pocs/utils/cli/camera.py
+++ b/src/panoptes/pocs/utils/cli/camera.py
@@ -149,6 +149,12 @@ def setup_cameras(
     # Turn off the autodetect
     set_config("cameras.defaults.auto_detect", False)
 
+    # Set default exptime to 1 second if ZWO cameras detected
+    has_zwo = any(cam_config.get("model", "").endswith("zwo.Camera") for cam_config in cameras.values())
+    if has_zwo:
+        print("ZWO cameras detected, setting default exposure time to 1 second.")
+        set_config("cameras.defaults.exptime", 1)
+
     # Now create the cameras from the config, calling the `setup_camera` method if available.
     print("Now creating the cameras from the config and setting them up.")
     cameras = create_cameras_from_config()

--- a/tests/test_observation.py
+++ b/tests/test_observation.py
@@ -190,7 +190,7 @@ def test_observation_from_dict_without_tags():
 
 def test_default_exptime_from_config(field):
     """Test that default exptime comes from camera config when not specified."""
-    # The testing.yaml config has cameras.defaults.exptime not set, so should use fallback of 120
+    # The testing.yaml config sets cameras.defaults.exptime to 120, so the configured default is used
     obs = Observation(field)
     assert obs.exptime == 120 * u.second
 

--- a/tests/test_observation.py
+++ b/tests/test_observation.py
@@ -186,3 +186,23 @@ def test_observation_from_dict_without_tags():
     obs = Observation.from_dict(observation_config)
     assert obs.tags == []
     assert obs.priority == 100
+
+
+def test_default_exptime_from_config(field):
+    """Test that default exptime comes from camera config when not specified."""
+    # The testing.yaml config has cameras.defaults.exptime not set, so should use fallback of 120
+    obs = Observation(field)
+    assert obs.exptime == 120 * u.second
+
+
+def test_observation_from_dict_without_exptime():
+    """Test creating observation from dict without exptime uses camera config default."""
+    observation_config = {
+        "field": {"name": "Test Field", "position": "20h00m43.7135s +22d42m39.0645s"},
+        "observation": {"priority": 100},  # No exptime specified
+    }
+
+    obs = Observation.from_dict(observation_config)
+    # Should use default from config (120 seconds in test config)
+    assert obs.exptime == 120 * u.second
+    assert obs.priority == 100

--- a/tests/testing.yaml
+++ b/tests/testing.yaml
@@ -81,6 +81,7 @@ cameras:
     keep_jpgs: False
     readout_time: 0.5  # seconds
     timeout: 10  # seconds
+    exptime: 120  # Default exposure time in seconds (used when not specified in field files)
     filter_type: RGGB
     cooling:
       enabled: True


### PR DESCRIPTION
* Default exptime can be set at the camera config level rather than defaulted at the Observation level. See README for details.
* Use pocs camera setup to set default exptime based on camera model.

Tested on PAN000 in lab.