### PR TITLE
Add `pocs weather setup` command for AAG CloudWatcher udev configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added `pocs weather setup` subcommand that detects a newly-connected weather station USB serial device and writes a udev rule to `/etc/udev/rules.d/92-panoptes-weather.rules` creating a stable `/dev/weather` symlink. Supports optional power-cycling via the power service (`--power-cycle`) or interactive prompting for manual power-cycle.
+- Added `pocs weather setup` subcommand that scans `/dev/ttyUSB*` ports (skipping any claimed by `/dev/mount`), probes each with the AAG CloudWatcher serial handshake, and writes a udev rule to `/etc/udev/rules.d/92-panoptes-weather.rules` creating a stable `/dev/weather` symlink.
 
 ## 0.8.2 - 2026-04-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- Added `pocs weather setup` subcommand that detects a newly-connected weather station USB serial device and writes a udev rule to `/etc/udev/rules.d/92-panoptes-weather.rules` creating a stable `/dev/weather` symlink. Supports optional power-cycling via the power service (`--power-cycle`) or interactive prompting for manual power-cycle.
+
 ## 0.8.2 - 2026-04-15
 
 ### Added

--- a/conftest.py
+++ b/conftest.py
@@ -56,6 +56,7 @@ os.chmod(log_file_path, stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)
 def pytest_configure(config):
     """Set up the testing."""
     from astropy.utils.iers import conf
+
     conf.auto_max_age = None
     logger.info("Setting up the config server.")
     config_file = "tests/testing.yaml"

--- a/src/panoptes/pocs/camera/camera.py
+++ b/src/panoptes/pocs/camera/camera.py
@@ -627,10 +627,7 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
             name=f"{self.name}PollExposureThread",
             target=self._poll_exposure,
             args=(readout_args, seconds),
-            kwargs=dict(
-                timeout=timeout_duration,
-                interval=get_quantity_value(self.readout_time, u.second)
-            ),
+            kwargs=dict(timeout=timeout_duration, interval=get_quantity_value(self.readout_time, u.second)),
         )
         readout_thread.start()
 
@@ -883,9 +880,9 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         """
         if timeout is None:
             timer_duration = (
-                get_quantity_value(self.timeout, u.second) +
-                get_quantity_value(self.readout_time, u.second) +
-                get_quantity_value(exposure_time, u.second)
+                get_quantity_value(self.timeout, u.second)
+                + get_quantity_value(self.readout_time, u.second)
+                + get_quantity_value(exposure_time, u.second)
             )
         else:
             timer_duration = get_quantity_value(timeout, u.second)

--- a/src/panoptes/pocs/utils/cli/weather.py
+++ b/src/panoptes/pocs/utils/cli/weather.py
@@ -404,8 +404,7 @@ def setup_weather(
         subprocess.run(
             ["sudo", "udevadm", "control", "--reload"],
             check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             text=True,
         )
         console.print(

--- a/src/panoptes/pocs/utils/cli/weather.py
+++ b/src/panoptes/pocs/utils/cli/weather.py
@@ -341,6 +341,10 @@ def setup_weather(
     # Retrieve USB VID / PID / serial number for the udev rule.
     # ------------------------------------------------------------------
     port_info = port_info_map.get(found_device)
+    if port_info is None:
+        resolved_found_device = str(Path(found_device).resolve())
+        if resolved_found_device != found_device:
+            port_info = port_info_map.get(resolved_found_device)
     if port_info is None or port_info.vid is None or port_info.pid is None:
         console.print(
             "[bold red]Could not read USB vendor/product ID from the device.[/bold red]\n"
@@ -397,14 +401,24 @@ def setup_weather(
     # Reload udev rules so the symlink is active on the next plug-in.
     # ------------------------------------------------------------------
     try:
-        subprocess.run(["sudo", "udevadm", "control", "--reload"], check=True)
+        subprocess.run(
+            ["sudo", "udevadm", "control", "--reload"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
         console.print(
             "[green]✅ udev rules reloaded.[/green] Unplug and re-plug the weather station "
             "to activate the [bold]/dev/weather[/bold] symlink."
         )
     except subprocess.CalledProcessError as exc:
+        error_output = (exc.stderr or "").strip()
+        stdout_output = (exc.stdout or "").strip()
+        details = error_output or stdout_output
+        detail_message = f"\n  {details}" if details else ""
         console.print(
-            f"[yellow]Warning: failed to reload udev rules: {exc}[/yellow]\n"
+            f"[yellow]Warning: failed to reload udev rules: {exc}[/yellow]{detail_message}\n"
             "Run [bold]sudo udevadm control --reload[/bold] manually."
         )
 

--- a/src/panoptes/pocs/utils/cli/weather.py
+++ b/src/panoptes/pocs/utils/cli/weather.py
@@ -1,11 +1,15 @@
 """Typer CLI for interacting with the PANOPTES weather station service.
 
-Provides commands to query status/config and to restart the service.
+Provides commands to query status/config, restart the service, and set up
+the weather station udev rules for persistent device naming.
 """
 
 import subprocess
+import time
 from dataclasses import dataclass
 from datetime import datetime
+from pathlib import Path
+from typing import Annotated
 
 import human_readable
 import requests
@@ -13,6 +17,8 @@ import typer
 from rich import print
 from rich.console import Console
 from rich.table import Table
+
+from panoptes.utils.serial.device import get_serial_port_info
 
 
 @dataclass
@@ -242,6 +248,199 @@ def get_page(page, base_url):
         console.print("\n[green]Try:[/green]")
         console.print("  • Running [bold]weather restart[/bold] to restart the weather service")
         exit(1)
+
+
+@app.command(name="setup")
+def setup_weather(
+    power_cycle: Annotated[
+        bool,
+        typer.Option(
+            help="Attempt to power-cycle the weather station via the power service before detection.",
+        ),
+    ] = False,
+    power_host: str = typer.Option("localhost", help="Power service host for power-cycling."),
+    power_port: str = typer.Option("6564", help="Power service port for power-cycling."),
+    relay: str = typer.Option("weather_station", help="Power relay label for the weather station."),
+    wait: int = typer.Option(5, help="Seconds to wait between power off and power on during power-cycle."),
+    timeout: int = typer.Option(30, help="Seconds to wait for the device to appear after power-on."),
+):
+    """Set up the weather station udev rules for persistent device naming.
+
+    This command detects the weather station USB serial device and writes a udev
+    rule that creates a stable ``/dev/weather`` symlink.  Detection works by
+    snapshotting the available serial ports, optionally power-cycling the station,
+    and then watching for a newly-appeared port.
+
+    The generated rule file is written to ``/etc/udev/rules.d/`` via ``sudo``,
+    then ``udevadm`` is invoked to reload rules so the symlink is created
+    immediately on the next plug-in.
+
+    Args:
+        power_cycle: When True, toggle the relay named ``relay`` off then on via
+            the power service at ``power_host:power_port`` before detecting the
+            device.
+        power_host: Hostname or IP address of the running power service.
+        power_port: TCP port of the running power service.
+        relay: Label (or index) of the power relay connected to the weather
+            station.
+        wait: Seconds to wait with the relay off before turning it back on.
+        timeout: Seconds to wait for the new serial device to appear.
+
+    Returns:
+        None
+    """
+    console = Console()
+
+    # ------------------------------------------------------------------
+    # Snapshot ports that already exist before we do anything.
+    # ------------------------------------------------------------------
+    before_ports = {p.device for p in get_serial_port_info()}
+
+    # ------------------------------------------------------------------
+    # Power-cycle via the power service if requested.
+    # ------------------------------------------------------------------
+    if power_cycle:
+        power_url = f"http://{power_host}:{power_port}/control"
+        console.print(f"[cyan]Power-cycling relay [bold]{relay}[/bold] via {power_url}...[/cyan]")
+        try:
+            resp = requests.post(power_url, json={"relay": relay, "command": "turn_off"}, timeout=10)
+            if not resp.ok:
+                console.print(f"[yellow]Warning: power-off returned {resp.status_code}.[/yellow]")
+        except requests.exceptions.ConnectionError:
+            console.print(
+                f"[yellow]Warning: could not reach power service at {power_url}. "
+                "Continuing without power-cycle.[/yellow]"
+            )
+        else:
+            console.print(f"[dim]Waiting {wait}s with relay off...[/dim]")
+            time.sleep(wait)
+            try:
+                resp = requests.post(power_url, json={"relay": relay, "command": "turn_on"}, timeout=10)
+                if not resp.ok:
+                    console.print(f"[yellow]Warning: power-on returned {resp.status_code}.[/yellow]")
+                else:
+                    console.print("[green]Relay back on.[/green]")
+            except requests.exceptions.ConnectionError:
+                console.print(
+                    f"[yellow]Warning: could not reach power service at {power_url} for power-on.[/yellow]"
+                )
+    else:
+        console.print(
+            "[bold yellow]Please power-cycle the weather station now.[/bold yellow]\n"
+            "You can do this by running:\n"
+            f"  [cyan]pocs power off {relay} && pocs power on {relay}[/cyan]\n"
+            "or by manually unplugging and re-plugging the USB cable."
+        )
+        typer.confirm("Press Enter once the weather station has been power-cycled", default=True)
+
+    # ------------------------------------------------------------------
+    # Poll for a new serial port to appear.
+    # ------------------------------------------------------------------
+    new_port = None
+    deadline = time.monotonic() + timeout
+    with console.status(f"Waiting up to {timeout}s for a new serial device...", spinner="dots"):
+        while time.monotonic() < deadline:
+            current_ports = {p.device for p in get_serial_port_info()}
+            new_devices = current_ports - before_ports
+            if new_devices:
+                new_device = new_devices.pop()
+                # Find the full port info object.
+                for p in get_serial_port_info():
+                    if p.device == new_device:
+                        new_port = p
+                        break
+                break
+            time.sleep(1)
+
+    if new_port is None:
+        console.print(
+            f"[bold red]No new serial device detected within {timeout}s.[/bold red]\n"
+            "Please check that the weather station is connected and powered on,\n"
+            "then run this command again."
+        )
+        raise typer.Exit(code=1)
+
+    console.print(f"[green]Detected new device:[/green] [bold]{new_port.device}[/bold]")
+    if new_port.description:
+        console.print(f"  Description : {new_port.description}")
+    if new_port.manufacturer:
+        console.print(f"  Manufacturer: {new_port.manufacturer}")
+
+    # ------------------------------------------------------------------
+    # Build the udev rule string.
+    # ------------------------------------------------------------------
+    if new_port.vid is None or new_port.pid is None:
+        console.print(
+            "[bold red]Could not read USB vendor/product ID from the device.[/bold red]\n"
+            "The udev rule requires idVendor and idProduct; these are only\n"
+            "available for USB-attached devices."
+        )
+        raise typer.Exit(code=1)
+
+    udev_str = (
+        f'ACTION=="add", '
+        f'SUBSYSTEM=="tty", '
+        f'ATTRS{{idVendor}}=="{new_port.vid:04x}", '
+        f'ATTRS{{idProduct}}=="{new_port.pid:04x}", '
+    )
+    if new_port.serial_number:
+        udev_str += f'ATTRS{{serial}}=="{new_port.serial_number}", '
+    udev_str += 'SYMLINK+="weather"\n'
+
+    console.print("\n[bold]udev rule that will be written:[/bold]")
+    console.print(f"  [cyan]{udev_str.strip()}[/cyan]\n")
+
+    # ------------------------------------------------------------------
+    # Write the rule file via sudo.
+    # ------------------------------------------------------------------
+    udev_rules_name = "92-panoptes-weather.rules"
+    udev_rules_dest = Path(f"/etc/udev/rules.d/{udev_rules_name}")
+
+    try:
+        subprocess.run(
+            ["sudo", "tee", str(udev_rules_dest)],
+            input=udev_str.encode(),
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+    except subprocess.CalledProcessError as exc:
+        console.print(
+            f"[bold red]Failed to write udev rule to {udev_rules_dest}.[/bold red]\n"
+            f"  {exc.stderr.decode().strip()}"
+        )
+        raise typer.Exit(code=1)
+
+    console.print(f"Wrote udev rule to [green]{udev_rules_dest}[/green].")
+
+    # ------------------------------------------------------------------
+    # Reload udev rules so the symlink is active on next plug-in.
+    # ------------------------------------------------------------------
+    try:
+        subprocess.run(["sudo", "udevadm", "control", "--reload"], check=True)
+        console.print(
+            "[green]✅ udev rules reloaded.[/green] Unplug and re-plug the weather station "
+            "to activate the [bold]/dev/weather[/bold] symlink."
+        )
+    except subprocess.CalledProcessError as exc:
+        console.print(
+            f"[yellow]Warning: failed to reload udev rules: {exc}[/yellow]\n"
+            "Run [bold]sudo udevadm control --reload[/bold] manually."
+        )
+
+    # ------------------------------------------------------------------
+    # Optionally update the config server.
+    # ------------------------------------------------------------------
+    try:
+        from panoptes.utils.config.client import set_config
+
+        set_config("environment.weather.serial_port", "/dev/weather")
+        console.print("[green]Updated config:[/green] environment.weather.serial_port → /dev/weather")
+    except Exception as exc:
+        console.print(
+            f"[yellow]Could not update config server ({exc}). "
+            "You may need to set environment.weather.serial_port to /dev/weather manually.[/yellow]"
+        )
 
 
 @app.command(help="Restart the weather station service via supervisorctl")

--- a/src/panoptes/pocs/utils/cli/weather.py
+++ b/src/panoptes/pocs/utils/cli/weather.py
@@ -4,21 +4,20 @@ Provides commands to query status/config, restart the service, and set up
 the weather station udev rules for persistent device naming.
 """
 
+import glob as _glob
 import subprocess
-import time
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Annotated
 
 import human_readable
 import requests
+import serial
+import serial.tools.list_ports
 import typer
 from rich import print
 from rich.console import Console
 from rich.table import Table
-
-from panoptes.utils.serial.device import get_serial_port_info
 
 
 @dataclass
@@ -252,39 +251,29 @@ def get_page(page, base_url):
 
 @app.command(name="setup")
 def setup_weather(
-    power_cycle: Annotated[
-        bool,
-        typer.Option(
-            help="Attempt to power-cycle the weather station via the power service before detection.",
-        ),
-    ] = False,
-    power_host: str = typer.Option("localhost", help="Power service host for power-cycling."),
-    power_port: str = typer.Option("6564", help="Power service port for power-cycling."),
-    relay: str = typer.Option("weather_station", help="Power relay label for the weather station."),
-    wait: int = typer.Option(5, help="Seconds to wait between power off and power on during power-cycle."),
-    timeout: int = typer.Option(30, help="Seconds to wait for the device to appear after power-on."),
+    port_glob: str = typer.Option("/dev/ttyUSB*", help="Glob pattern for USB serial ports to scan."),
+    baud_rate: int = typer.Option(9600, help="Baud rate for the weather station serial port."),
+    read_timeout: float = typer.Option(2.0, help="Read timeout in seconds when probing each port."),
 ):
-    """Set up the weather station udev rules for persistent device naming.
+    """Scan USB serial ports for an AAG CloudWatcher and write a udev rule.
 
-    This command detects the weather station USB serial device and writes a udev
-    rule that creates a stable ``/dev/weather`` symlink.  Detection works by
-    snapshotting the available serial ports, optionally power-cycling the station,
-    and then watching for a newly-appeared port.
+    Each port matching ``port_glob`` is opened and sent the AAG
+    ``GET_INTERNAL_NAME`` command (``A!``).  A port that responds with the
+    expected ``!N `` response code is identified as the weather station.
 
-    The generated rule file is written to ``/etc/udev/rules.d/`` via ``sudo``,
-    then ``udevadm`` is invoked to reload rules so the symlink is created
-    immediately on the next plug-in.
+    Once found, a udev rule is written to
+    ``/etc/udev/rules.d/92-panoptes-weather.rules`` that creates a stable
+    ``/dev/weather`` symlink keyed on the device's USB vendor ID, product ID,
+    and serial number (when present).  ``udevadm`` is then called to reload
+    rules immediately.
+
+    The config server key ``environment.weather.serial_port`` is updated to
+    ``/dev/weather`` if the config server is reachable.
 
     Args:
-        power_cycle: When True, toggle the relay named ``relay`` off then on via
-            the power service at ``power_host:power_port`` before detecting the
-            device.
-        power_host: Hostname or IP address of the running power service.
-        power_port: TCP port of the running power service.
-        relay: Label (or index) of the power relay connected to the weather
-            station.
-        wait: Seconds to wait with the relay off before turning it back on.
-        timeout: Seconds to wait for the new serial device to appear.
+        port_glob: Shell glob for candidate ports, e.g. ``/dev/ttyUSB*``.
+        baud_rate: Serial baud rate; the AAG CloudWatcher uses 9600.
+        read_timeout: Per-port read timeout in seconds.
 
     Returns:
         None
@@ -292,84 +281,54 @@ def setup_weather(
     console = Console()
 
     # ------------------------------------------------------------------
-    # Snapshot ports that already exist before we do anything.
+    # Enumerate candidate ports.
     # ------------------------------------------------------------------
-    before_ports = {p.device for p in get_serial_port_info()}
+    port_paths = sorted(_glob.glob(port_glob))
+    if not port_paths:
+        console.print(f"[bold red]No devices found matching {port_glob!r}.[/bold red]")
+        raise typer.Exit(code=1)
+
+    console.print(f"Scanning {len(port_paths)} port(s): {', '.join(port_paths)}")
+
+    # Build a VID/PID/serial map from pyserial's port enumeration.
+    port_info_map = {p.device: p for p in serial.tools.list_ports.comports()}
 
     # ------------------------------------------------------------------
-    # Power-cycle via the power service if requested.
+    # Probe each port for the AAG handshake.
     # ------------------------------------------------------------------
-    if power_cycle:
-        power_url = f"http://{power_host}:{power_port}/control"
-        console.print(f"[cyan]Power-cycling relay [bold]{relay}[/bold] via {power_url}...[/cyan]")
+    found_device: str | None = None
+    for device in port_paths:
+        console.print(f"  Trying [cyan]{device}[/cyan]...", end=" ")
         try:
-            resp = requests.post(power_url, json={"relay": relay, "command": "turn_off"}, timeout=10)
-            if not resp.ok:
-                console.print(f"[yellow]Warning: power-off returned {resp.status_code}.[/yellow]")
-        except requests.exceptions.ConnectionError:
-            console.print(
-                f"[yellow]Warning: could not reach power service at {power_url}. "
-                "Continuing without power-cycle.[/yellow]"
-            )
-        else:
-            console.print(f"[dim]Waiting {wait}s with relay off...[/dim]")
-            time.sleep(wait)
-            try:
-                resp = requests.post(power_url, json={"relay": relay, "command": "turn_on"}, timeout=10)
-                if not resp.ok:
-                    console.print(f"[yellow]Warning: power-on returned {resp.status_code}.[/yellow]")
-                else:
-                    console.print("[green]Relay back on.[/green]")
-            except requests.exceptions.ConnectionError:
-                console.print(
-                    f"[yellow]Warning: could not reach power service at {power_url} for power-on.[/yellow]"
-                )
-    else:
-        console.print(
-            "[bold yellow]Please power-cycle the weather station now.[/bold yellow]\n"
-            "You can do this by running:\n"
-            f"  [cyan]pocs power off {relay} && pocs power on {relay}[/cyan]\n"
-            "or by manually unplugging and re-plugging the USB cable."
-        )
-        typer.confirm("Press Enter once the weather station has been power-cycled", default=True)
-
-    # ------------------------------------------------------------------
-    # Poll for a new serial port to appear.
-    # ------------------------------------------------------------------
-    new_port = None
-    deadline = time.monotonic() + timeout
-    with console.status(f"Waiting up to {timeout}s for a new serial device...", spinner="dots"):
-        while time.monotonic() < deadline:
-            current_ports = {p.device for p in get_serial_port_info()}
-            new_devices = current_ports - before_ports
-            if new_devices:
-                new_device = new_devices.pop()
-                # Find the full port info object.
-                for p in get_serial_port_info():
-                    if p.device == new_device:
-                        new_port = p
-                        break
+            with serial.Serial(device, baudrate=baud_rate, timeout=read_timeout) as ser:
+                ser.reset_input_buffer()
+                ser.reset_output_buffer()
+                # AAG GET_INTERNAL_NAME: command value 'A' + delimiter '!'
+                ser.write(b"A!")
+                response = ser.read(30)
+            if b"!N " in response:
+                console.print("[green]AAG CloudWatcher detected![/green]")
+                found_device = device
                 break
-            time.sleep(1)
+            else:
+                console.print("[dim]no response[/dim]")
+        except serial.SerialException as exc:
+            console.print(f"[dim]error: {exc}[/dim]")
+        except Exception as exc:
+            console.print(f"[dim]unexpected error: {exc}[/dim]")
 
-    if new_port is None:
+    if found_device is None:
         console.print(
-            f"[bold red]No new serial device detected within {timeout}s.[/bold red]\n"
-            "Please check that the weather station is connected and powered on,\n"
-            "then run this command again."
+            "[bold red]AAG CloudWatcher not found on any scanned port.[/bold red]\n"
+            "Make sure the weather station is connected and powered on."
         )
         raise typer.Exit(code=1)
 
-    console.print(f"[green]Detected new device:[/green] [bold]{new_port.device}[/bold]")
-    if new_port.description:
-        console.print(f"  Description : {new_port.description}")
-    if new_port.manufacturer:
-        console.print(f"  Manufacturer: {new_port.manufacturer}")
-
     # ------------------------------------------------------------------
-    # Build the udev rule string.
+    # Retrieve USB VID / PID / serial number for the udev rule.
     # ------------------------------------------------------------------
-    if new_port.vid is None or new_port.pid is None:
+    port_info = port_info_map.get(found_device)
+    if port_info is None or port_info.vid is None or port_info.pid is None:
         console.print(
             "[bold red]Could not read USB vendor/product ID from the device.[/bold red]\n"
             "The udev rule requires idVendor and idProduct; these are only\n"
@@ -377,17 +336,25 @@ def setup_weather(
         )
         raise typer.Exit(code=1)
 
+    if port_info.description:
+        console.print(f"  Description : {port_info.description}")
+    if port_info.manufacturer:
+        console.print(f"  Manufacturer: {port_info.manufacturer}")
+
+    # ------------------------------------------------------------------
+    # Build the udev rule string.
+    # ------------------------------------------------------------------
     udev_str = (
         f'ACTION=="add", '
         f'SUBSYSTEM=="tty", '
-        f'ATTRS{{idVendor}}=="{new_port.vid:04x}", '
-        f'ATTRS{{idProduct}}=="{new_port.pid:04x}", '
+        f'ATTRS{{idVendor}}=="{port_info.vid:04x}", '
+        f'ATTRS{{idProduct}}=="{port_info.pid:04x}", '
     )
-    if new_port.serial_number:
-        udev_str += f'ATTRS{{serial}}=="{new_port.serial_number}", '
+    if port_info.serial_number:
+        udev_str += f'ATTRS{{serial}}=="{port_info.serial_number}", '
     udev_str += 'SYMLINK+="weather"\n'
 
-    console.print("\n[bold]udev rule that will be written:[/bold]")
+    console.print("\n[bold]udev rule to be written:[/bold]")
     console.print(f"  [cyan]{udev_str.strip()}[/cyan]\n")
 
     # ------------------------------------------------------------------
@@ -414,7 +381,7 @@ def setup_weather(
     console.print(f"Wrote udev rule to [green]{udev_rules_dest}[/green].")
 
     # ------------------------------------------------------------------
-    # Reload udev rules so the symlink is active on next plug-in.
+    # Reload udev rules so the symlink is active on the next plug-in.
     # ------------------------------------------------------------------
     try:
         subprocess.run(["sudo", "udevadm", "control", "--reload"], check=True)
@@ -429,7 +396,7 @@ def setup_weather(
         )
 
     # ------------------------------------------------------------------
-    # Optionally update the config server.
+    # Update the config server if reachable.
     # ------------------------------------------------------------------
     try:
         from panoptes.utils.config.client import set_config

--- a/src/panoptes/pocs/utils/cli/weather.py
+++ b/src/panoptes/pocs/utils/cli/weather.py
@@ -293,11 +293,24 @@ def setup_weather(
     # Build a VID/PID/serial map from pyserial's port enumeration.
     port_info_map = {p.device: p for p in serial.tools.list_ports.comports()}
 
+    # Resolve /dev/mount symlink so we can skip that port during probing.
+    mount_device: str | None = None
+    mount_symlink = Path("/dev/mount")
+    if mount_symlink.is_symlink():
+        try:
+            mount_device = str(mount_symlink.resolve())
+            console.print(f"[dim]/dev/mount → {mount_device}; skipping that port[/dim]")
+        except OSError:
+            pass
+
     # ------------------------------------------------------------------
     # Probe each port for the AAG handshake.
     # ------------------------------------------------------------------
     found_device: str | None = None
     for device in port_paths:
+        if mount_device and Path(device).resolve() == Path(mount_device):
+            console.print(f"  Skipping [cyan]{device}[/cyan] (in use by mount)")
+            continue
         console.print(f"  Trying [cyan]{device}[/cyan]...", end=" ")
         try:
             with serial.Serial(device, baudrate=baud_rate, timeout=read_timeout) as ser:

--- a/tests/utils/test_weather_cli.py
+++ b/tests/utils/test_weather_cli.py
@@ -1,5 +1,6 @@
 """Tests for the `pocs weather` CLI commands, including the `setup` subcommand."""
 
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -265,3 +266,225 @@ def test_setup_skips_mount_port(mock_glob, mock_serial_cls, mock_comports, mock_
     # serial.Serial should have been called exactly once (for USB1, not USB0)
     assert mock_serial_cls.call_count == 1
     assert mock_serial_cls.call_args[0][0] == "/dev/ttyUSB1"
+
+
+# ---------------------------------------------------------------------------
+# setup — OSError when resolving /dev/mount is silently ignored
+# ---------------------------------------------------------------------------
+
+
+@patch("subprocess.run")
+@patch("panoptes.pocs.utils.cli.weather.serial.tools.list_ports.comports")
+@patch("panoptes.pocs.utils.cli.weather.serial.Serial")
+@patch("panoptes.pocs.utils.cli.weather._glob.glob")
+def test_setup_mount_symlink_resolve_oserror(mock_glob, mock_serial_cls, mock_comports, mock_run, cli_runner):
+    """/dev/mount exists but resolve() raises OSError — probing continues normally."""
+    mock_glob.return_value = ["/dev/ttyUSB0"]
+    mock_comports.return_value = [_make_port_info("/dev/ttyUSB0")]
+    mock_serial_cls.return_value = _make_serial_cm(b"!N CloudWatcher  !\x11            0")
+    mock_run.return_value = MagicMock(returncode=0, stderr=b"")
+
+    broken_symlink = MagicMock(spec=Path)
+    broken_symlink.is_symlink.return_value = True
+    broken_symlink.resolve.side_effect = OSError("dangling symlink")
+
+    with (
+        patch("panoptes.pocs.utils.cli.weather.Path") as mock_path_cls,
+        patch("panoptes.utils.config.client.set_config"),
+    ):
+
+        def path_side_effect(arg):
+            if arg == "/dev/mount":
+                return broken_symlink
+            return Path(arg)
+
+        mock_path_cls.side_effect = path_side_effect
+        result = cli_runner.invoke(app, ["weather", "setup"])
+
+    assert result.exit_code == 0, result.output
+    assert "AAG CloudWatcher detected" in result.output
+
+
+# ---------------------------------------------------------------------------
+# setup — generic Exception in probe loop is caught and port is skipped
+# ---------------------------------------------------------------------------
+
+
+@patch("panoptes.pocs.utils.cli.weather.serial.tools.list_ports.comports")
+@patch("panoptes.pocs.utils.cli.weather.serial.Serial")
+@patch("panoptes.pocs.utils.cli.weather._glob.glob")
+def test_setup_generic_exception_skipped(mock_glob, mock_serial_cls, mock_comports, cli_runner):
+    """Generic Exception (not SerialException) during probe is caught; port is skipped."""
+    mock_glob.return_value = ["/dev/ttyUSB0"]
+    mock_comports.return_value = [_make_port_info("/dev/ttyUSB0")]
+    mock_serial_cls.side_effect = RuntimeError("unexpected hardware error")
+
+    result = cli_runner.invoke(app, ["weather", "setup"])
+
+    assert result.exit_code != 0
+    assert "unexpected error" in result.output
+
+
+# ---------------------------------------------------------------------------
+# setup — port_info found via resolved path (symlink fallback)
+# ---------------------------------------------------------------------------
+
+
+@patch("subprocess.run")
+@patch("panoptes.pocs.utils.cli.weather.serial.tools.list_ports.comports")
+@patch("panoptes.pocs.utils.cli.weather.serial.Serial")
+@patch("panoptes.pocs.utils.cli.weather._glob.glob")
+def test_setup_port_info_via_resolved_path(mock_glob, mock_serial_cls, mock_comports, mock_run, cli_runner):
+    """When comports reports the real path but glob yields a symlink, the port_info
+    is found by resolving the found device path."""
+    mock_glob.return_value = ["/dev/ttyUSB-sym"]
+    # comports reports the resolved (real) path, not the symlink
+    mock_comports.return_value = [_make_port_info("/dev/ttyUSB-real")]
+    mock_serial_cls.return_value = _make_serial_cm(b"!N CloudWatcher  !\x11            0")
+    mock_run.return_value = MagicMock(returncode=0, stderr=b"")
+
+    with (
+        patch("panoptes.pocs.utils.cli.weather.Path") as mock_path_cls,
+        patch("panoptes.utils.config.client.set_config"),
+    ):
+
+        def path_side_effect(arg):
+            if arg == "/dev/mount":
+                m = MagicMock(spec=Path)
+                m.is_symlink.return_value = False
+                return m
+            if arg == "/dev/ttyUSB-sym":
+                m = MagicMock(spec=Path)
+                m.resolve.return_value = Path("/dev/ttyUSB-real")
+                return m
+            return Path(arg)
+
+        mock_path_cls.side_effect = path_side_effect
+        result = cli_runner.invoke(app, ["weather", "setup"])
+
+    assert result.exit_code == 0, result.output
+    assert "AAG CloudWatcher detected" in result.output
+
+
+# ---------------------------------------------------------------------------
+# setup — port_info with no description or manufacturer (branch coverage)
+# ---------------------------------------------------------------------------
+
+
+@patch("subprocess.run")
+@patch("panoptes.pocs.utils.cli.weather.serial.tools.list_ports.comports")
+@patch("panoptes.pocs.utils.cli.weather.serial.Serial")
+@patch("panoptes.pocs.utils.cli.weather._glob.glob")
+def test_setup_no_description_no_manufacturer(
+    mock_glob, mock_serial_cls, mock_comports, mock_run, cli_runner
+):
+    """When the port has no description or manufacturer the info lines are omitted."""
+    mock_glob.return_value = ["/dev/ttyUSB0"]
+    mock_comports.return_value = [_make_port_info("/dev/ttyUSB0", description=None, manufacturer=None)]
+    mock_serial_cls.return_value = _make_serial_cm(b"!N CloudWatcher  !\x11            0")
+    mock_run.return_value = MagicMock(returncode=0, stderr=b"")
+
+    with patch("panoptes.utils.config.client.set_config"):
+        result = cli_runner.invoke(app, ["weather", "setup"])
+
+    assert result.exit_code == 0, result.output
+    assert "Description" not in result.output
+    assert "Manufacturer" not in result.output
+    assert 'SYMLINK+="weather"' in result.output
+
+
+# ---------------------------------------------------------------------------
+# setup — sudo tee fails → non-zero exit
+# ---------------------------------------------------------------------------
+
+
+@patch("panoptes.pocs.utils.cli.weather.serial.tools.list_ports.comports")
+@patch("panoptes.pocs.utils.cli.weather.serial.Serial")
+@patch("panoptes.pocs.utils.cli.weather._glob.glob")
+def test_setup_tee_fails(mock_glob, mock_serial_cls, mock_comports, cli_runner):
+    """CalledProcessError from sudo tee produces an error message and exits non-zero."""
+    mock_glob.return_value = ["/dev/ttyUSB0"]
+    mock_comports.return_value = [_make_port_info("/dev/ttyUSB0")]
+    mock_serial_cls.return_value = _make_serial_cm(b"!N CloudWatcher  !\x11            0")
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.side_effect = subprocess.CalledProcessError(
+            1, ["sudo", "tee", "/etc/udev/rules.d/92-panoptes-weather.rules"], stderr=b"Permission denied"
+        )
+        result = cli_runner.invoke(app, ["weather", "setup"])
+
+    assert result.exit_code != 0
+    assert "Failed to write" in result.output
+
+
+# ---------------------------------------------------------------------------
+# setup — udevadm reload fails → warning only, exit 0
+# ---------------------------------------------------------------------------
+
+
+@patch("panoptes.pocs.utils.cli.weather.serial.tools.list_ports.comports")
+@patch("panoptes.pocs.utils.cli.weather.serial.Serial")
+@patch("panoptes.pocs.utils.cli.weather._glob.glob")
+def test_setup_udevadm_reload_fails(mock_glob, mock_serial_cls, mock_comports, cli_runner):
+    """CalledProcessError from udevadm prints a warning but does not exit non-zero."""
+    mock_glob.return_value = ["/dev/ttyUSB0"]
+    mock_comports.return_value = [_make_port_info("/dev/ttyUSB0")]
+    mock_serial_cls.return_value = _make_serial_cm(b"!N CloudWatcher  !\x11            0")
+
+    tee_ok = MagicMock(returncode=0, stderr=b"")
+    udevadm_err = subprocess.CalledProcessError(
+        1, ["sudo", "udevadm", "control", "--reload"], stderr="rules directory not found"
+    )
+
+    with (
+        patch("subprocess.run", side_effect=[tee_ok, udevadm_err]),
+        patch("panoptes.utils.config.client.set_config"),
+    ):
+        result = cli_runner.invoke(app, ["weather", "setup"])
+
+    assert result.exit_code == 0, result.output
+    assert "failed to reload" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# setup — config server update fails → warning only, exit 0
+# ---------------------------------------------------------------------------
+
+
+@patch("subprocess.run")
+@patch("panoptes.pocs.utils.cli.weather.serial.tools.list_ports.comports")
+@patch("panoptes.pocs.utils.cli.weather.serial.Serial")
+@patch("panoptes.pocs.utils.cli.weather._glob.glob")
+def test_setup_config_server_fails(mock_glob, mock_serial_cls, mock_comports, mock_run, cli_runner):
+    """Exception from set_config prints a warning but does not exit non-zero."""
+    mock_glob.return_value = ["/dev/ttyUSB0"]
+    mock_comports.return_value = [_make_port_info("/dev/ttyUSB0")]
+    mock_serial_cls.return_value = _make_serial_cm(b"!N CloudWatcher  !\x11            0")
+    mock_run.return_value = MagicMock(returncode=0, stderr=b"")
+
+    with patch("panoptes.utils.config.client.set_config", side_effect=ConnectionRefusedError("no server")):
+        result = cli_runner.invoke(app, ["weather", "setup"])
+
+    assert result.exit_code == 0, result.output
+    assert "config server" in result.output.lower() or "serial_port" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# setup — port not in comports and path doesn't resolve differently → VID/PID error
+# ---------------------------------------------------------------------------
+
+
+@patch("panoptes.pocs.utils.cli.weather.serial.tools.list_ports.comports")
+@patch("panoptes.pocs.utils.cli.weather.serial.Serial")
+@patch("panoptes.pocs.utils.cli.weather._glob.glob")
+def test_setup_port_info_not_in_comports_no_symlink(mock_glob, mock_serial_cls, mock_comports, cli_runner):
+    """AAG responds but the device isn't in comports and its path doesn't resolve to
+    a different string — port_info stays None → vendor/product ID error."""
+    mock_glob.return_value = ["/dev/ttyUSB0"]
+    mock_comports.return_value = []  # empty — device absent from comports
+    mock_serial_cls.return_value = _make_serial_cm(b"!N CloudWatcher  !\x11            0")
+
+    result = cli_runner.invoke(app, ["weather", "setup"])
+
+    assert result.exit_code != 0
+    assert "vendor/product ID" in result.output

--- a/tests/utils/test_weather_cli.py
+++ b/tests/utils/test_weather_cli.py
@@ -1,0 +1,180 @@
+"""Tests for the `pocs weather` CLI commands, including the `setup` subcommand."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from panoptes.pocs.utils.cli.main import app
+
+
+@pytest.fixture
+def cli_runner():
+    return CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_port(
+    device,
+    vid=0x0403,
+    pid=0x6001,
+    serial_number="SN123",
+    description="FT232R",
+    manufacturer="FTDI",
+):
+    """Return a mock ListPortInfo-like object."""
+    p = MagicMock()
+    p.device = device
+    p.vid = vid
+    p.pid = pid
+    p.serial_number = serial_number
+    p.description = description
+    p.manufacturer = manufacturer
+    return p
+
+
+# ---------------------------------------------------------------------------
+# setup — new device detected automatically (no power-cycle flag)
+# ---------------------------------------------------------------------------
+
+
+@patch("subprocess.run")
+@patch("panoptes.pocs.utils.cli.weather.time.sleep")
+@patch("panoptes.pocs.utils.cli.weather.time.monotonic")
+@patch("panoptes.pocs.utils.cli.weather.get_serial_port_info")
+def test_setup_detects_new_device(mock_ports, mock_monotonic, mock_sleep, mock_run, cli_runner):
+    """A new USB serial port appearing after the prompt writes a udev rule."""
+    before_port = _make_port("/dev/ttyUSB0")
+    new_port = _make_port("/dev/ttyUSB1", serial_number="WS999")
+
+    # First call (snapshot before): only the pre-existing port.
+    # Subsequent calls return both ports so the new one is found immediately.
+    mock_ports.side_effect = [
+        [before_port],  # snapshot
+        [before_port, new_port],  # first poll (finds new device)
+        [before_port, new_port],  # re-fetch for port info object
+    ]
+
+    # Monotonic advances past a single loop iteration without hitting the deadline.
+    mock_monotonic.side_effect = [0.0, 1.0, 2.0, 100.0]
+
+    # All subprocess.run calls succeed.
+    mock_run.return_value = MagicMock(returncode=0, stderr=b"")
+
+    # Patch set_config so we don't need a running config server.
+    with patch("panoptes.utils.config.client.set_config"):
+        # Supply "y" to the "press Enter once power-cycled" confirmation.
+        result = cli_runner.invoke(app, ["weather", "setup"], input="y\n")
+
+    assert result.exit_code == 0, result.output
+    assert "/dev/ttyUSB1" in result.output
+    assert "92-panoptes-weather.rules" in result.output
+
+    # Verify the udev rule content passed to `sudo tee`.
+    tee_call = next(c for c in mock_run.call_args_list if "tee" in c.args[0])
+    rule = tee_call.kwargs["input"].decode()
+    assert 'ATTRS{idVendor}=="0403"' in rule
+    assert 'ATTRS{idProduct}=="6001"' in rule
+    assert 'ATTRS{serial}=="WS999"' in rule
+    assert 'SYMLINK+="weather"' in rule
+
+
+# ---------------------------------------------------------------------------
+# setup — power-cycle path
+# ---------------------------------------------------------------------------
+
+
+@patch("subprocess.run")
+@patch("panoptes.pocs.utils.cli.weather.time.sleep")
+@patch("panoptes.pocs.utils.cli.weather.time.monotonic")
+@patch("panoptes.pocs.utils.cli.weather.get_serial_port_info")
+@patch("panoptes.pocs.utils.cli.weather.requests.post")
+def test_setup_power_cycle(mock_post, mock_ports, mock_monotonic, mock_sleep, mock_run, cli_runner):
+    """--power-cycle issues power-off / power-on before detection."""
+    before_port = _make_port("/dev/ttyUSB0")
+    new_port = _make_port("/dev/ttyUSB1", serial_number=None)
+
+    mock_ports.side_effect = [
+        [before_port],
+        [before_port, new_port],
+        [before_port, new_port],
+    ]
+    mock_monotonic.side_effect = [0.0, 1.0, 2.0, 100.0]
+
+    mock_resp = MagicMock()
+    mock_resp.ok = True
+    mock_post.return_value = mock_resp
+    mock_run.return_value = MagicMock(returncode=0, stderr=b"")
+
+    with patch("panoptes.utils.config.client.set_config"):
+        result = cli_runner.invoke(
+            app,
+            ["weather", "setup", "--power-cycle", "--relay", "weather_station"],
+        )
+
+    assert result.exit_code == 0, result.output
+
+    # Expect two POST calls: turn_off then turn_on.
+    assert mock_post.call_count == 2
+    commands = [c.kwargs["json"]["command"] for c in mock_post.call_args_list]
+    assert commands == ["turn_off", "turn_on"]
+
+    # Rule should omit the serial attribute when serial_number is None.
+    tee_call = next(c for c in mock_run.call_args_list if "tee" in c.args[0])
+    rule = tee_call.kwargs["input"].decode()
+    assert "serial" not in rule
+    assert 'SYMLINK+="weather"' in rule
+
+
+# ---------------------------------------------------------------------------
+# setup — timeout: no new device appears
+# ---------------------------------------------------------------------------
+
+
+@patch("panoptes.pocs.utils.cli.weather.time.sleep")
+@patch("panoptes.pocs.utils.cli.weather.time.monotonic")
+@patch("panoptes.pocs.utils.cli.weather.get_serial_port_info")
+def test_setup_timeout(mock_ports, mock_monotonic, mock_sleep, cli_runner):
+    """When no new device appears within the timeout the command exits non-zero."""
+    existing_port = _make_port("/dev/ttyUSB0")
+
+    # Always return the same single port.
+    mock_ports.return_value = [existing_port]
+
+    # Simulate the deadline being reached on the second monotonic() call.
+    mock_monotonic.side_effect = [0.0, 0.5, 999.0]
+
+    result = cli_runner.invoke(app, ["weather", "setup"], input="y\n")
+
+    assert result.exit_code != 0
+    assert "No new serial device detected" in result.output
+
+
+# ---------------------------------------------------------------------------
+# setup — no USB VID/PID available
+# ---------------------------------------------------------------------------
+
+
+@patch("panoptes.pocs.utils.cli.weather.time.sleep")
+@patch("panoptes.pocs.utils.cli.weather.time.monotonic")
+@patch("panoptes.pocs.utils.cli.weather.get_serial_port_info")
+def test_setup_no_vid_pid(mock_ports, mock_monotonic, mock_sleep, cli_runner):
+    """If the detected device has no VID/PID the command exits non-zero."""
+    before_port = _make_port("/dev/ttyUSB0")
+    new_port = _make_port("/dev/ttyUSB1", vid=None, pid=None)
+
+    mock_ports.side_effect = [
+        [before_port],
+        [before_port, new_port],
+        [before_port, new_port],
+    ]
+    mock_monotonic.side_effect = [0.0, 1.0, 100.0]
+
+    result = cli_runner.invoke(app, ["weather", "setup"], input="y\n")
+
+    assert result.exit_code != 0
+    assert "vendor/product ID" in result.output

--- a/tests/utils/test_weather_cli.py
+++ b/tests/utils/test_weather_cli.py
@@ -18,15 +18,15 @@ def cli_runner():
 # ---------------------------------------------------------------------------
 
 
-def _make_port(
+def _make_port_info(
     device,
-    vid=0x0403,
-    pid=0x6001,
-    serial_number="SN123",
-    description="FT232R",
-    manufacturer="FTDI",
+    vid=0x067B,
+    pid=0x2303,
+    serial_number="SN42",
+    description="PL2303",
+    manufacturer="Prolific",
 ):
-    """Return a mock ListPortInfo-like object."""
+    """Return a mock pyserial ListPortInfo-like object."""
     p = MagicMock()
     p.device = device
     p.vid = vid
@@ -38,143 +38,184 @@ def _make_port(
 
 
 # ---------------------------------------------------------------------------
-# setup — new device detected automatically (no power-cycle flag)
+# Helpers to build a mock serial.Serial context manager
+# ---------------------------------------------------------------------------
+
+
+def _make_serial_cm(response: bytes):
+    """Return a mock Serial instance (usable as context manager) that returns ``response`` on read()."""
+    ser = MagicMock()
+    ser.read.return_value = response
+    ser.__enter__ = MagicMock(return_value=ser)
+    ser.__exit__ = MagicMock(return_value=False)
+    return ser
+
+
+# ---------------------------------------------------------------------------
+# setup — AAG device found on first port
 # ---------------------------------------------------------------------------
 
 
 @patch("subprocess.run")
-@patch("panoptes.pocs.utils.cli.weather.time.sleep")
-@patch("panoptes.pocs.utils.cli.weather.time.monotonic")
-@patch("panoptes.pocs.utils.cli.weather.get_serial_port_info")
-def test_setup_detects_new_device(mock_ports, mock_monotonic, mock_sleep, mock_run, cli_runner):
-    """A new USB serial port appearing after the prompt writes a udev rule."""
-    before_port = _make_port("/dev/ttyUSB0")
-    new_port = _make_port("/dev/ttyUSB1", serial_number="WS999")
-
-    # First call (snapshot before): only the pre-existing port.
-    # Subsequent calls return both ports so the new one is found immediately.
-    mock_ports.side_effect = [
-        [before_port],  # snapshot
-        [before_port, new_port],  # first poll (finds new device)
-        [before_port, new_port],  # re-fetch for port info object
-    ]
-
-    # Monotonic advances past a single loop iteration without hitting the deadline.
-    mock_monotonic.side_effect = [0.0, 1.0, 2.0, 100.0]
-
-    # All subprocess.run calls succeed.
+@patch("panoptes.pocs.utils.cli.weather.serial.tools.list_ports.comports")
+@patch("panoptes.pocs.utils.cli.weather.serial.Serial")
+@patch("panoptes.pocs.utils.cli.weather._glob.glob")
+def test_setup_finds_aag_on_first_port(mock_glob, mock_serial_cls, mock_comports, mock_run, cli_runner):
+    """First port responds with !N  → udev rule is written for that port."""
+    mock_glob.return_value = ["/dev/ttyUSB0"]
+    mock_comports.return_value = [_make_port_info("/dev/ttyUSB0")]
+    mock_serial_cls.return_value = _make_serial_cm(b"!N CloudWatcher  !\x11            0")
     mock_run.return_value = MagicMock(returncode=0, stderr=b"")
 
-    # Patch set_config so we don't need a running config server.
     with patch("panoptes.utils.config.client.set_config"):
-        # Supply "y" to the "press Enter once power-cycled" confirmation.
-        result = cli_runner.invoke(app, ["weather", "setup"], input="y\n")
+        result = cli_runner.invoke(app, ["weather", "setup"])
 
     assert result.exit_code == 0, result.output
-    assert "/dev/ttyUSB1" in result.output
+    assert "AAG CloudWatcher detected" in result.output
     assert "92-panoptes-weather.rules" in result.output
 
-    # Verify the udev rule content passed to `sudo tee`.
     tee_call = next(c for c in mock_run.call_args_list if "tee" in c.args[0])
     rule = tee_call.kwargs["input"].decode()
-    assert 'ATTRS{idVendor}=="0403"' in rule
-    assert 'ATTRS{idProduct}=="6001"' in rule
-    assert 'ATTRS{serial}=="WS999"' in rule
+    assert 'ATTRS{idVendor}=="067b"' in rule
+    assert 'ATTRS{idProduct}=="2303"' in rule
+    assert 'ATTRS{serial}=="SN42"' in rule
     assert 'SYMLINK+="weather"' in rule
 
 
 # ---------------------------------------------------------------------------
-# setup — power-cycle path
+# setup — first port is not AAG, second port is
 # ---------------------------------------------------------------------------
 
 
 @patch("subprocess.run")
-@patch("panoptes.pocs.utils.cli.weather.time.sleep")
-@patch("panoptes.pocs.utils.cli.weather.time.monotonic")
-@patch("panoptes.pocs.utils.cli.weather.get_serial_port_info")
-@patch("panoptes.pocs.utils.cli.weather.requests.post")
-def test_setup_power_cycle(mock_post, mock_ports, mock_monotonic, mock_sleep, mock_run, cli_runner):
-    """--power-cycle issues power-off / power-on before detection."""
-    before_port = _make_port("/dev/ttyUSB0")
-    new_port = _make_port("/dev/ttyUSB1", serial_number=None)
-
-    mock_ports.side_effect = [
-        [before_port],
-        [before_port, new_port],
-        [before_port, new_port],
+@patch("panoptes.pocs.utils.cli.weather.serial.tools.list_ports.comports")
+@patch("panoptes.pocs.utils.cli.weather.serial.Serial")
+@patch("panoptes.pocs.utils.cli.weather._glob.glob")
+def test_setup_skips_non_aag_ports(mock_glob, mock_serial_cls, mock_comports, mock_run, cli_runner):
+    """Non-responding ports are skipped; the AAG is identified on the second port."""
+    mock_glob.return_value = ["/dev/ttyUSB0", "/dev/ttyUSB1"]
+    mock_comports.return_value = [
+        _make_port_info("/dev/ttyUSB0", serial_number=None),
+        _make_port_info("/dev/ttyUSB1", vid=0x0403, pid=0x6001, serial_number="FT001"),
     ]
-    mock_monotonic.side_effect = [0.0, 1.0, 2.0, 100.0]
-
-    mock_resp = MagicMock()
-    mock_resp.ok = True
-    mock_post.return_value = mock_resp
+    # First port returns garbage; second returns valid AAG response.
+    mock_serial_cls.side_effect = [
+        _make_serial_cm(b"\x00\x00\x00"),
+        _make_serial_cm(b"!N CloudWatcher  !\x11            0"),
+    ]
     mock_run.return_value = MagicMock(returncode=0, stderr=b"")
 
     with patch("panoptes.utils.config.client.set_config"):
-        result = cli_runner.invoke(
-            app,
-            ["weather", "setup", "--power-cycle", "--relay", "weather_station"],
-        )
+        result = cli_runner.invoke(app, ["weather", "setup"])
 
     assert result.exit_code == 0, result.output
+    assert "AAG CloudWatcher detected" in result.output
 
-    # Expect two POST calls: turn_off then turn_on.
-    assert mock_post.call_count == 2
-    commands = [c.kwargs["json"]["command"] for c in mock_post.call_args_list]
-    assert commands == ["turn_off", "turn_on"]
+    tee_call = next(c for c in mock_run.call_args_list if "tee" in c.args[0])
+    rule = tee_call.kwargs["input"].decode()
+    assert 'ATTRS{idVendor}=="0403"' in rule
+    assert 'ATTRS{serial}=="FT001"' in rule
 
-    # Rule should omit the serial attribute when serial_number is None.
+
+# ---------------------------------------------------------------------------
+# setup — no AAG found on any port
+# ---------------------------------------------------------------------------
+
+
+@patch("panoptes.pocs.utils.cli.weather.serial.tools.list_ports.comports")
+@patch("panoptes.pocs.utils.cli.weather.serial.Serial")
+@patch("panoptes.pocs.utils.cli.weather._glob.glob")
+def test_setup_no_aag_found(mock_glob, mock_serial_cls, mock_comports, cli_runner):
+    """If no port responds with an AAG handshake the command exits non-zero."""
+    mock_glob.return_value = ["/dev/ttyUSB0"]
+    mock_comports.return_value = [_make_port_info("/dev/ttyUSB0")]
+    mock_serial_cls.return_value = _make_serial_cm(b"\x00" * 30)
+
+    result = cli_runner.invoke(app, ["weather", "setup"])
+
+    assert result.exit_code != 0
+    assert "not found" in result.output
+
+
+# ---------------------------------------------------------------------------
+# setup — no matching ports at all
+# ---------------------------------------------------------------------------
+
+
+@patch("panoptes.pocs.utils.cli.weather._glob.glob")
+def test_setup_no_ports_match_glob(mock_glob, cli_runner):
+    """If the glob matches nothing, the command exits non-zero immediately."""
+    mock_glob.return_value = []
+
+    result = cli_runner.invoke(app, ["weather", "setup"])
+
+    assert result.exit_code != 0
+    assert "No devices found" in result.output
+
+
+# ---------------------------------------------------------------------------
+# setup — device found but no VID/PID
+# ---------------------------------------------------------------------------
+
+
+@patch("panoptes.pocs.utils.cli.weather.serial.tools.list_ports.comports")
+@patch("panoptes.pocs.utils.cli.weather.serial.Serial")
+@patch("panoptes.pocs.utils.cli.weather._glob.glob")
+def test_setup_no_vid_pid(mock_glob, mock_serial_cls, mock_comports, cli_runner):
+    """A port that responds to AAG but has no USB VID/PID exits non-zero."""
+    mock_glob.return_value = ["/dev/ttyUSB0"]
+    mock_comports.return_value = [_make_port_info("/dev/ttyUSB0", vid=None, pid=None)]
+    mock_serial_cls.return_value = _make_serial_cm(b"!N CloudWatcher  !\x11            0")
+
+    result = cli_runner.invoke(app, ["weather", "setup"])
+
+    assert result.exit_code != 0
+    assert "vendor/product ID" in result.output
+
+
+# ---------------------------------------------------------------------------
+# setup — serial port raises SerialException
+# ---------------------------------------------------------------------------
+
+
+@patch("panoptes.pocs.utils.cli.weather.serial.tools.list_ports.comports")
+@patch("panoptes.pocs.utils.cli.weather.serial.Serial")
+@patch("panoptes.pocs.utils.cli.weather._glob.glob")
+def test_setup_serial_exception_is_skipped(mock_glob, mock_serial_cls, mock_comports, cli_runner):
+    """Ports that raise SerialException are skipped gracefully."""
+    import serial as _serial
+
+    mock_glob.return_value = ["/dev/ttyUSB0"]
+    mock_comports.return_value = [_make_port_info("/dev/ttyUSB0")]
+    mock_serial_cls.side_effect = _serial.SerialException("Permission denied")
+
+    result = cli_runner.invoke(app, ["weather", "setup"])
+
+    assert result.exit_code != 0
+    assert "not found" in result.output
+
+
+# ---------------------------------------------------------------------------
+# setup — udev rule omits serial when serial_number is None
+# ---------------------------------------------------------------------------
+
+
+@patch("subprocess.run")
+@patch("panoptes.pocs.utils.cli.weather.serial.tools.list_ports.comports")
+@patch("panoptes.pocs.utils.cli.weather.serial.Serial")
+@patch("panoptes.pocs.utils.cli.weather._glob.glob")
+def test_setup_rule_omits_serial_when_none(mock_glob, mock_serial_cls, mock_comports, mock_run, cli_runner):
+    """When serial_number is None the ATTRS{serial} clause is omitted from the rule."""
+    mock_glob.return_value = ["/dev/ttyUSB0"]
+    mock_comports.return_value = [_make_port_info("/dev/ttyUSB0", serial_number=None)]
+    mock_serial_cls.return_value = _make_serial_cm(b"!N CloudWatcher  !\x11            0")
+    mock_run.return_value = MagicMock(returncode=0, stderr=b"")
+
+    with patch("panoptes.utils.config.client.set_config"):
+        result = cli_runner.invoke(app, ["weather", "setup"])
+
+    assert result.exit_code == 0, result.output
     tee_call = next(c for c in mock_run.call_args_list if "tee" in c.args[0])
     rule = tee_call.kwargs["input"].decode()
     assert "serial" not in rule
     assert 'SYMLINK+="weather"' in rule
-
-
-# ---------------------------------------------------------------------------
-# setup — timeout: no new device appears
-# ---------------------------------------------------------------------------
-
-
-@patch("panoptes.pocs.utils.cli.weather.time.sleep")
-@patch("panoptes.pocs.utils.cli.weather.time.monotonic")
-@patch("panoptes.pocs.utils.cli.weather.get_serial_port_info")
-def test_setup_timeout(mock_ports, mock_monotonic, mock_sleep, cli_runner):
-    """When no new device appears within the timeout the command exits non-zero."""
-    existing_port = _make_port("/dev/ttyUSB0")
-
-    # Always return the same single port.
-    mock_ports.return_value = [existing_port]
-
-    # Simulate the deadline being reached on the second monotonic() call.
-    mock_monotonic.side_effect = [0.0, 0.5, 999.0]
-
-    result = cli_runner.invoke(app, ["weather", "setup"], input="y\n")
-
-    assert result.exit_code != 0
-    assert "No new serial device detected" in result.output
-
-
-# ---------------------------------------------------------------------------
-# setup — no USB VID/PID available
-# ---------------------------------------------------------------------------
-
-
-@patch("panoptes.pocs.utils.cli.weather.time.sleep")
-@patch("panoptes.pocs.utils.cli.weather.time.monotonic")
-@patch("panoptes.pocs.utils.cli.weather.get_serial_port_info")
-def test_setup_no_vid_pid(mock_ports, mock_monotonic, mock_sleep, cli_runner):
-    """If the detected device has no VID/PID the command exits non-zero."""
-    before_port = _make_port("/dev/ttyUSB0")
-    new_port = _make_port("/dev/ttyUSB1", vid=None, pid=None)
-
-    mock_ports.side_effect = [
-        [before_port],
-        [before_port, new_port],
-        [before_port, new_port],
-    ]
-    mock_monotonic.side_effect = [0.0, 1.0, 100.0]
-
-    result = cli_runner.invoke(app, ["weather", "setup"], input="y\n")
-
-    assert result.exit_code != 0
-    assert "vendor/product ID" in result.output

--- a/tests/utils/test_weather_cli.py
+++ b/tests/utils/test_weather_cli.py
@@ -1,5 +1,6 @@
 """Tests for the `pocs weather` CLI commands, including the `setup` subcommand."""
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -219,3 +220,48 @@ def test_setup_rule_omits_serial_when_none(mock_glob, mock_serial_cls, mock_comp
     rule = tee_call.kwargs["input"].decode()
     assert "serial" not in rule
     assert 'SYMLINK+="weather"' in rule
+
+
+# ---------------------------------------------------------------------------
+# setup — /dev/mount symlink causes that port to be skipped
+# ---------------------------------------------------------------------------
+
+
+@patch("subprocess.run")
+@patch("panoptes.pocs.utils.cli.weather.serial.tools.list_ports.comports")
+@patch("panoptes.pocs.utils.cli.weather.serial.Serial")
+@patch("panoptes.pocs.utils.cli.weather._glob.glob")
+def test_setup_skips_mount_port(mock_glob, mock_serial_cls, mock_comports, mock_run, cli_runner):
+    """/dev/ttyUSB0 claimed by /dev/mount is skipped; AAG found on /dev/ttyUSB1."""
+    mock_glob.return_value = ["/dev/ttyUSB0", "/dev/ttyUSB1"]
+    mock_comports.return_value = [
+        _make_port_info("/dev/ttyUSB0"),
+        _make_port_info("/dev/ttyUSB1", vid=0x0403, pid=0x6001, serial_number="FT001"),
+    ]
+    # Only USB1 should be probed; USB0 is the mount.
+    mock_serial_cls.return_value = _make_serial_cm(b"!N CloudWatcher  !\x11            0")
+    mock_run.return_value = MagicMock(returncode=0, stderr=b"")
+
+    mount_symlink = MagicMock(spec=Path)
+    mount_symlink.is_symlink.return_value = True
+    mount_symlink.resolve.return_value = Path("/dev/ttyUSB0")
+
+    with (
+        patch("panoptes.pocs.utils.cli.weather.Path") as mock_path_cls,
+        patch("panoptes.utils.config.client.set_config"),
+    ):
+        # Path("/dev/mount") → our mock; Path(device).resolve() uses real Path
+        def path_side_effect(arg):
+            if arg == "/dev/mount":
+                return mount_symlink
+            return Path(arg)
+
+        mock_path_cls.side_effect = path_side_effect
+
+        result = cli_runner.invoke(app, ["weather", "setup"])
+
+    assert result.exit_code == 0, result.output
+    assert "skipping" in result.output.lower() or "mount" in result.output.lower()
+    # serial.Serial should have been called exactly once (for USB1, not USB0)
+    assert mock_serial_cls.call_count == 1
+    assert mock_serial_cls.call_args[0][0] == "/dev/ttyUSB1"


### PR DESCRIPTION
## Summary

Adds a `pocs weather setup` CLI subcommand that automatically detects an AAG CloudWatcher weather station and writes a persistent udev rule for it.

## How it works

1. Scans all `/dev/ttyUSB*` ports (configurable via `--port-glob`)
2. Skips any port that `/dev/mount` already points to, preventing accidental probing of the telescope mount
4. On a successful handshake, reads the USB VID, PID, and serial number from pyserial's port enumeration
5. Writes `/etc/udev/rules.d/92-panoptes-weather.rules` (via `sudo tee`) creating a stable `/dev/weather` symlink
6. Reloads udev rules with `sudo udevadm control --reload`
7. Updates `environment.weather.serial_port → /dev/weather` in the config server if reachable

## Usage

```
pocs weather setup
pocs weather setup --port-glob '/dev/ttyUSB*' --baud-rate 9600 --read-timeout 2.0
```

## Tests

8 unit tests added in `tests/utils/test_weather_cli.py` covering:
- AAG detected on first port
- Non-AAG ports skipped, AAG found on second port
- No AAG found → non-zero exit
- No ports match glob → non-zero exit
- Device found but no USB VID/PID → non-zero exit
- `SerialException` on a port → skipped gracefully
- udev rule omits `ATTRS{serial}` when serial number is `None`
- `/dev/mount` port is skipped during probing
