### PR TITLE
If no `key` is provided to `get_config`, return entire config.

### DIFF
--- a/src/panoptes/pocs/base.py
+++ b/src/panoptes/pocs/base.py
@@ -55,14 +55,15 @@ class PanBase:
         self.db = PAN_DB_OBJ
 
     def get_config(
-        self, key: str, default: Any | None = None, remember: bool = False, *args, **kwargs
+        self, key: str | None = None, default: Any | None = None, remember: bool = False, *args, **kwargs
     ) -> Any:
         """Thin-wrapper around client based get_config that sets default port.
 
         See `panoptes.utils.config.client.get_config` for more information.
 
         Args:
-            key (str): The key name to use, can be namespaced with dots.
+            key (str | None): The key name to use, can be namespaced with dots. The default of
+                `None` will return the entire config.
             default (any): The default value to return if the key is not found.
             remember (bool): If True, cache the result for future calls.
             *args: Passed to get_config

--- a/tests/test_pocs.py
+++ b/tests/test_pocs.py
@@ -131,6 +131,11 @@ def test_observatory_cannot_observe(pocs):
     assert pocs.is_initialized
 
 
+def test_pocs_get_config(pocs):
+    conf = pocs.get_config()
+    assert conf is not None
+
+
 def test_simple_simulator(caplog):
     pocs = POCS.from_config(simulators="all")
     assert isinstance(pocs, POCS)


### PR DESCRIPTION
Fixes a warning shown on initial startup.