### PR TITLE
docs: add weather station JSON schema documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added `pocs weather setup` subcommand that scans `/dev/ttyUSB*` ports (skipping any claimed by `/dev/mount`), probes each with the AAG CloudWatcher serial handshake, and writes a udev rule to `/etc/udev/rules.d/92-panoptes-weather.rules` creating a stable `/dev/weather` symlink.
+- Added `docs/weather-station.md` documenting the weather reading JSON schema, safety evaluation logic, HTTP API, and configuration reference.
 
 ## 0.8.2 - 2026-04-15
 

--- a/docs/weather-station.md
+++ b/docs/weather-station.md
@@ -1,7 +1,7 @@
 # Weather Station
 
 POCS integrates with the **AAG CloudWatcher** weather station via a thin wrapper class
-([`WeatherStation`][panoptes.pocs.sensor.weather.WeatherStation]) and a FastAPI service that
+(`WeatherStation`) and a FastAPI service that
 exposes the readings over HTTP.
 
 ## How It Works
@@ -83,7 +83,7 @@ Condition strings are derived by comparing the measurements against configurable
 
 ## Safety Evaluation
 
-[`POCS.is_weather_safe()`][panoptes.pocs.core.POCS.is_weather_safe] reads the latest
+`POCS.is_weather_safe()` reads the latest
 `weather` record from the database and applies two checks:
 
 1. **Safety flag** — looks for `is_safe` (then `safe`) and casts it to `bool`.

--- a/docs/weather-station.md
+++ b/docs/weather-station.md
@@ -1,32 +1,100 @@
 # Weather Station
 
-POCS integrates with the **AAG CloudWatcher** weather station via a thin wrapper class
-(`WeatherStation`) and a FastAPI service that
-exposes the readings over HTTP.
+POCS integrates with the **AAG CloudWatcher** weather station out of the box, but it can
+work with **any weather source** — a different sensor, a scraper for a local weather API,
+or a home-built station — as long as you write records in the expected JSON format to the
+`weather` database collection.
 
 ## How It Works
 
 ```
-AAG CloudWatcher ──serial──► WeatherStation.record()
-                                     │
-                                     ▼
-                              DB "weather" collection
-                                     │
-                                     ▼
-                          POCS.is_weather_safe()  ──► allow / deny observations
+Weather source ──────────────────► DB "weather" collection
+(AAG CloudWatcher, adapter script,         │
+ or any custom integration)                ▼
+                               POCS.is_weather_safe()  ──► allow / deny observations
 ```
 
-1. The `WeatherStation` reads data from the sensor over a serial port.
-2. `record()` is called on a configurable interval (default 60 s) and writes the
-   latest snapshot to the `weather` database collection.
-3. `POCS.is_weather_safe()` reads the most recent record from that collection and
-   decides whether observing is safe.
+The only thing `POCS.is_weather_safe()` cares about is the **most recent document** in
+the `weather` collection. It reads two fields and makes a go/no-go decision:
+
+| Field | Required | Description |
+|---|---|---|
+| `is_safe` | **yes** | `true` = conditions are safe to observe |
+| `timestamp` | **yes** | ISO 8601 string; records older than 180 s are treated as unsafe |
 
 ---
 
-## JSON Reading Schema
+## Building a Custom Integration
 
-Every weather record written to the database contains the following fields.
+If you are using a non-AAG sensor, scraping a weather page, or writing an adapter script,
+this is the section for you.
+
+### Minimum Viable Record
+
+The smallest record POCS will act on:
+
+```json
+{
+    "is_safe": true,
+    "timestamp": "2024-01-15T10:30:00.123456"
+}
+```
+
+That's it. Write a document with those two fields to the `weather` collection on the
+configured interval and POCS will use it to gate observations.
+
+### Example Adapter Script
+
+```python
+#!/usr/bin/env python3
+"""Minimal weather adapter — scrapes an external source and writes to POCS DB."""
+
+from datetime import UTC, datetime
+
+from panoptes.utils.database import PanDB
+
+db = PanDB()  # uses the same DB backend as POCS
+
+
+def is_currently_safe() -> bool:
+    """Replace this with your own safety logic."""
+    # e.g. call a local weather API, read a sensor, scrape a web page …
+    return True
+
+
+def write_weather_record() -> None:
+    record = {
+        "is_safe": is_currently_safe(),
+        "timestamp": datetime.now(UTC).isoformat(),
+    }
+    db.insert_current("weather", record)
+    print(f"Wrote: {record}")
+
+
+if __name__ == "__main__":
+    import time
+
+    while True:
+        write_weather_record()
+        time.sleep(60)
+```
+
+Run this script alongside POCS and it will keep the `weather` collection up to date.
+POCS will stop observing if the script stops writing (records go stale after 180 s).
+
+!!! tip "Adding more detail"
+    You can include any extra fields you like alongside the two required ones.
+    The full schema used by the built-in AAG integration is described
+    [below](#full-json-schema). Including those extra fields makes your records
+    visible in `pocs weather status` output.
+
+---
+
+## Full JSON Schema
+
+The built-in AAG CloudWatcher integration writes all of the following fields.
+Custom integrations may include any subset (only `is_safe` and `timestamp` are required),
+or additional fields of their own.
 
 ### Measurement Fields
 
@@ -34,14 +102,14 @@ Every weather record written to the database contains the following fields.
 |---|---|---|---|
 | `timestamp` | `str` | — | ISO 8601 datetime of the reading, e.g. `"2024-01-15T10:30:00.123456"` |
 | `ambient_temp` | `float` | °C | Ambient (air) temperature |
-| `sky_temp` | `float` | °C | Sky infrared temperature. The difference `sky_temp − ambient_temp` is used to infer cloud cover |
+| `sky_temp` | `float` | °C | Sky infrared temperature; the difference `sky_temp − ambient_temp` indicates cloud cover |
 | `wind_speed` | `float` | m/s | Wind speed |
-| `rain_frequency` | `float` | — | Raw rain-sensor frequency value; higher values indicate drier conditions |
+| `rain_frequency` | `float` | — | Raw rain-sensor frequency; higher values mean drier conditions |
 | `pwm` | `float` | % | Heater element duty cycle |
 
 ### Condition Fields
 
-Condition strings are derived by comparing the measurements against configurable thresholds
+Derived by comparing the measurements against configurable thresholds
 (see `environment.weather` in `conf_files/pocs.yaml`).
 
 | Field | Type | Possible Values |
@@ -59,7 +127,7 @@ Condition strings are derived by comparing the measurements against configurable
 | `rain_safe` | `bool` | `True` when `rain_condition == "dry"` |
 | `is_safe` | `bool` | `True` only when **all three** of `cloud_safe`, `wind_safe`, and `rain_safe` are `True` |
 
-### Example Record
+### Full Example Record
 
 ```json
 {
@@ -83,20 +151,16 @@ Condition strings are derived by comparing the measurements against configurable
 
 ## Safety Evaluation
 
-`POCS.is_weather_safe()` reads the latest
-`weather` record from the database and applies two checks:
+`POCS.is_weather_safe()` reads the latest `weather` record from the database and
+applies two checks:
 
-1. **Safety flag** — looks for `is_safe` (then `safe`) and casts it to `bool`.
+1. **Safety flag** — looks for `is_safe` (then falls back to `safe`) and casts it to `bool`.
 2. **Staleness** — compares `timestamp` to the current time. If the record is older
    than `stale` seconds (default **180 s**) the record is treated as unsafe regardless
    of the flag value.
 
-!!! warning "Custom weather integrations"
-    If you write weather data directly to the `weather` database collection from a
-    custom source, your records **must** include at minimum:
-
-    - `is_safe` (*bool*) — the overall safety decision
-    - `timestamp` (*str*) — ISO 8601 datetime so staleness can be evaluated
+This means **any integration that stops writing records will automatically halt
+observations** after the staleness window expires.
 
 ---
 
@@ -127,9 +191,10 @@ pocs weather --host 192.168.1.100 --port 6566 status
 
 ---
 
-## Configuration
+## AAG CloudWatcher Configuration
 
-Weather station settings live under `environment.weather` in your config file:
+For the built-in AAG integration, settings live under `environment.weather` in your
+config file:
 
 ```yaml
 environment:

--- a/docs/weather-station.md
+++ b/docs/weather-station.md
@@ -1,0 +1,150 @@
+# Weather Station
+
+POCS integrates with the **AAG CloudWatcher** weather station via a thin wrapper class
+([`WeatherStation`][panoptes.pocs.sensor.weather.WeatherStation]) and a FastAPI service that
+exposes the readings over HTTP.
+
+## How It Works
+
+```
+AAG CloudWatcher ──serial──► WeatherStation.record()
+                                     │
+                                     ▼
+                              DB "weather" collection
+                                     │
+                                     ▼
+                          POCS.is_weather_safe()  ──► allow / deny observations
+```
+
+1. The `WeatherStation` reads data from the sensor over a serial port.
+2. `record()` is called on a configurable interval (default 60 s) and writes the
+   latest snapshot to the `weather` database collection.
+3. `POCS.is_weather_safe()` reads the most recent record from that collection and
+   decides whether observing is safe.
+
+---
+
+## JSON Reading Schema
+
+Every weather record written to the database contains the following fields.
+
+### Measurement Fields
+
+| Field | Type | Unit | Description |
+|---|---|---|---|
+| `timestamp` | `str` | — | ISO 8601 datetime of the reading, e.g. `"2024-01-15T10:30:00.123456"` |
+| `ambient_temp` | `float` | °C | Ambient (air) temperature |
+| `sky_temp` | `float` | °C | Sky infrared temperature. The difference `sky_temp − ambient_temp` is used to infer cloud cover |
+| `wind_speed` | `float` | m/s | Wind speed |
+| `rain_frequency` | `float` | — | Raw rain-sensor frequency value; higher values indicate drier conditions |
+| `pwm` | `float` | % | Heater element duty cycle |
+
+### Condition Fields
+
+Condition strings are derived by comparing the measurements against configurable thresholds
+(see `environment.weather` in `conf_files/pocs.yaml`).
+
+| Field | Type | Possible Values |
+|---|---|---|
+| `cloud_condition` | `str` | `"clear"`, `"cloudy"`, `"very cloudy"`, `"unknown"` |
+| `wind_condition` | `str` | `"calm"`, `"windy"`, `"very windy"`, `"gusty"`, `"very gusty"`, `"unknown"` |
+| `rain_condition` | `str` | `"dry"`, `"wet"`, `"rainy"`, `"unknown"` |
+
+### Safety Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `cloud_safe` | `bool` | `True` when `cloud_condition == "clear"` |
+| `wind_safe` | `bool` | `True` when `wind_condition == "calm"` |
+| `rain_safe` | `bool` | `True` when `rain_condition == "dry"` |
+| `is_safe` | `bool` | `True` only when **all three** of `cloud_safe`, `wind_safe`, and `rain_safe` are `True` |
+
+### Example Record
+
+```json
+{
+    "timestamp": "2024-01-15T10:30:00.123456",
+    "ambient_temp": 15.5,
+    "sky_temp": -25.0,
+    "wind_speed": 2.3,
+    "rain_frequency": 2700.0,
+    "pwm": 75.0,
+    "cloud_condition": "clear",
+    "wind_condition": "calm",
+    "rain_condition": "dry",
+    "cloud_safe": true,
+    "wind_safe": true,
+    "rain_safe": true,
+    "is_safe": true
+}
+```
+
+---
+
+## Safety Evaluation
+
+[`POCS.is_weather_safe()`][panoptes.pocs.core.POCS.is_weather_safe] reads the latest
+`weather` record from the database and applies two checks:
+
+1. **Safety flag** — looks for `is_safe` (then `safe`) and casts it to `bool`.
+2. **Staleness** — compares `timestamp` to the current time. If the record is older
+   than `stale` seconds (default **180 s**) the record is treated as unsafe regardless
+   of the flag value.
+
+!!! warning "Custom weather integrations"
+    If you write weather data directly to the `weather` database collection from a
+    custom source, your records **must** include at minimum:
+
+    - `is_safe` (*bool*) — the overall safety decision
+    - `timestamp` (*str*) — ISO 8601 datetime so staleness can be evaluated
+
+---
+
+## HTTP API
+
+The weather FastAPI service (default port **6566**) exposes two endpoints:
+
+| Endpoint | Method | Description |
+|---|---|---|
+| `/status` | `GET` | Returns the most recent reading as a JSON object (schema above) |
+| `/config` | `GET` | Returns the active weather station configuration |
+
+### Querying via the CLI
+
+```bash
+# Show a formatted status table
+pocs weather status
+
+# Show raw JSON
+pocs weather status --show-raw-values
+
+# Show configuration
+pocs weather config
+
+# Connect to a remote unit
+pocs weather --host 192.168.1.100 --port 6566 status
+```
+
+---
+
+## Configuration
+
+Weather station settings live under `environment.weather` in your config file:
+
+```yaml
+environment:
+  weather:
+    serial_port: /dev/weather   # or /dev/ttyUSB0
+    auto_detect: false          # set true to probe all ttyUSB* ports
+    record_interval: 60         # seconds between DB writes
+    store_permanently: false    # keep every reading, not just the latest
+```
+
+To set up the stable `/dev/weather` symlink automatically, run:
+
+```bash
+pocs weather setup
+```
+
+This scans USB serial ports, identifies the AAG CloudWatcher by its handshake response,
+and writes a udev rule to `/etc/udev/rules.d/92-panoptes-weather.rules`.

--- a/docs/weather-station.md
+++ b/docs/weather-station.md
@@ -26,12 +26,14 @@ the `weather` collection. It reads two fields and makes a go/no-go decision:
 
 ## Building a Custom Integration
 
-If you are using a non-AAG sensor, scraping a weather page, or writing an adapter script,
-this is the section for you.
+If you are using a non-AAG sensor or want to pull data from an existing weather service,
+the only thing you need to do is **expose an HTTP endpoint that returns a JSON object**
+with the required fields. POCS already has the polling and database-writing machinery
+built in via `RemoteMonitor` and `pocs sensor monitor`.
 
-### Minimum Viable Record
+### What your endpoint must return
 
-The smallest record POCS will act on:
+The JSON object returned by your endpoint must include at minimum:
 
 ```json
 {
@@ -40,53 +42,55 @@ The smallest record POCS will act on:
 }
 ```
 
-That's it. Write a document with those two fields to the `weather` collection on the
-configured interval and POCS will use it to gate observations.
+| Field | Type | Description |
+|---|---|---|
+| `is_safe` | `bool` | `true` = conditions are safe to observe |
+| `timestamp` | `str` | ISO 8601 datetime of the reading; records older than 180 s are treated as unsafe |
 
-### Example Adapter Script
+Your endpoint can return any additional fields — they will be stored alongside the
+required ones. Including the [full AAG schema](#full-json-schema) fields makes your
+readings visible in `pocs weather status` output.
 
-```python
-#!/usr/bin/env python3
-"""Minimal weather adapter — scrapes an external source and writes to POCS DB."""
+### Polling the endpoint
 
-from datetime import UTC, datetime
+Once your endpoint is running, point `pocs sensor monitor` at it:
 
-from panoptes.utils.database import PanDB
-
-db = PanDB()  # uses the same DB backend as POCS
-
-
-def is_currently_safe() -> bool:
-    """Replace this with your own safety logic."""
-    # e.g. call a local weather API, read a sensor, scrape a web page …
-    return True
-
-
-def write_weather_record() -> None:
-    record = {
-        "is_safe": is_currently_safe(),
-        "timestamp": datetime.now(UTC).isoformat(),
-    }
-    db.insert_current("weather", record)
-    print(f"Wrote: {record}")
-
-
-if __name__ == "__main__":
-    import time
-
-    while True:
-        write_weather_record()
-        time.sleep(60)
+```bash
+# One-liner: poll http://myweather.local/status every 90 seconds
+pocs sensor monitor weather --endpoint http://myweather.local/status --read-frequency 90
 ```
 
-Run this script alongside POCS and it will keep the `weather` collection up to date.
-POCS will stop observing if the script stops writing (records go stale after 180 s).
+Or configure the URL in your config file so no `--endpoint` flag is needed:
 
-!!! tip "Adding more detail"
-    You can include any extra fields you like alongside the two required ones.
-    The full schema used by the built-in AAG integration is described
-    [below](#full-json-schema). Including those extra fields makes your records
-    visible in `pocs weather status` output.
+```yaml
+environment:
+  weather:
+    url: http://myweather.local/status
+```
+
+```bash
+pocs sensor monitor weather --read-frequency 90
+```
+
+`pocs sensor monitor` fetches the endpoint on every interval, merges in a `date`
+timestamp, and writes the result to the `weather` database collection — the same
+collection that `POCS.is_weather_safe()` reads.
+
+### Running as a background service
+
+The supervisord configuration already includes a ready-to-use entry for this pattern.
+Enable the `pocs-weather-reader-remote` program in `conf_files/pocs-supervisord.conf`
+(and disable `pocs-weather-reader` if the AAG is not physically connected):
+
+```ini
+; Use this when your weather station is NOT connected to the POCS computer.
+[program:pocs-weather-reader-remote]
+command=pocs sensor monitor weather --read-frequency 90
+autostart=true   ; change from false → true
+```
+
+If the monitor process stops for any reason, readings in the database will go stale and
+POCS will automatically suspend observations after 180 s.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
   - Examples: examples.md
   - Architecture: architecture-for-beginners.md
   - CLI Guide: cli-guide.md
+  - Weather Station: weather-station.md
   - Glossary: glossary.md
   - API Reference: api.md
   - Contributing: contributing.md

--- a/src/panoptes/pocs/core.py
+++ b/src/panoptes/pocs/core.py
@@ -479,6 +479,21 @@ class POCS(PanStateMachine, PanBase):
     def is_weather_safe(self, stale=180):
         """Determines whether current weather conditions are safe or not.
 
+        Reads the most recent document from the ``weather`` database collection
+        (written by :meth:`panoptes.pocs.sensor.weather.WeatherStation.record`) and
+        inspects the following fields:
+
+        - **is_safe** or **safe** (*bool*, **required**): Overall safety flag. The
+          check tries ``is_safe`` first, then falls back to ``safe``. A record that
+          contains neither key is treated as unsafe.
+        - **timestamp** (*str*, **required**): ISO 8601 datetime of the reading. If the
+          record is older than *stale* seconds it is treated as unsafe regardless of the
+          safety flag value.
+
+        Custom or third-party weather integrations that write directly to the
+        ``weather`` database collection must include both of these fields for POCS to
+        recognise the record as safe.
+
         Args:
             stale (int, optional): Number of seconds before record is stale, defaults to 180
 

--- a/src/panoptes/pocs/sensor/weather.py
+++ b/src/panoptes/pocs/sensor/weather.py
@@ -51,7 +51,34 @@ class WeatherStation(PanBase):
 
     @property
     def status(self):
-        """Returns the most recent weather reading."""
+        """Returns the most recent weather reading.
+
+        Returns:
+            dict | str: A dictionary of the most recent sensor values, or a string
+                message if no readings are available yet. The dictionary contains the
+                following fields:
+
+                - **timestamp** (*str*): ISO 8601 datetime of the reading
+                  (e.g. ``"2024-01-15T10:30:00.123456"``).
+                - **ambient_temp** (*float*): Ambient temperature in degrees Celsius.
+                - **sky_temp** (*float*): Sky (infrared) temperature in degrees Celsius.
+                  Subtract ``ambient_temp`` to get the cloud-temperature delta.
+                - **wind_speed** (*float*): Wind speed in m/s.
+                - **rain_frequency** (*float*): Raw rain-sensor frequency value.
+                  Higher values indicate drier conditions.
+                - **pwm** (*float*): Heater duty cycle in percent.
+                - **cloud_condition** (*str*): One of ``"clear"``, ``"cloudy"``,
+                  ``"very cloudy"``, or ``"unknown"``.
+                - **wind_condition** (*str*): One of ``"calm"``, ``"windy"``,
+                  ``"very windy"``, ``"gusty"``, ``"very gusty"``, or ``"unknown"``.
+                - **rain_condition** (*str*): One of ``"dry"``, ``"wet"``, ``"rainy"``,
+                  or ``"unknown"``.
+                - **cloud_safe** (*bool*): ``True`` when ``cloud_condition == "clear"``.
+                - **wind_safe** (*bool*): ``True`` when ``wind_condition == "calm"``.
+                - **rain_safe** (*bool*): ``True`` when ``rain_condition == "dry"``.
+                - **is_safe** (*bool*): ``True`` only when *all three* of
+                  ``cloud_safe``, ``wind_safe``, and ``rain_safe`` are ``True``.
+        """
         reading = "No valid readings found. If the system just started, wait a few seconds and try again."
         try:
             reading = self.weather_station.readings[-1]
@@ -61,7 +88,23 @@ class WeatherStation(PanBase):
         return reading
 
     def record(self):
-        """Record the rolling mean of the power readings in the database."""
+        """Capture a fresh reading and persist it to the database.
+
+        Calls :meth:`aag.weather.CloudSensor.get_reading` to obtain an averaged
+        sensor snapshot, then stores it in the ``weather`` database collection via
+        :meth:`panoptes.utils.db.PanDB.insert_current`.
+
+        The stored document contains the same fields described in :attr:`status`.
+        The two fields that POCS reads back when evaluating safety are:
+
+        - **is_safe** (*bool*): Overall safety flag — ``True`` only when cloud,
+          wind, and rain conditions are all individually safe.
+        - **timestamp** (*str*): ISO 8601 datetime used to determine whether the
+          record is stale (default staleness threshold: 180 s).
+
+        Returns:
+            dict: The reading dictionary that was written to the database.
+        """
         recent_values = self.weather_station.get_reading()
 
         self.db.insert_current(self.collection_name, recent_values, store_permanently=self.store_permanently)


### PR DESCRIPTION
## Summary

Adds a dedicated documentation page for the weather station, covering the full JSON reading schema that POCS writes to and reads from the database.

## Changes

- **docs/weather-station.md** (new) - complete reference including:
  - JSON reading schema with all fields, types, units, and descriptions
  - Example JSON record
  - Safety evaluation logic (what is_weather_safe() checks and why)
  - Custom integration note (minimum required fields for third-party weather sources)
  - HTTP API endpoint reference
  - Configuration reference
- **mkdocs.yml** - registered the new page in the nav (between CLI Guide and Glossary)
- **src/panoptes/pocs/sensor/weather.py** - expanded status and record() docstrings with per-field detail
- **src/panoptes/pocs/core.py** - expanded is_weather_safe() docstring documenting the required DB record fields
- **CHANGELOG.md** - entry under Unreleased

## Motivation

Previously there was no single place to look up what fields a weather record contains, what values are valid for condition strings, or what the minimum requirements are for a custom weather integration to work with POCS's safety system.