### PR TITLE
Fix dependencies sort order

### DIFF
--- a/.github/workflows/pythontest.yaml
+++ b/.github/workflows/pythontest.yaml
@@ -28,7 +28,7 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
       - name: Install dependencies
-        run: uv sync --group lint
+        run: uv sync --group lint --all-extras
       - name: Lint with ruff
         run: uv run ruff check .
   test:

--- a/conftest.py
+++ b/conftest.py
@@ -5,6 +5,7 @@ import tempfile
 from contextlib import suppress
 
 import pytest
+
 from panoptes.utils.config.client import set_config
 from panoptes.utils.config.server import config_server
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,6 +192,21 @@ select = [
 ]
 ignore = []
 
+[tool.ruff.lint.isort]
+section-order = [
+    "future",
+    "standard-library",
+    "third-party",
+    "first-party",
+    "local-folder",
+    "panoptes-utils",
+    "panoptes-pocs"
+]
+
+[tool.ruff.lint.isort.sections]
+"panoptes-utils" = ["panoptes.utils"]
+"panoptes-pocs" = ["panoptes.pocs"]
+
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"

--- a/src/panoptes/pocs/base.py
+++ b/src/panoptes/pocs/base.py
@@ -7,9 +7,10 @@ shared lightweight database handle used throughout the project.
 import os
 from typing import Any
 
+from requests.exceptions import ConnectionError
+
 from panoptes.utils.config import client
 from panoptes.utils.database import PanDB
-from requests.exceptions import ConnectionError
 
 from panoptes.pocs import __version__, hardware
 from panoptes.pocs.utils.logger import get_logger

--- a/src/panoptes/pocs/camera/__init__.py
+++ b/src/panoptes/pocs/camera/__init__.py
@@ -6,10 +6,11 @@ from collections import OrderedDict
 from contextlib import suppress
 
 import requests
+from pydantic import AnyHttpUrl
+
 from panoptes.utils import error
 from panoptes.utils.config.client import get_config
 from panoptes.utils.library import load_module
-from pydantic import AnyHttpUrl
 
 from panoptes.pocs.camera.camera import AbstractCamera  # noqa
 from panoptes.pocs.utils.logger import get_logger

--- a/src/panoptes/pocs/camera/camera.py
+++ b/src/panoptes/pocs/camera/camera.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import astropy.units as u
 from astropy.io import fits
 from astropy.time import Time
+
 from panoptes.utils import error
 from panoptes.utils.images import fits as fits_utils
 from panoptes.utils.images.misc import crop_data

--- a/src/panoptes/pocs/camera/fli.py
+++ b/src/panoptes/pocs/camera/fli.py
@@ -9,6 +9,7 @@ from contextlib import suppress
 import numpy as np
 from astropy import units as u
 from astropy.io import fits
+
 from panoptes.utils import error
 
 from panoptes.pocs.camera import libfliconstants as c

--- a/src/panoptes/pocs/camera/gphoto/canon.py
+++ b/src/panoptes/pocs/camera/gphoto/canon.py
@@ -8,6 +8,7 @@ compatible with the CLI-driven gphoto2 interface.
 from functools import lru_cache
 
 from astropy import units as u
+
 from panoptes.utils import error
 from panoptes.utils.error import PanError
 from panoptes.utils.time import current_time

--- a/src/panoptes/pocs/camera/libasi.py
+++ b/src/panoptes/pocs/camera/libasi.py
@@ -10,6 +10,7 @@ import enum
 
 import numpy as np
 from astropy import units as u
+
 from panoptes.utils import error
 from panoptes.utils.utils import get_quantity_value
 

--- a/src/panoptes/pocs/camera/libfli.py
+++ b/src/panoptes/pocs/camera/libfli.py
@@ -9,6 +9,7 @@ import os
 
 import numpy as np
 from astropy import units as u
+
 from panoptes.utils import error
 from panoptes.utils.utils import get_quantity_value
 

--- a/src/panoptes/pocs/camera/sbig.py
+++ b/src/panoptes/pocs/camera/sbig.py
@@ -7,6 +7,7 @@ SBIG CCD/CMOS cameras and integrate with the AbstractSDKCamera interface.
 from contextlib import suppress
 
 from astropy.io import fits
+
 from panoptes.utils import error
 
 from panoptes.pocs.camera.sbigudrv import INVALID_HANDLE_VALUE, SBIGDriver

--- a/src/panoptes/pocs/camera/sbigudrv.py
+++ b/src/panoptes/pocs/camera/sbigudrv.py
@@ -17,6 +17,7 @@ import time
 import numpy as np
 from astropy import units as u
 from numpy.ctypeslib import as_ctypes
+
 from panoptes.utils import error
 from panoptes.utils.time import CountdownTimer
 from panoptes.utils.utils import get_quantity_value

--- a/src/panoptes/pocs/camera/sdk.py
+++ b/src/panoptes/pocs/camera/sdk.py
@@ -9,6 +9,7 @@ from abc import ABCMeta, abstractmethod
 from contextlib import suppress
 
 from astropy.io import fits
+
 from panoptes.utils import error
 from panoptes.utils.library import load_c_library
 

--- a/src/panoptes/pocs/camera/simulator/ccd.py
+++ b/src/panoptes/pocs/camera/simulator/ccd.py
@@ -12,6 +12,7 @@ from abc import ABC
 from contextlib import suppress
 
 import astropy.units as u
+
 from panoptes.utils.config.client import get_config
 
 from panoptes.pocs.camera.sdk import AbstractSDKCamera, AbstractSDKDriver

--- a/src/panoptes/pocs/camera/simulator/dslr.py
+++ b/src/panoptes/pocs/camera/simulator/dslr.py
@@ -11,6 +11,7 @@ from threading import Timer
 import numpy as np
 from astropy import units as u
 from astropy.io import fits
+
 from panoptes.utils.images import fits as fits_utils
 from panoptes.utils.time import CountdownTimer
 from panoptes.utils.utils import get_quantity_value

--- a/src/panoptes/pocs/camera/zwo.py
+++ b/src/panoptes/pocs/camera/zwo.py
@@ -13,6 +13,7 @@ import numpy as np
 from astropy import units as u
 from astropy.io import fits
 from astropy.time import Time
+
 from panoptes.utils import error
 from panoptes.utils.utils import get_quantity_value
 

--- a/src/panoptes/pocs/core.py
+++ b/src/panoptes/pocs/core.py
@@ -11,6 +11,7 @@ from zoneinfo import ZoneInfo
 
 from astropy import units as u
 from astropy.time import Time
+
 from panoptes.utils.time import CountdownTimer, current_time
 from panoptes.utils.utils import get_free_space
 

--- a/src/panoptes/pocs/dome/protocol_astrohaven_simulator.py
+++ b/src/panoptes/pocs/dome/protocol_astrohaven_simulator.py
@@ -10,8 +10,9 @@ import queue
 import threading
 import time
 
-from panoptes.utils.serial.handlers.protocol_no_op import NoOpSerial
 from serial import serialutil
+
+from panoptes.utils.serial.handlers.protocol_no_op import NoOpSerial
 
 from panoptes.pocs.dome import astrohaven
 from panoptes.pocs.utils.logger import get_logger
@@ -338,7 +339,7 @@ class AstrohavenSerialSimulator(NoOpSerial):
             SerialTimeoutException: In case a write timeout is configured for
                 the port and the time is exceeded.
         """
-        if not isinstance(data, (bytes, bytearray)):
+        if not isinstance(data, bytes | bytearray):
             raise ValueError("write takes bytes")
         data = bytes(data)  # Make sure it can't change.
         self.logger.info(f"AstrohavenSerialSimulator.write({data!r})")

--- a/src/panoptes/pocs/filterwheel/filterwheel.py
+++ b/src/panoptes/pocs/filterwheel/filterwheel.py
@@ -10,6 +10,7 @@ from collections import abc
 from contextlib import suppress
 
 from astropy import units as u
+
 from panoptes.utils import error
 from panoptes.utils.utils import listify
 

--- a/src/panoptes/pocs/filterwheel/simulator.py
+++ b/src/panoptes/pocs/filterwheel/simulator.py
@@ -10,6 +10,7 @@ import random
 import threading
 
 from astropy import units as u
+
 from panoptes.utils import error
 
 from panoptes.pocs.filterwheel import AbstractFilterWheel

--- a/src/panoptes/pocs/filterwheel/zwo.py
+++ b/src/panoptes/pocs/filterwheel/zwo.py
@@ -7,6 +7,7 @@ control ZWO electronic filter wheels.
 from contextlib import suppress
 
 from astropy import units as u
+
 from panoptes.utils import error
 
 from panoptes.pocs.camera.camera import AbstractCamera

--- a/src/panoptes/pocs/focuser/birger.py
+++ b/src/panoptes/pocs/focuser/birger.py
@@ -10,6 +10,7 @@ import re
 from contextlib import suppress
 
 import serial
+
 from panoptes.utils import error
 
 from panoptes.pocs.focuser.serial import AbstractSerialFocuser

--- a/src/panoptes/pocs/focuser/focuser.py
+++ b/src/panoptes/pocs/focuser/focuser.py
@@ -12,10 +12,11 @@ from threading import Event, Thread
 
 import numpy as np
 from astropy.modeling import fitting, models
+from scipy.ndimage import binary_dilation
+
 from panoptes.utils.images import focus as focus_utils
 from panoptes.utils.images.misc import mask_saturated
 from panoptes.utils.time import current_time
-from scipy.ndimage import binary_dilation
 
 from panoptes.pocs.base import PanBase
 from panoptes.pocs.utils.plotting import make_autofocus_plot

--- a/src/panoptes/pocs/images.py
+++ b/src/panoptes/pocs/images.py
@@ -13,6 +13,7 @@ from astropy import units as u
 from astropy.coordinates import FK5, EarthLocation, SkyCoord
 from astropy.io import fits
 from astropy.time import Time
+
 from panoptes.utils.images import fits as fits_utils
 
 from panoptes.pocs.base import PanBase

--- a/src/panoptes/pocs/mount/bisque.py
+++ b/src/panoptes/pocs/mount/bisque.py
@@ -12,6 +12,7 @@ from threading import Lock
 
 from astropy import units as u
 from astropy.coordinates import SkyCoord
+
 from panoptes.utils import error
 
 from panoptes.pocs.mount import AbstractMount

--- a/src/panoptes/pocs/mount/ioptron/base.py
+++ b/src/panoptes/pocs/mount/ioptron/base.py
@@ -11,6 +11,7 @@ from astropy import units as u
 from astropy.coordinates import Latitude, Longitude, SkyCoord
 from astropy.coordinates.earth import EarthLocation
 from astropy.time import Time
+
 from panoptes.utils import error as error
 from panoptes.utils.time import current_time
 

--- a/src/panoptes/pocs/mount/mount.py
+++ b/src/panoptes/pocs/mount/mount.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from astropy import units as u
 from astropy.coordinates import EarthLocation, SkyCoord
+
 from panoptes.utils import error
 from panoptes.utils.serializers import from_yaml
 from panoptes.utils.time import CountdownTimer, current_time

--- a/src/panoptes/pocs/mount/simulator.py
+++ b/src/panoptes/pocs/mount/simulator.py
@@ -8,6 +8,7 @@ import time
 from threading import Timer
 
 from astropy import units as u
+
 from panoptes.utils import error
 from panoptes.utils.time import current_time
 

--- a/src/panoptes/pocs/observatory.py
+++ b/src/panoptes/pocs/observatory.py
@@ -14,6 +14,7 @@ import numpy as np
 from astropy import units as u
 from astropy.coordinates import get_body
 from astropy.io.fits import setval
+
 from panoptes.utils import error
 from panoptes.utils import images as img_utils
 from panoptes.utils.images import fits as fits_utils

--- a/src/panoptes/pocs/scheduler/constraint.py
+++ b/src/panoptes/pocs/scheduler/constraint.py
@@ -12,6 +12,7 @@ from contextlib import suppress
 from astropy import units as u
 from astropy.time import Time
 from dateutil.parser import parse as parse_date
+
 from panoptes.utils import error
 from panoptes.utils import horizon as horizon_utils
 from panoptes.utils.utils import get_quantity_value
@@ -80,7 +81,7 @@ class Altitude(BaseConstraint):
 
         if isinstance(horizon, horizon_utils.Horizon):
             self.horizon_line = horizon.horizon_line
-        elif horizon is None or isinstance(horizon, (int, float, u.Quantity)):
+        elif horizon is None or isinstance(horizon, int | float | u.Quantity):
             obstruction_list = obstructions
             default_horizon = horizon
 

--- a/src/panoptes/pocs/scheduler/field.py
+++ b/src/panoptes/pocs/scheduler/field.py
@@ -6,6 +6,7 @@ additional conveniences for naming and construction from AltAz coordinates.
 
 from astroplan import FixedTarget
 from astropy.coordinates import SkyCoord
+
 from panoptes.utils.time import current_time
 from panoptes.utils.utils import altaz_to_radec
 

--- a/src/panoptes/pocs/scheduler/observation/base.py
+++ b/src/panoptes/pocs/scheduler/observation/base.py
@@ -10,10 +10,11 @@ from contextlib import suppress
 from pathlib import Path
 
 from astropy import units as u
+from pydantic.dataclasses import dataclass
+
 from panoptes.utils import error
 from panoptes.utils.library import load_module
 from panoptes.utils.utils import get_quantity_value, listify
-from pydantic.dataclasses import dataclass
 
 from panoptes.pocs.base import PanBase
 from panoptes.pocs.scheduler import create_constraints_from_config

--- a/src/panoptes/pocs/scheduler/observation/bias.py
+++ b/src/panoptes/pocs/scheduler/observation/bias.py
@@ -7,6 +7,7 @@ counts and set size, storing results under an images/bias subdirectory.
 import os
 
 from astropy import units as u
+
 from panoptes.utils.config.client import get_config
 
 from panoptes.pocs.scheduler.field import Field

--- a/src/panoptes/pocs/scheduler/observation/compound.py
+++ b/src/panoptes/pocs/scheduler/observation/compound.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 from astropy import units as u
+
 from panoptes.utils.utils import get_quantity_value, listify
 
 from panoptes.pocs.scheduler.observation.base import Observation as BaseObservation

--- a/src/panoptes/pocs/scheduler/observation/dark.py
+++ b/src/panoptes/pocs/scheduler/observation/dark.py
@@ -7,6 +7,7 @@ lengths, saving outputs under an images/dark subdirectory.
 import os
 
 from astropy import units as u
+
 from panoptes.utils.utils import get_quantity_value, listify
 
 from panoptes.pocs.scheduler.field import Field

--- a/src/panoptes/pocs/scheduler/scheduler.py
+++ b/src/panoptes/pocs/scheduler/scheduler.py
@@ -14,6 +14,7 @@ from contextlib import suppress
 from astroplan import Observer
 from astropy import units as u
 from astropy.coordinates import get_body
+
 from panoptes.utils import error
 from panoptes.utils.serializers import from_yaml
 from panoptes.utils.time import current_time

--- a/src/panoptes/pocs/sensor/power.py
+++ b/src/panoptes/pocs/sensor/power.py
@@ -15,6 +15,7 @@ from functools import partial
 
 import pandas as pd
 from astropy import units as u
+
 from panoptes.utils import error
 from panoptes.utils.serial.device import SerialDevice, find_serial_port
 from panoptes.utils.serializers import from_json, to_json

--- a/src/panoptes/pocs/sensor/remote.py
+++ b/src/panoptes/pocs/sensor/remote.py
@@ -5,6 +5,7 @@ reading in the local PANOPTES database.
 """
 
 import requests
+
 from panoptes.utils import error
 from panoptes.utils.config.client import get_config
 from panoptes.utils.time import current_time

--- a/src/panoptes/pocs/state/machine.py
+++ b/src/panoptes/pocs/state/machine.py
@@ -1,13 +1,14 @@
 from contextlib import suppress
 from pathlib import Path
 
+from transitions import Machine
+from transitions.extensions.states import Tags as MachineState
+
 from panoptes.utils import error
 from panoptes.utils.config.client import get_config
 from panoptes.utils.library import load_module
 from panoptes.utils.serializers import from_yaml
 from panoptes.utils.utils import listify
-from transitions import Machine
-from transitions.extensions.states import Tags as MachineState
 
 
 class PanStateMachine(Machine):

--- a/src/panoptes/pocs/state/states/default/pointing.py
+++ b/src/panoptes/pocs/state/states/default/pointing.py
@@ -5,6 +5,7 @@ then proceed to 'tracking'.
 """
 
 import numpy as np
+
 from panoptes.utils.time import wait_for_events
 
 from panoptes.pocs.images import Image

--- a/src/panoptes/pocs/state/states/default/ready.py
+++ b/src/panoptes/pocs/state/states/default/ready.py
@@ -5,6 +5,7 @@ transition to 'scheduling' (or to 'parking' if dome open fails).
 """
 
 from astropy import units as u
+
 from panoptes.utils.time import current_time
 
 

--- a/src/panoptes/pocs/utils/alignment.py
+++ b/src/panoptes/pocs/utils/alignment.py
@@ -18,12 +18,13 @@ from astropy.wcs import WCS, FITSFixedWarning
 from matplotlib import pyplot as plt
 from matplotlib.figure import Figure
 from matplotlib.patches import Circle
-from panoptes.utils.error import PanError
-from panoptes.utils.images import fits
-from panoptes.utils.images.fits import get_solve_field, get_wcsinfo, getdata
 from rich import print
 from skimage.feature import canny
 from skimage.transform import hough_circle, hough_circle_peaks
+
+from panoptes.utils.error import PanError
+from panoptes.utils.images import fits
+from panoptes.utils.images.fits import get_solve_field, get_wcsinfo, getdata
 
 warnings.simplefilter("ignore", category=FITSFixedWarning)
 

--- a/src/panoptes/pocs/utils/cli/camera.py
+++ b/src/panoptes/pocs/utils/cli/camera.py
@@ -16,12 +16,6 @@ import numpy as np
 import typer
 from astropy.io import fits
 from astropy.stats import sigma_clipped_stats
-from panoptes.utils.config.client import get_config, set_config
-from panoptes.utils.error import PanError
-from panoptes.utils.images import cr2 as cr2_utils
-from panoptes.utils.images import make_pretty_image
-from panoptes.utils.images.fits import fpack, get_solve_field, getdata
-from panoptes.utils.time import current_time
 from rich import print
 from rich.console import Group
 from rich.live import Live
@@ -37,6 +31,13 @@ from rich.progress import (
 )
 from rich.table import Table
 from rich.text import Text
+
+from panoptes.utils.config.client import get_config, set_config
+from panoptes.utils.error import PanError
+from panoptes.utils.images import cr2 as cr2_utils
+from panoptes.utils.images import make_pretty_image
+from panoptes.utils.images.fits import fpack, get_solve_field, getdata
+from panoptes.utils.time import current_time
 
 from panoptes.pocs.camera import (
     AbstractCamera,

--- a/src/panoptes/pocs/utils/cli/config.py
+++ b/src/panoptes/pocs/utils/cli/config.py
@@ -9,10 +9,11 @@ import subprocess
 
 import typer
 from astropy import units as u
-from panoptes.utils.config.client import get_config, server_is_running, set_config
 from pydantic import BaseModel
 from rich import print, prompt
 from rich.console import Console
+
+from panoptes.utils.config.client import get_config, server_is_running, set_config
 
 from panoptes.pocs.utils.logger import get_logger
 

--- a/src/panoptes/pocs/utils/cli/mount.py
+++ b/src/panoptes/pocs/utils/cli/mount.py
@@ -15,12 +15,13 @@ import typer
 from astropy import units as u
 from astropy.coordinates import AltAz
 from human_readable import time_delta as friendly_time_delta
+from pick import pick
+from rich import print
+
 from panoptes.utils.config.client import set_config
 from panoptes.utils.rs232 import SerialData
 from panoptes.utils.serial.device import get_serial_port_info
 from panoptes.utils.time import CountdownTimer, current_time
-from pick import pick
-from rich import print
 
 from panoptes.pocs.mount import create_mount_from_config
 from panoptes.pocs.mount.ioptron import MountInfo

--- a/src/panoptes/pocs/utils/cli/network.py
+++ b/src/panoptes/pocs/utils/cli/network.py
@@ -13,10 +13,11 @@ from pathlib import Path
 import requests
 import typer
 from google.cloud import firestore, storage
-from panoptes.utils.config.client import get_config, set_config
 from rich import print
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
+
+from panoptes.utils.config.client import get_config, set_config
 
 from panoptes.pocs.utils.cloud import upload_image
 

--- a/src/panoptes/pocs/utils/cli/run.py
+++ b/src/panoptes/pocs/utils/cli/run.py
@@ -12,10 +12,11 @@ from pathlib import Path
 
 import typer
 from astropy.coordinates import SkyCoord
+from rich import print
+
 from panoptes.utils.error import PanError
 from panoptes.utils.time import current_time
 from panoptes.utils.utils import altaz_to_radec, listify
-from rich import print
 
 from panoptes.pocs.core import POCS
 from panoptes.pocs.scheduler.field import Field

--- a/src/panoptes/pocs/utils/coords.py
+++ b/src/panoptes/pocs/utils/coords.py
@@ -7,6 +7,7 @@ from astropy.coordinates import SkyCoord, get_body, solar_system_ephemeris
 from astropy.coordinates.name_resolve import NameResolveError
 from astropy.time import Time
 from astroquery.jplhorizons import Horizons
+
 from panoptes.utils.time import current_time
 
 

--- a/src/panoptes/pocs/utils/location.py
+++ b/src/panoptes/pocs/utils/location.py
@@ -11,6 +11,7 @@ from astroplan import Observer
 from astropy import units as u
 from astropy.coordinates import EarthLocation
 from astropy.utils.iers import Conf as iers_conf
+
 from panoptes.utils import error
 from panoptes.utils.config.client import get_config
 from panoptes.utils.utils import get_quantity_value

--- a/src/panoptes/pocs/utils/plotting.py
+++ b/src/panoptes/pocs/utils/plotting.py
@@ -6,6 +6,7 @@ and focus metric scatter with an optional fit overlay.
 
 from matplotlib.colors import LogNorm
 from matplotlib.figure import Figure
+
 from panoptes.utils.images.plot import add_colorbar, get_palette
 
 from panoptes.pocs.utils.logger import get_logger

--- a/src/panoptes/pocs/utils/service/power.py
+++ b/src/panoptes/pocs/utils/service/power.py
@@ -12,8 +12,9 @@ from threading import Thread
 
 from fastapi import FastAPI
 from fastapi_utils.enums import StrEnum
-from panoptes.utils.config.client import get_config
 from pydantic import BaseModel
+
+from panoptes.utils.config.client import get_config
 
 from panoptes.pocs.sensor.power import PowerBoard
 

--- a/src/panoptes/pocs/utils/service/weather.py
+++ b/src/panoptes/pocs/utils/service/weather.py
@@ -11,8 +11,9 @@ from contextlib import asynccontextmanager, suppress
 from threading import Thread
 
 from fastapi import FastAPI
-from panoptes.utils.config.client import get_config
 from serial.tools.list_ports import comports as get_comports
+
+from panoptes.utils.config.client import get_config
 
 from panoptes.pocs.sensor.weather import WeatherStation
 

--- a/tests/bisque/test_mount.py
+++ b/tests/bisque/test_mount.py
@@ -3,6 +3,7 @@ import os
 import pytest
 from astropy import units as u
 from astropy.coordinates import EarthLocation
+
 from panoptes.utils.config.client import get_config
 from panoptes.utils.time import current_time
 from panoptes.utils.utils import altaz_to_radec

--- a/tests/bisque/test_run.py
+++ b/tests/bisque/test_run.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 from astropy.coordinates import EarthLocation
+
 from panoptes.utils.config.client import get_config
 from panoptes.utils.time import current_time
 from panoptes.utils.utils import altaz_to_radec

--- a/tests/scheduler/test_base_scheduler.py
+++ b/tests/scheduler/test_base_scheduler.py
@@ -2,6 +2,7 @@ import pytest
 from astroplan import Observer
 from astropy import units as u
 from astropy.coordinates import EarthLocation
+
 from panoptes.utils import error
 from panoptes.utils.config.client import get_config, set_config
 from panoptes.utils.serializers import from_yaml

--- a/tests/scheduler/test_dispatch_scheduler.py
+++ b/tests/scheduler/test_dispatch_scheduler.py
@@ -7,6 +7,7 @@ from astroplan import Observer
 from astropy import units as u
 from astropy.coordinates import EarthLocation
 from astropy.time import Time
+
 from panoptes.utils.config.client import get_config
 
 from panoptes.pocs.scheduler.constraint import Duration, MoonAvoidance

--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -1,5 +1,6 @@
 import pytest
 import requests
+
 from panoptes.utils import error
 from panoptes.utils.config.client import set_config
 from panoptes.utils.serializers import to_json

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -8,6 +8,7 @@ import astropy.units as u
 import pytest
 import requests
 from astropy.io import fits
+
 from panoptes.utils import error
 from panoptes.utils.config.client import get_config, set_config
 from panoptes.utils.error import NotFound

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -5,6 +5,7 @@ from astroplan import Observer
 from astropy import units as u
 from astropy.coordinates import EarthLocation, get_body
 from astropy.time import Time
+
 from panoptes.utils import horizon as horizon_utils
 from panoptes.utils.config.client import get_config
 from panoptes.utils.error import PanError

--- a/tests/test_dome_astrohaven.py
+++ b/tests/test_dome_astrohaven.py
@@ -3,6 +3,7 @@ from contextlib import suppress
 
 import pytest
 import serial
+
 from panoptes.utils.config.client import set_config
 
 from panoptes.pocs import hardware

--- a/tests/test_dome_simulator.py
+++ b/tests/test_dome_simulator.py
@@ -1,4 +1,5 @@
 import pytest
+
 from panoptes.utils.config.client import set_config
 
 from panoptes.pocs.dome import create_dome_simulator, simulator

--- a/tests/test_filterwheel.py
+++ b/tests/test_filterwheel.py
@@ -3,6 +3,7 @@ from timeit import timeit
 
 import pytest
 from astropy import units as u
+
 from panoptes.utils import error
 
 from panoptes.pocs.camera.simulator.dslr import Camera as SimCamera

--- a/tests/test_focuser.py
+++ b/tests/test_focuser.py
@@ -3,6 +3,7 @@ from contextlib import suppress
 from threading import Thread
 
 import pytest
+
 from panoptes.utils import error
 from panoptes.utils.config.helpers import load_config
 

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -5,6 +5,7 @@ import tempfile
 import pytest
 from astropy import units as u
 from astropy.coordinates import SkyCoord
+
 from panoptes.utils.error import SolveError, Timeout
 
 from panoptes.pocs.images import Image, OffsetError

--- a/tests/test_ioptron.py
+++ b/tests/test_ioptron.py
@@ -4,6 +4,7 @@ from contextlib import suppress
 import pytest
 from astropy import units as u
 from astropy.coordinates import EarthLocation
+
 from panoptes.utils.config.client import get_config
 
 from panoptes.pocs.images import OffsetError

--- a/tests/test_mount.py
+++ b/tests/test_mount.py
@@ -3,6 +3,7 @@ from contextlib import suppress
 import pytest
 import requests
 from astropy.utils.iers import Conf as iers_conf
+
 from panoptes.utils import error
 from panoptes.utils.config.client import get_config, set_config
 from panoptes.utils.serializers import to_json

--- a/tests/test_mount_simulator.py
+++ b/tests/test_mount_simulator.py
@@ -3,6 +3,7 @@ import os
 import pytest
 from astropy import units as u
 from astropy.coordinates import EarthLocation, SkyCoord
+
 from panoptes.utils import error
 from panoptes.utils.config.client import get_config
 from panoptes.utils.utils import altaz_to_radec

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -5,6 +5,7 @@ import pytest
 import requests
 from astropy.coordinates import get_body
 from astropy.time import Time
+
 from panoptes.utils import error
 from panoptes.utils.config.client import set_config
 from panoptes.utils.serializers import to_json

--- a/tests/test_pocs.py
+++ b/tests/test_pocs.py
@@ -5,6 +5,7 @@ import time
 import pytest
 import requests
 from astropy import units as u
+
 from panoptes.utils.config.client import set_config
 from panoptes.utils.serializers import to_json, to_yaml
 from panoptes.utils.time import current_time

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -2,6 +2,7 @@
 
 import pytest
 import responses
+
 from panoptes.utils import error
 
 from panoptes.pocs.sensor import power, remote

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+
 from panoptes.utils import error
 from panoptes.utils.serializers import to_yaml
 


### PR DESCRIPTION
Add section to `pyproject.toml` to specify sort order of `panoptes` so that `panoptes.pocs` will sort after `panoptes.utils` within this repo.