### PR TITLE
Weather station updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
     - `pocs run take-flats`: Takes flat field images with automatic exposure adjustment and mount positioning
 - ZWO cameras now have a `fix_bit_padding` option: `True` means restore raw data to native
       resolution of camera, `False` (default) will keep the data driver-padded 16-bits.
+- Ability to store the weather readings permanently via the config. #1405
 
 ### Changed
 

--- a/conf_files/pocs.yaml
+++ b/conf_files/pocs.yaml
@@ -139,6 +139,7 @@ environment:
     safety_delay: 15  # minutes from bad reading until safe again
     capture_delay: 60  # seconds between taking measurements
     num_readings: 5  # number of readings to average for each measurement
+    store_permanently: False  # Whether to store all weather readings permanently (e.g. in a database)
     thresholds:
       cloudy: -25  # Cloudy threshold in delta degrees C
       very_cloudy: -15  # Very cloudy threshold in delta degrees C

--- a/src/panoptes/pocs/sensor/weather.py
+++ b/src/panoptes/pocs/sensor/weather.py
@@ -45,7 +45,7 @@ class WeatherStation(PanBase):
         self.serial_port = serial_port or conf.get("serial_port", "/dev/ttyUSB0")
         self.name = name
         self.collection_name = db_collection
-        self.store_permanently = store_permanently or conf.get("store_permanently", False)
+        self.store_permanently = store_permanently or conf.pop("store_permanently", False)
 
         self.logger.debug(f"Setting up weather station connection for {name=} on {self.serial_port}")
         self.weather_station = CloudSensor(serial_port=self.serial_port, **conf)

--- a/src/panoptes/pocs/sensor/weather.py
+++ b/src/panoptes/pocs/sensor/weather.py
@@ -16,6 +16,7 @@ class WeatherStation(PanBase):
         serial_port: str = None,
         name: str = "Weather Station",
         db_collection: str = "weather",
+        store_permanently: bool | None = None,
         *args,
         **kwargs,
     ):
@@ -25,6 +26,9 @@ class WeatherStation(PanBase):
             serial_port (str, optional): The dev port for the mount, usually the usb-serial converter.
             name (str): The user-friendly name for the weather station.
             db_collection (str): Which collection (i.e. table) to store the values in, default 'weather'.
+            store_permanently (bool | None): Whether to store readings permanently in the database,
+                default None first checks the conf for an `environment.weather.store_permanently`
+                setting, if not found default to False.
         """
         super().__init__(*args, **kwargs)
 
@@ -41,6 +45,7 @@ class WeatherStation(PanBase):
         self.serial_port = serial_port or conf.get("serial_port", "/dev/ttyUSB0")
         self.name = name
         self.collection_name = db_collection
+        self.store_permanently = store_permanently or conf.get("store_permanently", False)
 
         self.logger.debug(f"Setting up weather station connection for {name=} on {self.serial_port}")
         self.weather_station = CloudSensor(serial_port=self.serial_port, **conf)
@@ -63,7 +68,7 @@ class WeatherStation(PanBase):
         """Record the rolling mean of the power readings in the database."""
         recent_values = self.weather_station.get_reading()
 
-        self.db.insert_current(self.collection_name, recent_values, store_permanently=False)
+        self.db.insert_current(self.collection_name, recent_values, store_permanently=self.store_permanently)
 
         return recent_values
 

--- a/src/panoptes/pocs/sensor/weather.py
+++ b/src/panoptes/pocs/sensor/weather.py
@@ -16,7 +16,6 @@ class WeatherStation(PanBase):
         serial_port: str = None,
         name: str = "Weather Station",
         db_collection: str = "weather",
-        store_permanently: bool | None = None,
         *args,
         **kwargs,
     ):
@@ -26,9 +25,6 @@ class WeatherStation(PanBase):
             serial_port (str, optional): The dev port for the mount, usually the usb-serial converter.
             name (str): The user-friendly name for the weather station.
             db_collection (str): Which collection (i.e. table) to store the values in, default 'weather'.
-            store_permanently (bool | None): Whether to store readings permanently in the database,
-                default None first checks the conf for an `environment.weather.store_permanently`
-                setting, if not found default to False.
         """
         super().__init__(*args, **kwargs)
 
@@ -45,7 +41,7 @@ class WeatherStation(PanBase):
         self.serial_port = serial_port or conf.get("serial_port", "/dev/ttyUSB0")
         self.name = name
         self.collection_name = db_collection
-        self.store_permanently = store_permanently or conf.pop("store_permanently", False)
+        self.store_permanently = conf.pop("store_permanently", False)
 
         self.logger.debug(f"Setting up weather station connection for {name=} on {self.serial_port}")
         self.weather_station = CloudSensor(serial_port=self.serial_port, **conf)


### PR DESCRIPTION
Adding a `store_permanently` key to the `environment.weather` that controls if the weather readings should be permanently recorded.