### PR TITLE
Migrate from PanDB to TelemetryClient (panoptes-utils v0.3.5)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - v1.0.0
   pull_request:
     branches:
       - main
+      - v1.0.0
 
 jobs:
   deploy:

--- a/.github/workflows/pythontest.yaml
+++ b/.github/workflows/pythontest.yaml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - v1.0.0
   pull_request:
     branches:
       - main
+      - v1.0.0
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,7 @@ conf_files/*_local.yaml
 temp*
 src/panoptes/pocs/_version.py
 json_store
-telemetry
+/telemetry
 .junie
 site/
 plans/

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ conf_files/*_local.yaml
 temp*
 src/panoptes/pocs/_version.py
 json_store
+telemetry
 .junie
 site/
 plans/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,6 +244,31 @@ pocs config setup
 - Document new configuration options
 - Config changes take effect immediately for new `get_config` calls; no restart needed
 
+### Telemetry Server
+
+POCS uses a telemetry server (from `panoptes-utils[telemetry]`) to record observatory state, sensor readings, and
+observation data. It replaces the legacy `PanDB` / `PanFileDB` JSON file database.
+
+**Starting the telemetry server locally:**
+
+```bash
+# For normal development (data stored in ./telemetry/)
+panoptes-telemetry --host 0.0.0.0 --port 6562 run --site-dir telemetry/
+
+# For testing (started automatically by conftest.py)
+# No manual start needed — pytest conftest.py handles it
+```
+
+**Notes:**
+
+- Default port is 6562 (config server remains on 6563)
+- Must be running before any `PanBase` subclass is instantiated
+- Configured via `telemetry: {host: localhost, port: 6562}` in YAML config files
+- Data is stored as NDJSON in the `site-dir` (default: `telemetry/`)
+- `store_permanently=False` skips disk writes (in-memory only) — used for high-frequency sensor readings
+- `start_run(run_dir=...)` / `stop_run()` mark observation run boundaries in the telemetry stream
+- For historical data queries, use `jq`, `pandas`, or DuckDB directly on the NDJSON files
+
 ## Common Tasks
 
 ### Adding a New Hardware Driver
@@ -647,6 +672,9 @@ When making changes, update:
 ### Common Commands
 
 ```bash
+# Start telemetry server (required before running POCS)
+panoptes-utils telemetry run --site-dir telemetry/
+
 # Install dependencies
 uv sync
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,7 +253,7 @@ observation data. It replaces the legacy `PanDB` / `PanFileDB` JSON file databas
 
 ```bash
 # For normal development (data stored in ./telemetry/)
-panoptes-telemetry --host 0.0.0.0 --port 6562 run --site-dir telemetry/
+panoptes-utils telemetry run --host 0.0.0.0 --port 6562 --site-dir telemetry/
 
 # For testing (started automatically by conftest.py)
 # No manual start needed — pytest conftest.py handles it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `pocs update` now defaults to checking out the latest tagged release. Use `--dev` for the latest commit or `--branch` for a specific branch.
 - Config is now loaded and managed via `panoptes.utils.config.store` from `panoptes-utils>=0.5.0`; in-process changes use `persist=False` to avoid writing back to disk. #1448
 - Bumped `panoptes-utils` requirement to `>=0.5.0`. #1448
+- Migrated from `PanDB` / `PanFileDB` JSON database to `TelemetryClient` / telemetry server (`panoptes-utils` v0.5.0+). Requires the `panoptes-utils telemetry run` server running on port 6562 before POCS starts.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - POCS now auto-creates any missing configured directories (e.g. `images`, `resources`) on startup, logging each creation.
 - Added `pocs telemetry run` CLI command (`src/panoptes/pocs/utils/cli/telemetry.py`) — starts the POCS-flavoured telemetry server with an optional Firestore upload hook (`--no-upload` disables it for local dev).
 - Added `src/panoptes/pocs/utils/service/telemetry.py` with `make_firestore_hook()` and `make_pocs_telemetry_app()` — Firestore upload is non-blocking and non-fatal.
+- Added `pocs telemetry current` subcommand — thin wrapper around `panoptes-utils telemetry current` for live telemetry inspection.
+- Added `sequence_id` property to `Observation` (returns `seq_time`) so callers can use a stable name for an observation run before any exposures start.
+- Telemetry run directories are now `telemetry/runs/<sequence_id>/` (no unit-id prefix, images remain in `images/`); `seq_time` is stamped at scheduling time.
 
 ### Changed
 
@@ -19,6 +22,7 @@
 - Bumped `panoptes-utils` requirement to `>=0.5.0`. #1448
 - Migrated from `PanDB` / `PanFileDB` JSON database to `TelemetryClient` / telemetry server (`panoptes-utils` v0.5.0+). Requires the `panoptes-utils telemetry run` server running on port 6562 before POCS starts.
 - Added `pocs-telemetry-server` program to `pocs-supervisord.conf` (port 6562, `priority=1`, data stored in `/home/panoptes/telemetry`).
+- `make_firestore_hook` now emits a clear warning (`pip install panoptes-pocs[google]`) at hook-creation time when `google-cloud-firestore` is not installed, instead of a per-event error.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Migrated from `PanDB` / `PanFileDB` JSON database to `TelemetryClient` / telemetry server (`panoptes-utils` v0.5.0+). Requires the `panoptes-utils telemetry run` server running on port 6562 before POCS starts.
 - Added `pocs-telemetry-server` program to `pocs-supervisord.conf` (port 6562, `priority=1`, data stored in `/home/panoptes/telemetry`).
 - `make_firestore_hook` now emits a clear warning (`pip install panoptes-pocs[google]`) at hook-creation time when `google-cloud-firestore` is not installed, instead of a per-event error.
+- Telemetry persistence defaults updated: `state` transitions, `weather` readings, `power` readings, and `images` metadata are now written permanently to the NDJSON log. `safety` is written permanently only when values change (ephemeral otherwise). `status` remains ephemeral (current-snapshot only).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Config is now loaded and managed via `panoptes.utils.config.store` from `panoptes-utils>=0.5.0`; in-process changes use `persist=False` to avoid writing back to disk. #1448
 - Bumped `panoptes-utils` requirement to `>=0.5.0`. #1448
 - Migrated from `PanDB` / `PanFileDB` JSON database to `TelemetryClient` / telemetry server (`panoptes-utils` v0.5.0+). Requires the `panoptes-utils telemetry run` server running on port 6562 before POCS starts.
+- Added `pocs-telemetry-server` program to `pocs-supervisord.conf` (port 6562, `priority=1`, data stored in `/home/panoptes/telemetry`).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - `POCS.from_config` now accepts `simulators=["all"]` (a list) in addition to `simulators="all"` (a string).
 - Improvements to `pocs config setup`: base directory now defaults to the current working directory; added `--from` option to load a base config (auto-detects `conf_files/pocs.yaml` if present); added `--force` to skip the overwrite prompt; timezone detection now uses the system's `/etc/localtime` symlink (no subprocess, no confusing errors); GMT offset computed via Python's `datetime`; fixed double-colon in unit prompts.
 - POCS now auto-creates any missing configured directories (e.g. `images`, `resources`) on startup, logging each creation.
+- Added `pocs telemetry run` CLI command (`src/panoptes/pocs/utils/cli/telemetry.py`) — starts the POCS-flavoured telemetry server with an optional Firestore upload hook (`--no-upload` disables it for local dev).
+- Added `src/panoptes/pocs/utils/service/telemetry.py` with `make_firestore_hook()` and `make_pocs_telemetry_app()` — Firestore upload is non-blocking and non-fatal.
 
 ### Changed
 
@@ -21,6 +23,7 @@
 ### Removed
 
 - Legacy HTTP config server; POCS no longer depends on a running config server process. #1448
+- Removed `pocs-metadata-uploader` supervisord program — Firestore metadata uploads are now handled directly inside the telemetry server process via `post_event_hooks`.
 
 
 ## 0.8.3 - 2026-05-26
@@ -43,6 +46,7 @@ Security and dependency updates, plus a new weather station setup command.
 - Updated `Pillow` to `>=12.2.0` (OOB write with invalid PSD tiles; FITS GZIP decompression bomb).
 - Updated `urllib3` to `>=2.7.0` (decompression-bomb bypass; sensitive header forwarding).
 - Updated `pyopenssl` to `>=26.0.0` (DTLS cookie callback buffer overflow).
+
 
 ## 0.8.2 - 2026-04-15
 

--- a/conf_files/pocs-supervisord.conf
+++ b/conf_files/pocs-supervisord.conf
@@ -66,7 +66,7 @@ killasgroup=true
 [program:pocs-metadata-uploader]
 user=panoptes
 directory=/home/panoptes
-command=pocs network upload-metadata --verbose --dir-path="/home/panoptes/json_store/panoptes"
+command=pocs network upload-metadata --verbose --dir-path="/home/panoptes/telemetry"
 redirect_stderr=true
 stdout_logfile=/home/panoptes/logs/metadata-uploader.log
 autostart=true

--- a/conf_files/pocs-supervisord.conf
+++ b/conf_files/pocs-supervisord.conf
@@ -12,7 +12,7 @@ environment=
 priority=1
 user=panoptes
 directory=/home/panoptes
-command=panoptes-utils telemetry run --host 0.0.0.0 --port 6562 --site-dir /home/panoptes/telemetry
+command=pocs telemetry run --host 0.0.0.0 --port 6562 --site-dir /home/panoptes/telemetry
 redirect_stderr=true
 stdout_logfile=/home/panoptes/logs/telemetry-server.log
 autorestart=true
@@ -63,12 +63,5 @@ autostart=false
 stopasgroup=true
 killasgroup=true
 
-[program:pocs-metadata-uploader]
-user=panoptes
-directory=/home/panoptes
-command=pocs network upload-metadata --verbose --dir-path="/home/panoptes/telemetry"
-redirect_stderr=true
-stdout_logfile=/home/panoptes/logs/metadata-uploader.log
-autostart=true
-stopasgroup=true
-killasgroup=true
+; Metadata is now uploaded to Firestore directly by the pocs-telemetry-server
+; via the post_event_hooks mechanism. The separate uploader process is no longer needed.

--- a/conf_files/pocs-supervisord.conf
+++ b/conf_files/pocs-supervisord.conf
@@ -8,6 +8,17 @@ environment=
     PATH="/home/panoptes/bin:/usr/bin:%(ENV_PATH)s",
     GOOGLE_APPLICATION_CREDENTIALS="/home/panoptes/keys/panoptes-upload-key.json"
 
+[program:pocs-telemetry-server]
+priority=1
+user=panoptes
+directory=/home/panoptes
+command=panoptes-utils telemetry run --host 0.0.0.0 --port 6562 --site-dir /home/panoptes/telemetry
+redirect_stderr=true
+stdout_logfile=/home/panoptes/logs/telemetry-server.log
+autorestart=true
+stopasgroup=true
+killasgroup=true
+
 [program:pocs-power-monitor]
 user=panoptes
 directory=/home/panoptes

--- a/conf_files/pocs.yaml
+++ b/conf_files/pocs.yaml
@@ -169,7 +169,6 @@ environment:
 observations:
   make_timelapse: False
   compress_fits: True
-  record_observations: True
   make_pretty_images: True
   keep_jpgs: False
   plate_solve: False

--- a/conf_files/pocs.yaml
+++ b/conf_files/pocs.yaml
@@ -33,11 +33,6 @@ directories:
   mounts: resources/mounts
   fields: conf_files/fields
 
-db:
-  name: panoptes
-  type: file
-  folder: json_store
-
 telemetry:
   host: localhost
   port: 6562

--- a/conf_files/pocs.yaml
+++ b/conf_files/pocs.yaml
@@ -38,6 +38,10 @@ db:
   type: file
   folder: json_store
 
+telemetry:
+  host: localhost
+  port: 6562
+
 wait_delay: 180 # time in seconds before checking safety/etc while waiting.
 max_transition_attempts: 5  # number of transitions attempts.
 max_observing_attempts: 3  # maximum number of observing loop iterations before stopping.

--- a/conftest.py
+++ b/conftest.py
@@ -9,7 +9,8 @@ import pytest
 from panoptes.utils.config import store as config_store
 from panoptes.utils.telemetry.server import telemetry_server
 
-from panoptes.pocs import hardware, base as pocs_base
+from panoptes.pocs import base as pocs_base
+from panoptes.pocs import hardware
 from panoptes.pocs.utils.location import download_iers_a_file
 from panoptes.pocs.utils.logger import PanLogger, get_logger
 

--- a/conftest.py
+++ b/conftest.py
@@ -9,7 +9,7 @@ import pytest
 from panoptes.utils.config import store as config_store
 from panoptes.utils.telemetry.server import telemetry_server
 
-from panoptes.pocs import hardware
+from panoptes.pocs import hardware, base as pocs_base
 from panoptes.pocs.utils.location import download_iers_a_file
 from panoptes.pocs.utils.logger import PanLogger, get_logger
 
@@ -72,6 +72,9 @@ def pytest_configure(config):
     proc = telemetry_server(site_dir=_telemetry_dir, host=telemetry_host, port=telemetry_port)
     config._telemetry_proc = proc
     config._telemetry_dir = _telemetry_dir
+
+    # Reset the global so PanBase picks up the test telemetry port on next instantiation.
+    pocs_base.PAN_TELEMETRY_OBJ = None
     logger.success("Telemetry server set up")
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -7,14 +7,13 @@ from contextlib import suppress
 import pytest
 
 from panoptes.utils.config import store as config_store
+from panoptes.utils.telemetry.server import telemetry_server
 
 from panoptes.pocs import hardware
 from panoptes.pocs.utils.location import download_iers_a_file
 from panoptes.pocs.utils.logger import PanLogger, get_logger
 
-_all_databases = ["file", "memory"]
-
-TESTING_LOG_LEVEL = "DEBUG"
+TESTING_LOG_LEVEL = "TRACE"
 LOGGER_INFO = PanLogger()
 
 logger = get_logger(console_log_level=TESTING_LOG_LEVEL)
@@ -62,10 +61,35 @@ def pytest_configure(config):
     download_iers_a_file()
     logger.success("Test config loaded")
 
+    logger.info("Setting up the telemetry server.")
+    telemetry_host = "localhost"
+    telemetry_port = 6562
+    _telemetry_dir = tempfile.mkdtemp(prefix="panoptes-testing-telemetry-")
+
+    os.environ["PANOPTES_TELEMETRY_HOST"] = telemetry_host
+    os.environ["PANOPTES_TELEMETRY_PORT"] = str(telemetry_port)
+
+    proc = telemetry_server(site_dir=_telemetry_dir, host=telemetry_host, port=telemetry_port)
+    config._telemetry_proc = proc
+    config._telemetry_dir = _telemetry_dir
+    logger.success("Telemetry server set up")
+
+
+def pytest_unconfigure(config):
+    """Tear down the telemetry server and clean up temp dir."""
+    proc = getattr(config, "_telemetry_proc", None)
+    if proc is not None and proc.is_alive():
+        proc.terminate()
+        proc.join(timeout=5)
+        logger.info("Telemetry server stopped")
+    telemetry_dir = getattr(config, "_telemetry_dir", None)
+    if telemetry_dir:
+        with suppress(Exception):
+            shutil.rmtree(telemetry_dir)
+
 
 def pytest_addoption(parser):
     hw_names = ",".join(hardware.get_all_names()) + " (or all for all hardware)"
-    db_names = ",".join(_all_databases) + " (or all for all databases)"
     group = parser.getgroup("PANOPTES pytest options")
     group.addoption(
         "--with-hardware",
@@ -78,14 +102,6 @@ def pytest_addoption(parser):
         nargs="+",
         default=[],
         help=f"A comma separated list of hardware to NOT test.  List items can include: {hw_names}",
-    )
-    group.addoption(
-        "--test-databases",
-        nargs="+",
-        default=["file"],
-        help=f"Test databases in the list. List items can include: {db_names}. Note that "
-        f"travis-ci will test all of "
-        f"them by default.",
     )
     group.addoption(
         "--test-solve",

--- a/conftest.py
+++ b/conftest.py
@@ -63,7 +63,7 @@ def pytest_configure(config):
 
     logger.info("Setting up the telemetry server.")
     telemetry_host = "localhost"
-    telemetry_port = 6562
+    telemetry_port = 6572  # separate from production port (6562); matches tests/testing.yaml
     _telemetry_dir = tempfile.mkdtemp(prefix="panoptes-testing-telemetry-")
 
     os.environ["PANOPTES_TELEMETRY_HOST"] = telemetry_host

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -369,6 +369,18 @@ pocs config setup
 POCS loads config directly from `~/.panoptes/config.yaml` (or `$PANOPTES_CONFIG_FILE`).
 No separate server process is required.
 
+### Telemetry Server Not Running
+
+**Error:** "Cannot connect to telemetry server" or `TelemetryClient` connection errors at startup
+
+**Solution:**
+```bash
+# Start the telemetry server (stores observatory state, sensor readings, and observations)
+panoptes-utils telemetry run --site-dir telemetry/
+```
+
+The telemetry server must be running before POCS starts. It stores data as NDJSON files under `--site-dir`.
+
 ### Mount Not Responding
 
 **Problem:** Mount commands don't work

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -376,7 +376,7 @@ No separate server process is required.
 **Solution:**
 ```bash
 # Start the telemetry server (stores observatory state, sensor readings, and observations)
-panoptes-utils telemetry run --site-dir telemetry/
+pocs telemetry run --site-dir telemetry/
 ```
 
 The telemetry server must be running before POCS starts. It stores data as NDJSON files under `--site-dir`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "GitPython",
     "human-readable",
     "numpy>=2",
-    "panoptes-utils[images]>=0.5.0,<3.0",
+    "panoptes-utils[images,telemetry]>=0.5.0,<3.0",
     "pandas",
     "pick",
     "pillow>=12.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ dependencies = [
     "typer",
     "typing-inspect",
     "urllib3>=2.7.0",
-    "watchdog",
     "cryptography>=46.0.5",
 ]
 

--- a/resources/scripts/install/install-pocs.sh
+++ b/resources/scripts/install/install-pocs.sh
@@ -22,7 +22,6 @@ cd "$PANDIR"
 echo "Creating POCS directories."
 mkdir -p "${HOME}/logs"
 mkdir -p "${HOME}/images"
-mkdir -p "${HOME}/json_store"
 mkdir -p "${HOME}/telemetry"
 mkdir -p "${HOME}/keys"
 

--- a/resources/scripts/install/install-pocs.sh
+++ b/resources/scripts/install/install-pocs.sh
@@ -23,6 +23,7 @@ echo "Creating POCS directories."
 mkdir -p "${HOME}/logs"
 mkdir -p "${HOME}/images"
 mkdir -p "${HOME}/json_store"
+mkdir -p "${HOME}/telemetry"
 mkdir -p "${HOME}/keys"
 
 # Link the needed POCS folders.

--- a/src/panoptes/pocs/base.py
+++ b/src/panoptes/pocs/base.py
@@ -4,6 +4,7 @@ Provides PanBase, which centralizes access to configuration, logging, and the
 shared lightweight telemetry client handle used throughout the project.
 """
 
+import os
 import warnings
 from typing import Any
 

--- a/src/panoptes/pocs/base.py
+++ b/src/panoptes/pocs/base.py
@@ -66,9 +66,15 @@ class PanBase:
             PAN_TELEMETRY_OBJ = kwargs.pop("db")
         elif PAN_TELEMETRY_OBJ is None:
             telemetry_host = kwargs.get(
-                "telemetry_host", self.get_config("telemetry.host", default="localhost")
+                "telemetry_host",
+                os.getenv("PANOPTES_TELEMETRY_HOST", self.get_config("telemetry.host", default="localhost")),
             )
-            telemetry_port = kwargs.get("telemetry_port", self.get_config("telemetry.port", default=6562))
+            telemetry_port = int(
+                kwargs.get(
+                    "telemetry_port",
+                    os.getenv("PANOPTES_TELEMETRY_PORT", self.get_config("telemetry.port", default=6562)),
+                )
+            )
             PAN_TELEMETRY_OBJ = TelemetryClient(host=telemetry_host, port=telemetry_port)
 
         self.db = PAN_TELEMETRY_OBJ

--- a/src/panoptes/pocs/base.py
+++ b/src/panoptes/pocs/base.py
@@ -1,7 +1,7 @@
 """Common base utilities for POCS classes.
 
 Provides PanBase, which centralizes access to configuration, logging, and the
-shared lightweight database handle used throughout the project.
+shared lightweight telemetry client handle used throughout the project.
 """
 
 import warnings
@@ -10,13 +10,13 @@ from typing import Any
 from loguru import logger as _bootstrap_logger
 
 from panoptes.utils.config import store as config_store
-from panoptes.utils.database import PanDB
+from panoptes.utils.telemetry import TelemetryClient
 
 from panoptes.pocs import __version__, hardware
 from panoptes.pocs.utils.logger import get_logger
 
-# Global database.
-PAN_DB_OBJ = None
+# Global telemetry client.
+PAN_TELEMETRY_OBJ = None
 
 
 class PanBase:
@@ -61,14 +61,17 @@ class PanBase:
             log_dir=kwargs.get("log_dir", log_dir), cloud_logging_level=cloud_logging_level
         )
 
-        global PAN_DB_OBJ
-        if PAN_DB_OBJ is None:
-            db_name = kwargs.get("db_name", self.get_config("db.name", default="panoptes"))
-            db_folder = kwargs.get("db_folder", self.get_config("db.folder", default="json_store"))
-            db_type = kwargs.get("db_type", self.get_config("db.type", default="file"))
-            PAN_DB_OBJ = PanDB(db_name=db_name, storage_dir=db_folder, db_type=db_type)
+        global PAN_TELEMETRY_OBJ
+        if "db" in kwargs:
+            PAN_TELEMETRY_OBJ = kwargs.pop("db")
+        elif PAN_TELEMETRY_OBJ is None:
+            telemetry_host = kwargs.get(
+                "telemetry_host", self.get_config("telemetry.host", default="localhost")
+            )
+            telemetry_port = kwargs.get("telemetry_port", self.get_config("telemetry.port", default=6562))
+            PAN_TELEMETRY_OBJ = TelemetryClient(host=telemetry_host, port=telemetry_port)
 
-        self.db = PAN_DB_OBJ
+        self.db = PAN_TELEMETRY_OBJ
 
     def get_config(
         self, key: str | None = None, default: Any | None = None, remember: bool = False, *args, **kwargs

--- a/src/panoptes/pocs/config/models.py
+++ b/src/panoptes/pocs/config/models.py
@@ -110,7 +110,6 @@ class ObservationsConfig(BaseModel):
 
     make_timelapse: bool = False
     compress_fits: bool = True
-    record_observations: bool = True
     make_pretty_images: bool = True
     keep_jpgs: bool = False
     plate_solve: bool = False

--- a/src/panoptes/pocs/core.py
+++ b/src/panoptes/pocs/core.py
@@ -402,8 +402,13 @@ class POCS(PanStateMachine, PanBase):
             )
         safe = all([v for k, v in is_safe_values.items() if k not in ignore])
 
-        # Insert safety reading
-        self.db.insert_current("safety", is_safe_values, store_permanently=False)
+        # Insert safety reading — only persist when values change to avoid
+        # flooding the telemetry log at loop cadence.
+        if is_safe_values != getattr(self, "_last_safety_values", None):
+            self._last_safety_values = is_safe_values
+            self.db.insert_current("safety", is_safe_values)
+        else:
+            self.db.insert_current("safety", is_safe_values, store_permanently=False)
 
         if not safe:
             if no_warning is False:

--- a/src/panoptes/pocs/core.py
+++ b/src/panoptes/pocs/core.py
@@ -86,6 +86,15 @@ class POCS(PanStateMachine, PanBase):
 
         self.say("Hi there!")
 
+        # Clear any stale telemetry run left over from a previous session so
+        # that events recorded before the first scheduling cycle are not
+        # incorrectly associated with an old run.
+        try:
+            self.db.stop_run()
+            self.logger.debug("Stopped stale telemetry run on POCS init")
+        except Exception:
+            pass  # No active run — that's expected on a clean start.
+
     @property
     def is_initialized(self) -> bool:
         """Indicates if POCS has been initialized or not."""

--- a/src/panoptes/pocs/core.py
+++ b/src/panoptes/pocs/core.py
@@ -581,7 +581,7 @@ class POCS(PanStateMachine, PanBase):
                 with suppress(KeyError):
                     has_power = bool(record["data"][power_key])
 
-            date = record["date"].replace(tzinfo=None)  # current_time is timezone naive
+            date = Time(record["date"]).datetime  # ts is an ISO string; Time parses it as UTC naive
             age = (current_time().datetime - date).total_seconds()
 
             self.logger.debug(f"Power Safety: {has_power} [{age:.0f}s old - {date:%m-%d %H:%M:%S}]")

--- a/src/panoptes/pocs/filterwheel/libefw.py
+++ b/src/panoptes/pocs/filterwheel/libefw.py
@@ -26,9 +26,7 @@ class EFWDriver(AbstractSDKDriver):
     AbstractFilterWheel implementations.
     """
 
-    # Because ZWO EFW library isn't linked properly have to manually load libudev
-    # in global mode first, otherwise get undefined symbol errors.
-    _libudev = load_c_library("udev", mode=ctypes.RTLD_GLOBAL)
+    _libudev = None
 
     def __init__(self, library_path=None, **kwargs):
         """Main class representing the ZWO EFW library interface.
@@ -51,6 +49,11 @@ class EFWDriver(AbstractSDKDriver):
             `OSError`: raises if the ctypes.CDLL loader cannot load the library.
         """
         super().__init__(name="EFWFilter", library_path=library_path, **kwargs)
+
+        # Because ZWO EFW library isn't linked properly have to manually load libudev
+        # in global mode first, otherwise get undefined symbol errors.
+        if EFWDriver._libudev is None:
+            EFWDriver._libudev = load_c_library("udev", mode=ctypes.RTLD_GLOBAL)
 
     # Methods
 

--- a/src/panoptes/pocs/observatory.py
+++ b/src/panoptes/pocs/observatory.py
@@ -510,7 +510,6 @@ class Observatory(PanBase):
     def process_observation(
         self,
         compress_fits: bool | None = None,
-        record_observations: bool | None = None,
         make_pretty_images: bool | None = None,
         plate_solve: bool | None = None,
         upload_image: bool | None = None,
@@ -522,7 +521,7 @@ class Observatory(PanBase):
             1. First checks to make sure that the file exists on the file system.
             2. Calls `_process_fits` with the filename and info, which is specific to each camera.
             3. Makes pretty images if requested.
-            4. Records observation metadata if requested.
+            4. Records observation metadata permanently to the telemetry store.
             5. Compress FITS files if requested.
             6. Sets the observation_event.
 
@@ -532,9 +531,6 @@ class Observatory(PanBase):
         Args:
             compress_fits (bool or None): If FITS files should be fpacked into .fits.fz.
                 If None (default), checks the `observations.compress_fits` config key.
-            record_observations (bool or None): If observation metadata should be saved.
-                If None (default), checks the `observations.record_observations`
-                config key.
             make_pretty_images (bool or None): Make a jpg from raw image.
                 If None (default), checks the `observations.make_pretty_images`
                 config key.

--- a/src/panoptes/pocs/observatory.py
+++ b/src/panoptes/pocs/observatory.py
@@ -664,12 +664,9 @@ class Observatory(PanBase):
                 except Exception as e:
                     self.logger.warning(f"Problem uploading exposure: {e!r}")
 
-            if record_observations is None:
-                record_observations = self.get_config("observations.record_observations", default=False)
-            if record_observations:
-                self.logger.debug(f"Adding current observation to db: {image_id}")
-                metadata["status"] = "complete"
-                self.db.insert_current("images", metadata, store_permanently=False)
+            self.logger.debug(f"Adding current observation to db: {image_id}")
+            metadata["status"] = "complete"
+            self.db.insert_current("images", metadata)
 
     def analyze_recent(self):
         """Analyze the most recent exposure

--- a/src/panoptes/pocs/scheduler/observation/base.py
+++ b/src/panoptes/pocs/scheduler/observation/base.py
@@ -219,6 +219,20 @@ class Observation(PanBase):
         self._seq_time = time
 
     @property
+    def sequence_id(self) -> str | None:
+        """Unique identifier for this observation run, derived from the selection timestamp.
+
+        Returns ``None`` until ``seq_time`` has been set (i.e. before the observation is
+        scheduled).  Use this as the run directory name under the telemetry ``runs/``
+        subfolder so that all run-scoped telemetry is co-located:
+        ``<site_dir>/runs/<sequence_id>/``.
+
+        Returns:
+            str: ISO-formatted selection timestamp, or ``None`` if not yet scheduled.
+        """
+        return self._seq_time
+
+    @property
     def directory(self) -> Path:
         """Return the directory for this Observation.
 

--- a/src/panoptes/pocs/sensor/power.py
+++ b/src/panoptes/pocs/sensor/power.py
@@ -253,7 +253,7 @@ class PowerBoard(PanBase):
         recent_values = self.readings
 
         collection_name = collection_name or self.arduino_board_name
-        self.db.insert_current(collection_name, recent_values, store_permanently=False)
+        self.db.insert_current(collection_name, recent_values)
 
         return recent_values
 

--- a/src/panoptes/pocs/sensor/weather.py
+++ b/src/panoptes/pocs/sensor/weather.py
@@ -88,11 +88,11 @@ class WeatherStation(PanBase):
         return reading
 
     def record(self):
-        """Capture a fresh reading and persist it to the database.
+        """Capture a fresh reading and persist it to the telemetry store.
 
         Calls :meth:`aag.weather.CloudSensor.get_reading` to obtain an averaged
-        sensor snapshot, then stores it in the ``weather`` database collection via
-        :meth:`panoptes.utils.db.PanDB.insert_current`.
+        sensor snapshot, then stores it in the ``weather`` collection via
+        :meth:`panoptes.utils.telemetry.client.TelemetryClient.insert_current`.
 
         The stored document contains the same fields described in :attr:`status`.
         The two fields that POCS reads back when evaluating safety are:

--- a/src/panoptes/pocs/sensor/weather.py
+++ b/src/panoptes/pocs/sensor/weather.py
@@ -41,7 +41,7 @@ class WeatherStation(PanBase):
         self.serial_port = serial_port or conf.get("serial_port", "/dev/ttyUSB0")
         self.name = name
         self.collection_name = db_collection
-        self.store_permanently = conf.pop("store_permanently", False)
+        self.store_permanently = conf.pop("store_permanently", True)
 
         self.logger.debug(f"Setting up weather station connection for {name=} on {self.serial_port}")
         self.weather_station = CloudSensor(serial_port=self.serial_port, **conf)

--- a/src/panoptes/pocs/state/machine.py
+++ b/src/panoptes/pocs/state/machine.py
@@ -209,9 +209,7 @@ class PanStateMachine(Machine):
         state_changed = transition_method()
         if state_changed:
             self.logger.success(f"Finished with {self.state} state")
-            self.db.insert_current(
-                "state", {"source": self.state, "dest": self.next_state}, store_permanently=False
-            )
+            self.db.insert_current("state", {"source": self.state, "dest": self.next_state})
 
         return state_changed
 

--- a/src/panoptes/pocs/state/states/default/parking.py
+++ b/src/panoptes/pocs/state/states/default/parking.py
@@ -9,6 +9,13 @@ def on_enter(event_data):
     """Handle transition into the parking state."""
     pocs = event_data.model
 
+    # Stop the telemetry run for the current observation (if one is active).
+    try:
+        pocs.db.stop_run()
+        pocs.logger.debug("Telemetry run stopped")
+    except Exception as e:
+        pocs.logger.warning(f"Unable to stop telemetry run: {e!r}")
+
     # Clear any current observation
     pocs.observatory.current_observation = None
     pocs.observatory.current_offset_info = None

--- a/src/panoptes/pocs/state/states/default/scheduling.py
+++ b/src/panoptes/pocs/state/states/default/scheduling.py
@@ -5,6 +5,7 @@ proper next state (slewing, tracking, or parking) based on availability.
 """
 
 from panoptes.utils import error
+from panoptes.utils.time import current_time
 
 
 def on_enter(event_data):
@@ -43,10 +44,16 @@ def on_enter(event_data):
             else:
                 pocs.say(f"Got it! I'm going to check out: {observation.name}")
 
-                # Start a new telemetry run scoped to this observation's directory.
+                # Stamp the observation with the scheduler selection time so that
+                # seq_time is available immediately (cameras will reuse it rather
+                # than stamping again on first exposure).
+                observation.seq_time = current_time(flatten=True)
+
+                # Start a new telemetry run under runs/<sequence_id>/ inside the
+                # telemetry site directory.  Images remain in directories.images.
                 try:
-                    pocs.db.start_run(run_dir=observation.directory)
-                    pocs.logger.debug(f"Telemetry run started for {observation.directory}")
+                    pocs.db.start_run(run_dir=f"runs/{observation.sequence_id}")
+                    pocs.logger.debug(f"Telemetry run started: runs/{observation.sequence_id}")
                 except Exception as e:
                     pocs.logger.warning(f"Unable to start telemetry run: {e!r}")
 

--- a/src/panoptes/pocs/state/states/default/scheduling.py
+++ b/src/panoptes/pocs/state/states/default/scheduling.py
@@ -43,6 +43,13 @@ def on_enter(event_data):
             else:
                 pocs.say(f"Got it! I'm going to check out: {observation.name}")
 
+                # Start a new telemetry run scoped to this observation's directory.
+                try:
+                    pocs.db.start_run(run_dir=observation.directory)
+                    pocs.logger.debug(f"Telemetry run started for {observation.directory}")
+                except Exception as e:
+                    pocs.logger.warning(f"Unable to start telemetry run: {e!r}")
+
                 pocs.logger.debug(f"Setting Observation coords: {observation.field}")
                 if pocs.observatory.mount.set_target_coordinates(observation.field) is True:
                     pocs.next_state = "slewing"

--- a/src/panoptes/pocs/state/states/default/scheduling.py
+++ b/src/panoptes/pocs/state/states/default/scheduling.py
@@ -51,6 +51,12 @@ def on_enter(event_data):
 
                 # Start a new telemetry run under runs/<sequence_id>/ inside the
                 # telemetry site directory.  Images remain in directories.images.
+                # Stop any stale run first (e.g. leftover from a previous POCS
+                # session) so start_run never gets a 409.
+                try:
+                    pocs.db.stop_run()
+                except Exception:
+                    pass  # No active run — that's fine.
                 try:
                     pocs.db.start_run(run_dir=f"runs/{observation.sequence_id}")
                     pocs.logger.debug(f"Telemetry run started: runs/{observation.sequence_id}")

--- a/src/panoptes/pocs/utils/cli/main.py
+++ b/src/panoptes/pocs/utils/cli/main.py
@@ -23,6 +23,7 @@ from panoptes.pocs.utils.cli import (
     power,
     run,
     sensor,
+    telemetry,
     weather,
 )
 
@@ -37,6 +38,7 @@ app.add_typer(notebook.app, name="notebook", help="Start Jupyter notebook enviro
 app.add_typer(power.app, name="power", help="Interact with power relays.")
 app.add_typer(run.app, name="run", help="Run POCS!")
 app.add_typer(sensor.app, name="sensor", help="Interact with system sensors.")
+app.add_typer(telemetry.app, name="telemetry", help="Run the POCS telemetry server.")
 app.add_typer(weather.app, name="weather", help="Interact with weather station service.")
 
 

--- a/src/panoptes/pocs/utils/cli/network.py
+++ b/src/panoptes/pocs/utils/cli/network.py
@@ -14,7 +14,7 @@ import typer
 from google.cloud import storage
 from rich import print
 
-from panoptes.utils.config.store import get_config, set_config
+from panoptes.utils.config.store import set_config
 
 from panoptes.pocs.utils.cloud import upload_image
 

--- a/src/panoptes/pocs/utils/cli/network.py
+++ b/src/panoptes/pocs/utils/cli/network.py
@@ -1,21 +1,18 @@
 """Typer CLI commands for PANOPTES networking and uploads.
 
-Includes helpers to retrieve a service account key, watch and upload JSON metadata
-to Firestore, and upload images or directories to Google Cloud Storage.
+Includes helpers to retrieve a service account key and upload images or
+directories to Google Cloud Storage. Metadata uploads to Firestore are handled
+by the telemetry server's post-event hook — see `pocs telemetry run`.
 """
 
-import json
 import os
 import stat
-import time
 from pathlib import Path
 
 import requests
 import typer
-from google.cloud import firestore, storage
+from google.cloud import storage
 from rich import print
-from watchdog.events import FileSystemEventHandler
-from watchdog.observers import Observer
 
 from panoptes.utils.config.store import get_config, set_config
 
@@ -110,89 +107,6 @@ def get_key_cmd(
             print(f"[red]Error updating config: {e}[/]")
 
 
-@app.command("upload-metadata")
-def upload_metadata(
-    dir_path: Path = "/home/panoptes/telemetry",
-    unit_id: str = None,
-    verbose: bool = False,
-):
-    """Watch a directory and upload JSON metadata files to Firestore.
-
-    Args:
-        dir_path (Path): Directory containing JSON envelopes to watch. Defaults to
-            '/home/panoptes/telemetry'.
-        unit_id (str | None): Unit identifier to attach to records; if None uses
-            environment/config via _get_unit_id().
-        verbose (bool): If True, echo progress and debug information.
-
-    Returns:
-        None
-
-    Notes:
-        Expects files named with 'current' under dir_path that contain envelopes of
-        the form {'type': <record_type>, 'data': {...}, 'date': ...}. Records are
-        added under units/{unit_id}/metadata and the unit document is updated.
-    """
-    unit_id = unit_id or _get_unit_id()
-
-    if verbose:
-        print(f"Listening to {dir_path.absolute()} for {unit_id}")
-
-    firestore_db = firestore.Client()
-    # Get the unit reference to link metadata to unit.
-    unit_ref = firestore_db.document(f"units/{unit_id}")
-    metadata_records_ref = unit_ref.collection("metadata")
-
-    def handleEvent(event):
-        if event.is_directory:
-            return
-
-        if "current" not in event.src_path:
-            if verbose:
-                print(f"Skipping {event.src_path}")
-            return
-
-        try:
-            record = json.loads(Path(event.src_path).read_text())
-
-            # Unpack the envelope.
-            record_type = record["type"]
-            data = record["data"]
-            data["date"] = record["date"]
-            data["received_time"] = firestore.SERVER_TIMESTAMP
-
-            if verbose:
-                print(f"Adding data for {record_type=}: {data}")
-
-            # Update the unit's metadata with the record_type.
-            unit_ref.set(
-                {
-                    "metadata": {record_type: data},
-                    "last_updated": firestore.SERVER_TIMESTAMP,
-                },
-                merge=True,
-            )
-
-            # Add the record, storing the record_type name in the data.
-            data["record_type"] = record_type
-            doc_ts, doc_id = metadata_records_ref.add(data)
-            if verbose:
-                print(f"Added data to firestore with {doc_id.id=} at {doc_ts}")
-        except Exception as e:
-            print(f"Exception {e!r}")
-
-    file_observer = _start_event_handler(dir_path, handleEvent)
-    try:
-        while True:
-            time.sleep(1)
-    except KeyboardInterrupt:
-        if verbose:
-            print("Cleaning up file watcher")
-        file_observer.stop()
-    finally:
-        file_observer.join()
-
-
 @upload_app.command("image")
 def upload_image_cmd(
     file_path: Path,
@@ -273,23 +187,3 @@ def upload_directory(
                 continue
 
     return public_urls
-
-
-def _get_unit_id():
-    """Get the unit id from the environment or config."""
-    unit_id = os.getenv("UNIT_ID", get_config("pan_id"))
-
-    if unit_id is None:
-        raise ValueError("No unit id found in environment or config")
-
-    return unit_id
-
-
-def _start_event_handler(dir_path: Path, handle_event: callable):
-    """Start the event handler."""
-    event_handler = FileSystemEventHandler()
-    event_handler.on_modified = handle_event
-    file_observer = Observer()
-    file_observer.schedule(event_handler, dir_path.as_posix())
-    file_observer.start()
-    return file_observer

--- a/src/panoptes/pocs/utils/cli/network.py
+++ b/src/panoptes/pocs/utils/cli/network.py
@@ -112,7 +112,7 @@ def get_key_cmd(
 
 @app.command("upload-metadata")
 def upload_metadata(
-    dir_path: Path = "/home/panoptes/json_store/panoptes",
+    dir_path: Path = "/home/panoptes/telemetry",
     unit_id: str = None,
     verbose: bool = False,
 ):
@@ -120,7 +120,7 @@ def upload_metadata(
 
     Args:
         dir_path (Path): Directory containing JSON envelopes to watch. Defaults to
-            '/home/panoptes/json_store/panoptes'.
+            '/home/panoptes/telemetry'.
         unit_id (str | None): Unit identifier to attach to records; if None uses
             environment/config via _get_unit_id().
         verbose (bool): If True, echo progress and debug information.

--- a/src/panoptes/pocs/utils/cli/run.py
+++ b/src/panoptes/pocs/utils/cli/run.py
@@ -79,11 +79,11 @@ def get_pocs(context: typer.Context):
     pocs = POCS.from_config(simulators=simulators)
 
     pocs.logger.debug("POCS created from config")
-    pocs.logger.debug("Sending POCS config to cloud")
+    pocs.logger.debug("Sending POCS config to telemetry server")
     try:
         pocs.db.insert_current("config", pocs.get_config())
     except Exception as e:
-        pocs.logger.warning(f"Unable to send config to cloud: {e}")
+        pocs.logger.warning(f"Unable to send config to telemetry server: {e}")
 
     pocs.initialize()
 

--- a/src/panoptes/pocs/utils/cli/run.py
+++ b/src/panoptes/pocs/utils/cli/run.py
@@ -291,7 +291,6 @@ def run_quick_alignment(
             kwargs=dict(
                 plate_solve=True,
                 compress_fits=False,
-                record_observations=False,
                 make_pretty_images=False,
                 upload_image=False,
             ),

--- a/src/panoptes/pocs/utils/cli/telemetry.py
+++ b/src/panoptes/pocs/utils/cli/telemetry.py
@@ -1,0 +1,48 @@
+"""Typer CLI commands for the POCS telemetry server."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+import uvicorn
+
+app = typer.Typer(no_args_is_help=True)
+
+
+@app.command("run")
+def run_telemetry_server(
+    host: str = typer.Option("0.0.0.0", help="Host address to bind the telemetry server to."),
+    port: int = typer.Option(6562, help="Port number to bind the telemetry server to."),
+    site_dir: Path = typer.Option(Path("telemetry"), help="Directory for rotated NDJSON telemetry files."),
+    unit_id: str = typer.Option(
+        None, help="PANOPTES unit id for Firestore uploads. Defaults to UNIT_ID env var."
+    ),
+    no_upload: bool = typer.Option(False, "--no-upload", help="Disable Firestore uploads (local dev mode)."),
+):
+    """Run the POCS telemetry server with optional Firestore mirroring.
+
+    This replaces the separate ``pocs-telemetry-server`` + ``pocs-metadata-uploader``
+    supervisord processes with a single service.  Events marked
+    ``store_permanently=True`` are mirrored to Firestore in a background thread
+    unless ``--no-upload`` is given.
+
+    Args:
+        host: Bind address for the uvicorn server.
+        port: TCP port for the uvicorn server.
+        site_dir: Directory where rotated NDJSON telemetry files are written.
+        unit_id: PANOPTES unit identifier for Firestore document paths.
+        no_upload: When set, skip Firestore uploads (useful for local development
+            without cloud credentials).
+    """
+    from panoptes.pocs.utils.service.telemetry import make_pocs_telemetry_app
+
+    upload = not no_upload
+    telemetry_app = make_pocs_telemetry_app(
+        site_dir=site_dir,
+        unit_id=unit_id,
+        upload_to_firestore=upload,
+    )
+
+    typer.echo(f"Starting POCS telemetry server on {host}:{port} (site_dir={site_dir}, firestore={upload})")
+    uvicorn.run(telemetry_app, host=host, port=port)

--- a/src/panoptes/pocs/utils/cli/telemetry.py
+++ b/src/panoptes/pocs/utils/cli/telemetry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import typer
@@ -46,3 +47,34 @@ def run_telemetry_server(
 
     typer.echo(f"Starting POCS telemetry server on {host}:{port} (site_dir={site_dir}, firestore={upload})")
     uvicorn.run(telemetry_app, host=host, port=port)
+
+
+@app.command("current")
+def current_telemetry(
+    event_type: str = typer.Argument(None, help="Optional event type to fetch (e.g. 'weather', 'power')."),
+    host: str = typer.Option("localhost", envvar="PANOPTES_TELEMETRY_HOST", help="Telemetry server host."),
+    port: int = typer.Option(6562, envvar="PANOPTES_TELEMETRY_PORT", help="Telemetry server port."),
+    follow: bool = typer.Option(False, "--follow", "-f", help="Poll repeatedly and print updated readings."),
+    interval: float = typer.Option(2.0, min=0.1, help="Polling interval in seconds when following."),
+):
+    """Display the current telemetry reading.
+
+    Thin wrapper around ``panoptes-utils telemetry current`` using the same
+    server connection options.
+
+    Args:
+        event_type: Limit output to a single event type instead of the full snapshot.
+        host: Host address of the telemetry server.
+        port: Port number of the telemetry server.
+        follow: When set, poll repeatedly and print updates as they change.
+        interval: Seconds between polls when ``--follow`` is active.
+    """
+    cmd = ["panoptes-utils", "telemetry", "current"]
+    if event_type:
+        cmd.append(event_type)
+    cmd += ["--host", host, "--port", str(port), "--interval", str(interval)]
+    if follow:
+        cmd.append("--follow")
+
+    result = subprocess.run(cmd)
+    raise typer.Exit(result.returncode)

--- a/src/panoptes/pocs/utils/service/telemetry.py
+++ b/src/panoptes/pocs/utils/service/telemetry.py
@@ -46,14 +46,31 @@ def make_firestore_hook(unit_id: str | None = None):
         )
         return lambda envelope, request: None
 
-    resolved_unit_id = unit_id or _get_unit_id()
+    try:
+        resolved_unit_id = unit_id or _get_unit_id()
+    except ValueError as exc:
+        logger.warning(
+            "Firestore uploads disabled: {exc}. "
+            "Set the UNIT_ID environment variable or add 'pan_id' to your config.",
+            exc=exc,
+        )
+        return lambda envelope, request: None
+
+    try:
+        db = firestore.Client()
+    except Exception as exc:
+        logger.warning(
+            "Firestore uploads disabled: failed to create Firestore client: {exc!r}. "
+            "Check that Google Cloud credentials are configured.",
+            exc=exc,
+        )
+        return lambda envelope, request: None
 
     def _hook(envelope: dict[str, Any], request: EventRequest) -> None:
         if not request.store_permanently:
             return
 
         try:
-            db = firestore.Client()
             unit_ref = db.document(f"units/{resolved_unit_id}")
             metadata_records_ref = unit_ref.collection("metadata")
 

--- a/src/panoptes/pocs/utils/service/telemetry.py
+++ b/src/panoptes/pocs/utils/service/telemetry.py
@@ -1,0 +1,127 @@
+"""POCS telemetry service with optional Firestore mirroring.
+
+Provides ``make_firestore_hook`` to create a ``post_event_hook`` callback
+that uploads permanently-stored telemetry events to Firestore, and
+``make_pocs_telemetry_app`` to assemble the FastAPI app with that hook
+already registered.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from panoptes.utils.telemetry.server import EventRequest, TelemetryService, create_app
+
+
+def make_firestore_hook(unit_id: str | None = None):
+    """Return a ``post_event_hook`` callable that mirrors events to Firestore.
+
+    The hook only acts on events where ``request.store_permanently`` is
+    ``True``, matching the previous behaviour of the watchdog-based metadata
+    uploader.  All Firestore imports are deferred so the telemetry server
+    can start even when the Google Cloud SDK is not installed or credentials
+    are unavailable.
+
+    Args:
+        unit_id: PANOPTES unit identifier (e.g. ``"PAN001"``).  Falls back to
+            the ``UNIT_ID`` environment variable, then the ``pan_id`` config
+            key if not provided.
+
+    Returns:
+        A callable suitable for passing as an element of
+        ``TelemetryService``'s ``post_event_hooks`` list.
+    """
+    resolved_unit_id = unit_id or _get_unit_id()
+
+    def _hook(envelope: dict[str, Any], request: EventRequest) -> None:
+        if not request.store_permanently:
+            return
+
+        try:
+            from google.cloud import firestore  # deferred import
+
+            db = firestore.Client()
+            unit_ref = db.document(f"units/{resolved_unit_id}")
+            metadata_records_ref = unit_ref.collection("metadata")
+
+            record_type = envelope.get("type", "unknown")
+            data: dict[str, Any] = dict(envelope.get("data") or {})
+            data["date"] = envelope.get("ts")
+            data["received_time"] = firestore.SERVER_TIMESTAMP
+
+            unit_ref.set(
+                {
+                    "metadata": {record_type: data},
+                    "last_updated": firestore.SERVER_TIMESTAMP,
+                },
+                merge=True,
+            )
+
+            data["record_type"] = record_type
+            metadata_records_ref.add(data)
+
+            logger.debug(
+                "Firestore hook: uploaded {record_type} for {unit_id}",
+                record_type=record_type,
+                unit_id=resolved_unit_id,
+            )
+        except Exception as exc:
+            # Non-fatal: logged as warning by the TelemetryService hook runner,
+            # but we also log here for clarity.
+            logger.warning(
+                "Firestore upload failed for unit {unit_id}: {exc!r}",
+                unit_id=resolved_unit_id,
+                exc=exc,
+            )
+            raise  # re-raise so TelemetryService logs via _fire_hook too
+
+    return _hook
+
+
+def make_pocs_telemetry_app(
+    site_dir: str | Path = "telemetry",
+    unit_id: str | None = None,
+    upload_to_firestore: bool = True,
+):
+    """Create a FastAPI telemetry app with optional Firestore mirroring.
+
+    Args:
+        site_dir: Directory for rotated NDJSON telemetry files.
+        unit_id: PANOPTES unit id for Firestore uploads.  If ``None``,
+            resolved from the ``UNIT_ID`` env var or config.
+        upload_to_firestore: When ``True`` (default), a Firestore hook is
+            registered.  Pass ``False`` for local development without cloud
+            credentials.
+
+    Returns:
+        A FastAPI application instance ready to be served with uvicorn.
+    """
+    hooks = [make_firestore_hook(unit_id)] if upload_to_firestore else []
+    service = TelemetryService(site_dir=site_dir, post_event_hooks=hooks)
+    return create_app(service)
+
+
+def _get_unit_id() -> str:
+    """Resolve the unit id from the environment or config server."""
+    unit_id = os.getenv("UNIT_ID")
+    if unit_id:
+        return unit_id
+
+    try:
+        from panoptes.utils.config.client import get_config
+
+        unit_id = get_config("pan_id")
+    except Exception:
+        pass
+
+    if not unit_id:
+        raise ValueError(
+            "No unit id found. Set the UNIT_ID environment variable or ensure "
+            "the config server is running with a 'pan_id' key."
+        )
+
+    return unit_id

--- a/src/panoptes/pocs/utils/service/telemetry.py
+++ b/src/panoptes/pocs/utils/service/telemetry.py
@@ -22,9 +22,9 @@ def make_firestore_hook(unit_id: str | None = None):
 
     The hook only acts on events where ``request.store_permanently`` is
     ``True``, matching the previous behaviour of the ``upload-metadata``
-    command.  All Firestore imports are deferred so the telemetry server
-    can start even when the Google Cloud SDK is not installed or credentials
-    are unavailable.
+    command.  The Firestore import is checked once at hook-creation time so
+    that a clear diagnostic is shown at startup if the ``google`` extra is
+    missing, rather than a cryptic per-event failure.
 
     Args:
         unit_id: PANOPTES unit identifier (e.g. ``"PAN001"``).  Falls back to
@@ -33,8 +33,19 @@ def make_firestore_hook(unit_id: str | None = None):
 
     Returns:
         A callable suitable for passing as an element of
-        ``TelemetryService``'s ``post_event_hooks`` list.
+        ``TelemetryService``'s ``post_event_hooks`` list.  Returns a no-op
+        callable if ``google-cloud-firestore`` is not installed.
     """
+    try:
+        import google.cloud.firestore as firestore
+    except ImportError:
+        logger.warning(
+            "Firestore uploads disabled: 'google-cloud-firestore' is not installed. "
+            "To enable cloud uploads, re-install with the 'google' extra:\n"
+            "    pip install panoptes-pocs[google]"
+        )
+        return lambda envelope, request: None
+
     resolved_unit_id = unit_id or _get_unit_id()
 
     def _hook(envelope: dict[str, Any], request: EventRequest) -> None:
@@ -42,8 +53,6 @@ def make_firestore_hook(unit_id: str | None = None):
             return
 
         try:
-            from google.cloud import firestore  # deferred import
-
             db = firestore.Client()
             unit_ref = db.document(f"units/{resolved_unit_id}")
             metadata_records_ref = unit_ref.collection("metadata")
@@ -106,13 +115,13 @@ def make_pocs_telemetry_app(
 
 
 def _get_unit_id() -> str:
-    """Resolve the unit id from the environment or config server."""
+    """Resolve the unit id from the environment or config."""
     unit_id = os.getenv("UNIT_ID")
     if unit_id:
         return unit_id
 
     try:
-        from panoptes.utils.config.client import get_config
+        from panoptes.utils.config.store import get_config
 
         unit_id = get_config("pan_id")
     except Exception:
@@ -121,7 +130,7 @@ def _get_unit_id() -> str:
     if not unit_id:
         raise ValueError(
             "No unit id found. Set the UNIT_ID environment variable or ensure "
-            "the config server is running with a 'pan_id' key."
+            "the config file contains a 'pan_id' key."
         )
 
     return unit_id

--- a/src/panoptes/pocs/utils/service/telemetry.py
+++ b/src/panoptes/pocs/utils/service/telemetry.py
@@ -21,8 +21,8 @@ def make_firestore_hook(unit_id: str | None = None):
     """Return a ``post_event_hook`` callable that mirrors events to Firestore.
 
     The hook only acts on events where ``request.store_permanently`` is
-    ``True``, matching the previous behaviour of the watchdog-based metadata
-    uploader.  All Firestore imports are deferred so the telemetry server
+    ``True``, matching the previous behaviour of the ``upload-metadata``
+    command.  All Firestore imports are deferred so the telemetry server
     can start even when the Google Cloud SDK is not installed or credentials
     are unavailable.
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,4 +1,4 @@
-from panoptes.utils.database import PanDB
+from panoptes.utils.telemetry import TelemetryClient
 
 from panoptes.pocs.base import PanBase
 
@@ -8,8 +8,9 @@ def test_with_logger():
 
 
 def test_with_db():
-    base = PanBase(db=PanDB(db_type="memory", db_name="tester"))
+    base = PanBase(db=TelemetryClient())
     assert isinstance(base, PanBase)
+    assert isinstance(base.db, TelemetryClient)
 
 
 def test_remember_config():

--- a/tests/test_pocs.py
+++ b/tests/test_pocs.py
@@ -243,8 +243,9 @@ def test_no_ac_power(pocs):
         # But double check it still matches longer entry
         assert pocs.has_ac_power() == has_power
 
-        # Remove entry and try again
-        pocs.db.clear_current("power")
+        # Remove entry and try again — clear_current is a no-op with TelemetryClient;
+        # explicitly insert a falsy value to reset the snapshot instead.
+        pocs.db.insert_current("power", {"main": False})
         assert pocs.has_ac_power() is False
 
 

--- a/tests/test_pocs.py
+++ b/tests/test_pocs.py
@@ -2,6 +2,7 @@ import os
 import sys
 import threading
 import time
+from unittest.mock import MagicMock, patch
 
 import pytest
 from astropy import units as u
@@ -351,6 +352,92 @@ def test_pocs_park_to_ready_without_observations(pocs):
 
     assert pocs.connected is False
     assert pocs.is_safe() is False
+
+
+def _make_scheduling_event(pocs):
+    """Initialize pocs and return (event_data_mock, scheduling module).
+
+    Calls scheduling.on_enter() directly to avoid the blocking while-loop
+    in the ready state.
+    """
+    from panoptes.pocs.state.states.default import scheduling as scheduling_state
+
+    pocs.initialize()
+
+    event_data = MagicMock()
+    event_data.model = pocs
+    return event_data, scheduling_state
+
+
+class TestSchedulingState:
+    """Unit tests for the scheduling state covering all branches."""
+
+    def test_run_once_with_observed_list_parks(self, pocs):
+        """run_once=True after observations have been recorded goes straight to parking."""
+        event_data, scheduling_state = _make_scheduling_event(pocs)
+
+        pocs.run_once = True
+        pocs.observatory.scheduler.observed_list["dummy_seq"] = MagicMock()
+
+        scheduling_state.on_enter(event_data)
+
+        assert pocs.next_state == "parking"
+
+    def test_get_observation_generic_error_parks(self, pocs):
+        """An unexpected exception from get_observation is caught and parks."""
+        event_data, scheduling_state = _make_scheduling_event(pocs)
+
+        with patch.object(pocs.observatory, "get_observation", side_effect=RuntimeError("boom")):
+            scheduling_state.on_enter(event_data)
+
+        assert pocs.next_state == "parking"
+
+    def test_no_observation_available_parks(self, pocs):
+        """NoObservation from get_observation is caught and parks."""
+        from panoptes.utils.error import NoObservation
+
+        event_data, scheduling_state = _make_scheduling_event(pocs)
+
+        with patch.object(pocs.observatory, "get_observation", side_effect=NoObservation("no targets")):
+            scheduling_state.on_enter(event_data)
+
+        assert pocs.next_state == "parking"
+
+    def test_same_observation_goes_to_tracking(self, pocs):
+        """Re-scheduling the same target reuses the existing observation and goes to tracking."""
+        event_data, scheduling_state = _make_scheduling_event(pocs)
+
+        # Grab a real observation, pre-seed it as the current one, and have get_observation
+        # return it again — simulating a re-schedule of the same target.
+        obs = pocs.observatory.get_observation()
+        # get_observation() adds to observed_list; reset it so run_once doesn't park early.
+        pocs.observatory.scheduler.reset_observed_list()
+        pocs.run_once = False
+        pocs.observatory.current_observation = obs
+
+        with patch.object(pocs.observatory, "get_observation", return_value=obs):
+            scheduling_state.on_enter(event_data)
+
+        assert pocs.next_state == "tracking"
+        assert pocs.observatory.current_observation is obs
+
+    def test_start_run_failure_still_slews(self, pocs):
+        """A start_run error is logged but slewing still proceeds normally."""
+        event_data, scheduling_state = _make_scheduling_event(pocs)
+
+        with patch.object(pocs.db, "start_run", side_effect=RuntimeError("telemetry down")):
+            scheduling_state.on_enter(event_data)
+
+        assert pocs.next_state == "slewing"
+
+    def test_mount_set_coordinates_failure_parks(self, pocs):
+        """Mount rejecting target coordinates results in next_state='parking'."""
+        event_data, scheduling_state = _make_scheduling_event(pocs)
+
+        with patch.object(pocs.observatory.mount, "set_target_coordinates", return_value=False):
+            scheduling_state.on_enter(event_data)
+
+        assert pocs.next_state == "parking"
 
 
 def test_run_wait_until_safe(observatory, valid_observation, pocstime_day, pocstime_night):

--- a/tests/test_pocs.py
+++ b/tests/test_pocs.py
@@ -55,7 +55,7 @@ def scheduler(site_details):
 
 
 @pytest.fixture(scope="function")
-def observatory(cameras, mount, site_details, scheduler):
+def observatory(cameras, mount, site_details, scheduler, images_dir):
     """Return a valid Observatory instance with a specific config."""
 
     obs = Observatory(scheduler=scheduler, simulator=["power", "weather"])

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -30,6 +30,13 @@ def test_remote_sensor(remote_response, remote_response_power):
     endpoint_url_with_power = "http://192.168.1.241:8080"
     responses.add(responses.GET, endpoint_url_no_power, json=remote_response)
     responses.add(responses.GET, endpoint_url_with_power, json=remote_response_power)
+    # Mock the telemetry server event endpoint used by TelemetryClient.
+    responses.add(
+        responses.POST,
+        "http://localhost:6572/event",
+        json={"seq": 1, "ts": "2020-01-01T08:00:00.000Z", "type": "power", "data": {}, "meta": {}},
+        status=200,
+    )
 
     remote_monitor = remote.RemoteMonitor(
         sensor_name="test_remote", endpoint_url=endpoint_url_no_power, db_type="memory"

--- a/tests/test_telemetry_service.py
+++ b/tests/test_telemetry_service.py
@@ -233,3 +233,57 @@ class TestRunTelemetryServerCli:
         # Confirm --no-upload was respected (no Firestore hook registered).
         args, _ = mock_svc.call_args
         assert mock_svc.call_args.kwargs.get("post_event_hooks", []) == []
+
+
+class TestCurrentTelemetryCli:
+    def test_current_no_event_type(self):
+        """current with no args delegates to panoptes-utils with host/port defaults."""
+        runner = CliRunner()
+        mock_proc = MagicMock(returncode=0)
+        with patch("subprocess.run", return_value=mock_proc) as mock_run:
+            result = runner.invoke(telemetry_cli_app, ["current"])
+        assert result.exit_code == 0, result.output
+        cmd = mock_run.call_args[0][0]
+        assert cmd[:3] == ["panoptes-utils", "telemetry", "current"]
+        assert "--host" in cmd
+        assert "--port" in cmd
+        assert "--follow" not in cmd
+
+    def test_current_with_event_type(self):
+        """current <event_type> passes the event type as a positional arg."""
+        runner = CliRunner()
+        mock_proc = MagicMock(returncode=0)
+        with patch("subprocess.run", return_value=mock_proc) as mock_run:
+            result = runner.invoke(telemetry_cli_app, ["current", "weather"])
+        assert result.exit_code == 0, result.output
+        cmd = mock_run.call_args[0][0]
+        assert "weather" in cmd
+
+    def test_current_follow_flag(self):
+        """--follow is passed through to the subprocess command."""
+        runner = CliRunner()
+        mock_proc = MagicMock(returncode=0)
+        with patch("subprocess.run", return_value=mock_proc) as mock_run:
+            result = runner.invoke(telemetry_cli_app, ["current", "--follow"])
+        assert result.exit_code == 0, result.output
+        cmd = mock_run.call_args[0][0]
+        assert "--follow" in cmd
+
+    def test_current_propagates_nonzero_exit_code(self):
+        """A non-zero subprocess returncode is propagated as the CLI exit code."""
+        runner = CliRunner()
+        mock_proc = MagicMock(returncode=1)
+        with patch("subprocess.run", return_value=mock_proc):
+            result = runner.invoke(telemetry_cli_app, ["current"])
+        assert result.exit_code == 1
+
+    def test_current_custom_host_port(self):
+        """--host and --port options are forwarded to the subprocess."""
+        runner = CliRunner()
+        mock_proc = MagicMock(returncode=0)
+        with patch("subprocess.run", return_value=mock_proc) as mock_run:
+            result = runner.invoke(telemetry_cli_app, ["current", "--host", "192.168.1.10", "--port", "9999"])
+        assert result.exit_code == 0, result.output
+        cmd = mock_run.call_args[0][0]
+        assert "192.168.1.10" in cmd
+        assert "9999" in cmd

--- a/tests/test_telemetry_service.py
+++ b/tests/test_telemetry_service.py
@@ -13,92 +13,127 @@ from panoptes.utils.telemetry.server import EventRequest, TelemetryService
 from panoptes.pocs.utils.cli.telemetry import app as telemetry_cli_app
 from panoptes.pocs.utils.service.telemetry import _get_unit_id, make_firestore_hook, make_pocs_telemetry_app
 
+_REAL_IMPORT = __builtins__.__import__ if hasattr(__builtins__, "__import__") else __import__
+
+
+def _raise_for_google(name, *args, **kwargs):
+    """Side-effect for builtins.__import__ that blocks google.cloud.firestore."""
+    if "google.cloud.firestore" in name or name == "google.cloud.firestore":
+        raise ImportError(f"Mocked ImportError for {name}")
+    return _REAL_IMPORT(name, *args, **kwargs)
+
 
 @pytest.fixture
 def unit_id():
     return "PAN001"
 
 
+@pytest.fixture
+def mock_firestore():
+    """Patch google.cloud.firestore.Client and SERVER_TIMESTAMP for hook tests."""
+    mock_client_cls = MagicMock()
+    with (
+        patch("google.cloud.firestore.Client", mock_client_cls),
+        patch("google.cloud.firestore.SERVER_TIMESTAMP", "SERVER_TIMESTAMP"),
+    ):
+        yield mock_client_cls
+
+
 class TestMakeFirestoreHook:
-    def test_hook_uploads_on_store_permanently(self, unit_id, tmp_path):
+    def test_hook_uploads_on_store_permanently(self, unit_id, mock_firestore):
         """Hook should upload to Firestore when store_permanently=True."""
         mock_db = MagicMock()
         mock_unit_ref = MagicMock()
         mock_metadata_ref = MagicMock()
         mock_db.document.return_value = mock_unit_ref
         mock_unit_ref.collection.return_value = mock_metadata_ref
+        mock_firestore.return_value = mock_db
 
         hook = make_firestore_hook(unit_id=unit_id)
 
-        with patch("google.cloud.firestore.Client", return_value=mock_db):
-            envelope = {"type": "weather", "data": {"temp": 20.0}, "ts": "2026-01-01T00:00:00Z"}
-            request = EventRequest(type="weather", data={"temp": 20.0}, store_permanently=True)
-            hook(envelope, request)
+        envelope = {"type": "weather", "data": {"temp": 20.0}, "ts": "2026-01-01T00:00:00Z"}
+        request = EventRequest(type="weather", data={"temp": 20.0}, store_permanently=True)
+        hook(envelope, request)
 
         mock_db.document.assert_called_once_with(f"units/{unit_id}")
         mock_unit_ref.set.assert_called_once()
         mock_metadata_ref.add.assert_called_once()
 
-    def test_hook_skips_ephemeral_events(self, unit_id):
+    def test_hook_skips_ephemeral_events(self, unit_id, mock_firestore):
         """Hook must be a no-op when store_permanently=False."""
         hook = make_firestore_hook(unit_id=unit_id)
 
-        with patch("google.cloud.firestore.Client") as mock_client:
-            envelope = {"type": "power", "data": {}, "ts": "2026-01-01T00:00:00Z"}
-            request = EventRequest(type="power", data={}, store_permanently=False)
-            hook(envelope, request)
+        envelope = {"type": "power", "data": {}, "ts": "2026-01-01T00:00:00Z"}
+        request = EventRequest(type="power", data={}, store_permanently=False)
+        hook(envelope, request)
 
-        mock_client.assert_not_called()
+        mock_firestore.assert_not_called()
 
-    def test_hook_sets_correct_firestore_paths(self, unit_id, tmp_path):
+    def test_hook_sets_correct_firestore_paths(self, unit_id, mock_firestore):
         """Hook should write to units/{unit_id}/metadata collection."""
         mock_db = MagicMock()
         mock_unit_ref = MagicMock()
         mock_metadata_ref = MagicMock()
         mock_db.document.return_value = mock_unit_ref
         mock_unit_ref.collection.return_value = mock_metadata_ref
+        mock_firestore.return_value = mock_db
 
         hook = make_firestore_hook(unit_id=unit_id)
 
-        with patch("google.cloud.firestore.Client", return_value=mock_db):
-            envelope = {"type": "status", "data": {"cpu": 10}, "ts": "2026-01-01T00:00:00Z"}
-            request = EventRequest(type="status", data={"cpu": 10}, store_permanently=True)
-            hook(envelope, request)
+        envelope = {"type": "status", "data": {"cpu": 10}, "ts": "2026-01-01T00:00:00Z"}
+        request = EventRequest(type="status", data={"cpu": 10}, store_permanently=True)
+        hook(envelope, request)
 
         mock_db.document.assert_called_with(f"units/{unit_id}")
         mock_unit_ref.collection.assert_called_with("metadata")
 
-    def test_hook_includes_timestamp_in_data(self, unit_id):
+    def test_hook_includes_timestamp_in_data(self, unit_id, mock_firestore):
         """Uploaded data should include 'date' from the envelope timestamp."""
         mock_db = MagicMock()
         mock_unit_ref = MagicMock()
         mock_metadata_ref = MagicMock()
         mock_db.document.return_value = mock_unit_ref
         mock_unit_ref.collection.return_value = mock_metadata_ref
+        mock_firestore.return_value = mock_db
 
         hook = make_firestore_hook(unit_id=unit_id)
         ts = "2026-01-01T12:00:00.000Z"
 
-        with patch("google.cloud.firestore.Client", return_value=mock_db):
-            envelope = {"type": "weather", "data": {"temp": 15.0}, "ts": ts}
-            request = EventRequest(type="weather", data={"temp": 15.0}, store_permanently=True)
-            hook(envelope, request)
+        envelope = {"type": "weather", "data": {"temp": 15.0}, "ts": ts}
+        request = EventRequest(type="weather", data={"temp": 15.0}, store_permanently=True)
+        hook(envelope, request)
 
         added_data = mock_metadata_ref.add.call_args[0][0]
         assert added_data["date"] == ts
         assert added_data["record_type"] == "weather"
 
-    def test_hook_exception_propagates_for_fire_hook(self, unit_id):
+    def test_hook_exception_propagates_for_fire_hook(self, unit_id, mock_firestore):
         """Exceptions in the hook should propagate so TelemetryService can log them."""
+        mock_firestore.side_effect = Exception("no credentials")
+
         hook = make_firestore_hook(unit_id=unit_id)
 
-        with patch("google.cloud.firestore.Client", side_effect=Exception("no credentials")):
-            envelope = {"type": "weather", "data": {}, "ts": "2026-01-01T00:00:00Z"}
-            request = EventRequest(type="weather", data={}, store_permanently=True)
-            with pytest.raises(Exception, match="no credentials"):
-                hook(envelope, request)
+        envelope = {"type": "weather", "data": {}, "ts": "2026-01-01T00:00:00Z"}
+        request = EventRequest(type="weather", data={}, store_permanently=True)
+        with pytest.raises(Exception, match="no credentials"):
+            hook(envelope, request)
 
-    def test_hook_non_fatal_via_telemetry_service(self, unit_id, tmp_path):
+    def test_hook_warns_and_returns_noop_when_google_not_installed(self, unit_id, caplog):
+        """When google-cloud-firestore is missing, warn with install instructions and return a no-op."""
+        import logging
+
+        with patch("builtins.__import__", side_effect=_raise_for_google):
+            with caplog.at_level(logging.WARNING):
+                hook = make_firestore_hook(unit_id=unit_id)
+
+        assert "google" in caplog.text.lower()
+
+        # The returned hook must be a harmless no-op.
+        envelope = {"type": "weather", "data": {}, "ts": "2026-01-01T00:00:00Z"}
+        request = EventRequest(type="weather", data={}, store_permanently=True)
+        hook(envelope, request)  # must not raise
+
+    def test_hook_non_fatal_via_telemetry_service(self, tmp_path):
         """When wired into TelemetryService, a Firestore failure must not affect the return value."""
         done = threading.Event()
 
@@ -129,11 +164,12 @@ class TestMakePocsTelemetryApp:
 
     def test_upload_registers_one_hook(self, tmp_path, unit_id):
         """With upload_to_firestore=True exactly one hook should be registered."""
-        app = make_pocs_telemetry_app(
-            site_dir=tmp_path / "telemetry",
-            unit_id=unit_id,
-            upload_to_firestore=True,
-        )
+        with patch("google.cloud.firestore.Client"), patch("google.cloud.firestore.SERVER_TIMESTAMP", "ts"):
+            app = make_pocs_telemetry_app(
+                site_dir=tmp_path / "telemetry",
+                unit_id=unit_id,
+                upload_to_firestore=True,
+            )
         service = app.state.telemetry_service
         assert len(service._post_event_hooks) == 1
 
@@ -145,22 +181,22 @@ class TestGetUnitId:
         assert _get_unit_id() == "PAN042"
 
     def test_falls_back_to_config(self, monkeypatch):
-        """Should query config server when UNIT_ID env var is absent."""
+        """Should query config store when UNIT_ID env var is absent."""
         monkeypatch.delenv("UNIT_ID", raising=False)
-        with patch("panoptes.utils.config.client.get_config", return_value="PAN099"):
+        with patch("panoptes.utils.config.store.get_config", return_value="PAN099"):
             assert _get_unit_id() == "PAN099"
 
     def test_raises_when_no_unit_id(self, monkeypatch):
         """Should raise ValueError when neither env var nor config provides a unit id."""
         monkeypatch.delenv("UNIT_ID", raising=False)
-        with patch("panoptes.utils.config.client.get_config", return_value=None):
+        with patch("panoptes.utils.config.store.get_config", return_value=None):
             with pytest.raises(ValueError, match="No unit id found"):
                 _get_unit_id()
 
     def test_raises_when_config_unavailable(self, monkeypatch):
-        """Should raise ValueError when config server is unreachable."""
+        """Should raise ValueError when config is unreachable."""
         monkeypatch.delenv("UNIT_ID", raising=False)
-        with patch("panoptes.utils.config.client.get_config", side_effect=Exception("no server")):
+        with patch("panoptes.utils.config.store.get_config", side_effect=Exception("no config")):
             with pytest.raises(ValueError, match="No unit id found"):
                 _get_unit_id()
 

--- a/tests/test_telemetry_service.py
+++ b/tests/test_telemetry_service.py
@@ -6,10 +6,12 @@ import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
+from typer.testing import CliRunner
 
 from panoptes.utils.telemetry.server import EventRequest, TelemetryService
 
-from panoptes.pocs.utils.service.telemetry import make_firestore_hook, make_pocs_telemetry_app
+from panoptes.pocs.utils.cli.telemetry import app as telemetry_cli_app
+from panoptes.pocs.utils.service.telemetry import _get_unit_id, make_firestore_hook, make_pocs_telemetry_app
 
 
 @pytest.fixture
@@ -134,3 +136,64 @@ class TestMakePocsTelemetryApp:
         )
         service = app.state.telemetry_service
         assert len(service._post_event_hooks) == 1
+
+
+class TestGetUnitId:
+    def test_returns_env_var(self, monkeypatch):
+        """Should return UNIT_ID env var when set."""
+        monkeypatch.setenv("UNIT_ID", "PAN042")
+        assert _get_unit_id() == "PAN042"
+
+    def test_falls_back_to_config(self, monkeypatch):
+        """Should query config server when UNIT_ID env var is absent."""
+        monkeypatch.delenv("UNIT_ID", raising=False)
+        with patch("panoptes.utils.config.client.get_config", return_value="PAN099"):
+            assert _get_unit_id() == "PAN099"
+
+    def test_raises_when_no_unit_id(self, monkeypatch):
+        """Should raise ValueError when neither env var nor config provides a unit id."""
+        monkeypatch.delenv("UNIT_ID", raising=False)
+        with patch("panoptes.utils.config.client.get_config", return_value=None):
+            with pytest.raises(ValueError, match="No unit id found"):
+                _get_unit_id()
+
+    def test_raises_when_config_unavailable(self, monkeypatch):
+        """Should raise ValueError when config server is unreachable."""
+        monkeypatch.delenv("UNIT_ID", raising=False)
+        with patch("panoptes.utils.config.client.get_config", side_effect=Exception("no server")):
+            with pytest.raises(ValueError, match="No unit id found"):
+                _get_unit_id()
+
+
+class TestRunTelemetryServerCli:
+    def test_run_no_upload(self, tmp_path, monkeypatch):
+        """CLI --no-upload flag should start uvicorn without Firestore hooks."""
+        runner = CliRunner()
+        mock_run = MagicMock()
+        monkeypatch.setenv("UNIT_ID", "PAN001")
+        with patch("uvicorn.run", mock_run):
+            result = runner.invoke(
+                telemetry_cli_app,
+                ["--no-upload", "--site-dir", str(tmp_path), "--port", "16562"],
+            )
+        assert result.exit_code == 0, result.output
+        mock_run.assert_called_once()
+        _, kwargs = mock_run.call_args
+        assert kwargs["port"] == 16562
+
+    def test_run_with_unit_id(self, tmp_path):
+        """CLI --unit-id flag should be passed through to make_pocs_telemetry_app."""
+        runner = CliRunner()
+        mock_run = MagicMock()
+        with patch("uvicorn.run", mock_run):
+            with patch("panoptes.pocs.utils.service.telemetry.TelemetryService") as mock_svc:
+                mock_svc.return_value = MagicMock(_post_event_hooks=[])
+                result = runner.invoke(
+                    telemetry_cli_app,
+                    ["--unit-id", "PAN001", "--no-upload", "--site-dir", str(tmp_path)],
+                )
+        assert result.exit_code == 0, result.output
+        mock_run.assert_called_once()
+        # Confirm --no-upload was respected (no Firestore hook registered).
+        args, _ = mock_svc.call_args
+        assert mock_svc.call_args.kwargs.get("post_event_hooks", []) == []

--- a/tests/test_telemetry_service.py
+++ b/tests/test_telemetry_service.py
@@ -210,7 +210,7 @@ class TestRunTelemetryServerCli:
         with patch("uvicorn.run", mock_run):
             result = runner.invoke(
                 telemetry_cli_app,
-                ["--no-upload", "--site-dir", str(tmp_path), "--port", "16562"],
+                ["run", "--no-upload", "--site-dir", str(tmp_path), "--port", "16562"],
             )
         assert result.exit_code == 0, result.output
         mock_run.assert_called_once()
@@ -226,7 +226,7 @@ class TestRunTelemetryServerCli:
                 mock_svc.return_value = MagicMock(_post_event_hooks=[])
                 result = runner.invoke(
                     telemetry_cli_app,
-                    ["--unit-id", "PAN001", "--no-upload", "--site-dir", str(tmp_path)],
+                    ["run", "--unit-id", "PAN001", "--no-upload", "--site-dir", str(tmp_path)],
                 )
         assert result.exit_code == 0, result.output
         mock_run.assert_called_once()

--- a/tests/test_telemetry_service.py
+++ b/tests/test_telemetry_service.py
@@ -1,0 +1,136 @@
+"""Tests for POCS telemetry service and Firestore hook."""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from panoptes.utils.telemetry.server import EventRequest, TelemetryService
+
+from panoptes.pocs.utils.service.telemetry import make_firestore_hook, make_pocs_telemetry_app
+
+
+@pytest.fixture
+def unit_id():
+    return "PAN001"
+
+
+class TestMakeFirestoreHook:
+    def test_hook_uploads_on_store_permanently(self, unit_id, tmp_path):
+        """Hook should upload to Firestore when store_permanently=True."""
+        mock_db = MagicMock()
+        mock_unit_ref = MagicMock()
+        mock_metadata_ref = MagicMock()
+        mock_db.document.return_value = mock_unit_ref
+        mock_unit_ref.collection.return_value = mock_metadata_ref
+
+        hook = make_firestore_hook(unit_id=unit_id)
+
+        with patch("google.cloud.firestore.Client", return_value=mock_db):
+            envelope = {"type": "weather", "data": {"temp": 20.0}, "ts": "2026-01-01T00:00:00Z"}
+            request = EventRequest(type="weather", data={"temp": 20.0}, store_permanently=True)
+            hook(envelope, request)
+
+        mock_db.document.assert_called_once_with(f"units/{unit_id}")
+        mock_unit_ref.set.assert_called_once()
+        mock_metadata_ref.add.assert_called_once()
+
+    def test_hook_skips_ephemeral_events(self, unit_id):
+        """Hook must be a no-op when store_permanently=False."""
+        hook = make_firestore_hook(unit_id=unit_id)
+
+        with patch("google.cloud.firestore.Client") as mock_client:
+            envelope = {"type": "power", "data": {}, "ts": "2026-01-01T00:00:00Z"}
+            request = EventRequest(type="power", data={}, store_permanently=False)
+            hook(envelope, request)
+
+        mock_client.assert_not_called()
+
+    def test_hook_sets_correct_firestore_paths(self, unit_id, tmp_path):
+        """Hook should write to units/{unit_id}/metadata collection."""
+        mock_db = MagicMock()
+        mock_unit_ref = MagicMock()
+        mock_metadata_ref = MagicMock()
+        mock_db.document.return_value = mock_unit_ref
+        mock_unit_ref.collection.return_value = mock_metadata_ref
+
+        hook = make_firestore_hook(unit_id=unit_id)
+
+        with patch("google.cloud.firestore.Client", return_value=mock_db):
+            envelope = {"type": "status", "data": {"cpu": 10}, "ts": "2026-01-01T00:00:00Z"}
+            request = EventRequest(type="status", data={"cpu": 10}, store_permanently=True)
+            hook(envelope, request)
+
+        mock_db.document.assert_called_with(f"units/{unit_id}")
+        mock_unit_ref.collection.assert_called_with("metadata")
+
+    def test_hook_includes_timestamp_in_data(self, unit_id):
+        """Uploaded data should include 'date' from the envelope timestamp."""
+        mock_db = MagicMock()
+        mock_unit_ref = MagicMock()
+        mock_metadata_ref = MagicMock()
+        mock_db.document.return_value = mock_unit_ref
+        mock_unit_ref.collection.return_value = mock_metadata_ref
+
+        hook = make_firestore_hook(unit_id=unit_id)
+        ts = "2026-01-01T12:00:00.000Z"
+
+        with patch("google.cloud.firestore.Client", return_value=mock_db):
+            envelope = {"type": "weather", "data": {"temp": 15.0}, "ts": ts}
+            request = EventRequest(type="weather", data={"temp": 15.0}, store_permanently=True)
+            hook(envelope, request)
+
+        added_data = mock_metadata_ref.add.call_args[0][0]
+        assert added_data["date"] == ts
+        assert added_data["record_type"] == "weather"
+
+    def test_hook_exception_propagates_for_fire_hook(self, unit_id):
+        """Exceptions in the hook should propagate so TelemetryService can log them."""
+        hook = make_firestore_hook(unit_id=unit_id)
+
+        with patch("google.cloud.firestore.Client", side_effect=Exception("no credentials")):
+            envelope = {"type": "weather", "data": {}, "ts": "2026-01-01T00:00:00Z"}
+            request = EventRequest(type="weather", data={}, store_permanently=True)
+            with pytest.raises(Exception, match="no credentials"):
+                hook(envelope, request)
+
+    def test_hook_non_fatal_via_telemetry_service(self, unit_id, tmp_path):
+        """When wired into TelemetryService, a Firestore failure must not affect the return value."""
+        done = threading.Event()
+
+        def failing_hook(envelope, request):
+            done.set()
+            raise RuntimeError("firestore down")
+
+        service = TelemetryService(tmp_path / "site", post_event_hooks=[failing_hook])
+        result = service.append_event(EventRequest(type="weather", data={"temp": 10}))
+
+        assert done.wait(timeout=1.0), "hook was never called"
+        assert result["seq"] == 1  # server returned normally despite hook failure
+
+
+class TestMakePocsTelemetryApp:
+    def test_returns_fastapi_app(self, tmp_path):
+        """make_pocs_telemetry_app should return a FastAPI instance."""
+        from fastapi import FastAPI
+
+        app = make_pocs_telemetry_app(site_dir=tmp_path / "telemetry", upload_to_firestore=False)
+        assert isinstance(app, FastAPI)
+
+    def test_no_upload_registers_no_hooks(self, tmp_path):
+        """With upload_to_firestore=False no hooks should be on the service."""
+        app = make_pocs_telemetry_app(site_dir=tmp_path / "telemetry", upload_to_firestore=False)
+        service = app.state.telemetry_service
+        assert service._post_event_hooks == []
+
+    def test_upload_registers_one_hook(self, tmp_path, unit_id):
+        """With upload_to_firestore=True exactly one hook should be registered."""
+        app = make_pocs_telemetry_app(
+            site_dir=tmp_path / "telemetry",
+            unit_id=unit_id,
+            upload_to_firestore=True,
+        )
+        service = app.state.telemetry_service
+        assert len(service._post_event_hooks) == 1

--- a/tests/test_telemetry_service.py
+++ b/tests/test_telemetry_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import builtins
 import threading
 from unittest.mock import MagicMock, patch
 
@@ -13,7 +14,7 @@ from panoptes.utils.telemetry.server import EventRequest, TelemetryService
 from panoptes.pocs.utils.cli.telemetry import app as telemetry_cli_app
 from panoptes.pocs.utils.service.telemetry import _get_unit_id, make_firestore_hook, make_pocs_telemetry_app
 
-_REAL_IMPORT = __builtins__.__import__ if hasattr(__builtins__, "__import__") else __import__
+_REAL_IMPORT = builtins.__import__
 
 
 def _raise_for_google(name, *args, **kwargs):
@@ -61,13 +62,16 @@ class TestMakeFirestoreHook:
 
     def test_hook_skips_ephemeral_events(self, unit_id, mock_firestore):
         """Hook must be a no-op when store_permanently=False."""
+        mock_db = MagicMock()
+        mock_firestore.return_value = mock_db
+
         hook = make_firestore_hook(unit_id=unit_id)
 
         envelope = {"type": "power", "data": {}, "ts": "2026-01-01T00:00:00Z"}
         request = EventRequest(type="power", data={}, store_permanently=False)
         hook(envelope, request)
 
-        mock_firestore.assert_not_called()
+        mock_db.document.assert_not_called()
 
     def test_hook_sets_correct_firestore_paths(self, unit_id, mock_firestore):
         """Hook should write to units/{unit_id}/metadata collection."""
@@ -108,14 +112,18 @@ class TestMakeFirestoreHook:
         assert added_data["record_type"] == "weather"
 
     def test_hook_exception_propagates_for_fire_hook(self, unit_id, mock_firestore):
-        """Exceptions in the hook should propagate so TelemetryService can log them."""
-        mock_firestore.side_effect = Exception("no credentials")
+        """Exceptions during hook invocation should propagate so TelemetryService can log them."""
+        mock_db = MagicMock()
+        mock_unit_ref = MagicMock()
+        mock_unit_ref.set.side_effect = Exception("network error")
+        mock_db.document.return_value = mock_unit_ref
+        mock_firestore.return_value = mock_db
 
         hook = make_firestore_hook(unit_id=unit_id)
 
         envelope = {"type": "weather", "data": {}, "ts": "2026-01-01T00:00:00Z"}
         request = EventRequest(type="weather", data={}, store_permanently=True)
-        with pytest.raises(Exception, match="no credentials"):
+        with pytest.raises(Exception, match="network error"):
             hook(envelope, request)
 
     def test_hook_warns_and_returns_noop_when_google_not_installed(self, unit_id, caplog):
@@ -129,6 +137,20 @@ class TestMakeFirestoreHook:
         assert "google" in caplog.text.lower()
 
         # The returned hook must be a harmless no-op.
+        envelope = {"type": "weather", "data": {}, "ts": "2026-01-01T00:00:00Z"}
+        request = EventRequest(type="weather", data={}, store_permanently=True)
+        hook(envelope, request)  # must not raise
+
+    def test_hook_warns_and_returns_noop_when_client_creation_fails(self, unit_id, mock_firestore, caplog):
+        """When firestore.Client() raises at hook-creation time, warn and return a no-op."""
+        import logging
+
+        mock_firestore.side_effect = Exception("no credentials")
+        with caplog.at_level(logging.WARNING):
+            hook = make_firestore_hook(unit_id=unit_id)
+
+        assert "credentials" in caplog.text.lower()
+
         envelope = {"type": "weather", "data": {}, "ts": "2026-01-01T00:00:00Z"}
         request = EventRequest(type="weather", data={}, store_permanently=True)
         hook(envelope, request)  # must not raise

--- a/tests/testing.yaml
+++ b/tests/testing.yaml
@@ -39,6 +39,10 @@ db:
   name: panoptes_testing
   type: file
 
+telemetry:
+  host: localhost
+  port: 6562
+
 scheduler:
   type: panoptes.pocs.scheduler.dispatch
   fields_file: simulator.yaml

--- a/tests/testing.yaml
+++ b/tests/testing.yaml
@@ -41,7 +41,7 @@ db:
 
 telemetry:
   host: localhost
-  port: 6562
+  port: 6572
 
 scheduler:
   type: panoptes.pocs.scheduler.dispatch

--- a/tests/testing.yaml
+++ b/tests/testing.yaml
@@ -35,10 +35,6 @@ directories:
   fields: conf_files/fields
   mounts: resources/mounts
 
-db:
-  name: panoptes_testing
-  type: file
-
 telemetry:
   host: localhost
   port: 6572

--- a/tests/testing.yaml
+++ b/tests/testing.yaml
@@ -195,7 +195,6 @@ cameras:
 ################################################################################
 observations:
   make_timelapse: True
-  record_observations: True
 
 ######################## Google Network ########################################
 # By default all images are stored on googlecloud servers and we also

--- a/uv.lock
+++ b/uv.lock
@@ -2317,7 +2317,7 @@ dependencies = [
     { name = "human-readable" },
     { name = "numpy" },
     { name = "pandas" },
-    { name = "panoptes-utils", extra = ["images"] },
+    { name = "panoptes-utils", extra = ["images", "telemetry"] },
     { name = "pick" },
     { name = "pillow" },
     { name = "pyserial" },
@@ -2413,7 +2413,7 @@ requires-dist = [
     { name = "pandas" },
     { name = "panoptes-aag", marker = "extra == 'weather'" },
     { name = "panoptes-pocs", extras = ["focuser", "google", "weather"], marker = "extra == 'all'" },
-    { name = "panoptes-utils", extras = ["images"], specifier = ">=0.5.0,<3.0" },
+    { name = "panoptes-utils", extras = ["images", "telemetry"], specifier = ">=0.5.0,<3.0" },
     { name = "pick" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "protobuf", marker = "extra == 'google'" },
@@ -2494,6 +2494,10 @@ images = [
     { name = "scipy" },
     { name = "sep" },
     { name = "watchfiles" },
+]
+telemetry = [
+    { name = "fastapi" },
+    { name = "uvicorn" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2330,7 +2330,6 @@ dependencies = [
     { name = "typer" },
     { name = "typing-inspect" },
     { name = "urllib3" },
-    { name = "watchdog" },
 ]
 
 [package.optional-dependencies]
@@ -2429,7 +2428,6 @@ requires-dist = [
     { name = "typer" },
     { name = "typing-inspect" },
     { name = "urllib3", specifier = ">=2.7.0" },
-    { name = "watchdog" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

Replaces the legacy `PanDB` / `PanFileDB` JSON file database with the new `TelemetryClient` backed by the `panoptes-telemetry` server introduced in `panoptes-utils` v0.3.4/v0.3.5.

The `TelemetryClient` provides a drop-in compatible interface for all existing `self.db.*` call sites (e.g. `insert_current`, `get_current`), so most of POCS required no changes — the main work was in the bootstrap layer (`base.py`) and the test harness.

## What Changed

### Core
- **`base.py`**: Swapped `PanDB` → `TelemetryClient`. The global singleton now connects to a running telemetry server (default: `localhost:6562`, configurable via `telemetry.host` / `telemetry.port` in the YAML config).
- **`scheduling.py`**: Calls `pocs.db.start_run(run_dir=...)` when a new observation target is selected, marking a new run boundary in the telemetry stream.
- **`parking.py`**: Calls `pocs.db.stop_run()` when entering the parking state.

### Configuration
- Added `telemetry: {host: localhost, port: 6562}` to `conf_files/pocs.yaml`, `conf_files/pocs_local.yaml`, and `tests/testing.yaml`.

### Tests
- `conftest.py`: Starts a real telemetry server process during `pytest_configure` and tears it down in `pytest_unconfigure` — mirrors the existing config server pattern.
- `test_base.py`: Updated to assert `TelemetryClient` is used instead of `PanDB`.
- `test_pocs.py`: Replaced one `clear_current()` call (now a no-op) with an explicit `insert_current("power", {"main": False})`.

### Dependency
- `panoptes-utils` bumped to `[config,images,telemetry]>=0.3.5` to pick up the `store_permanently=False` fix (v0.3.5) and the new `[telemetry]` extra.

## Running Locally

Before starting POCS (or running tests), both servers must be running:

```bash
# Config server (port 6563)
panoptes-config-server --host 0.0.0.0 --port 6563 run --config-file conf_files/pocs.yaml

# Telemetry server (port 6562)
panoptes-telemetry --host 0.0.0.0 --port 6562 run --site-dir telemetry/
```

Tests start/stop the telemetry server automatically — no manual step needed for `pytest`.

## Notes

- The old `db:` sections in YAML config files are still present but unused — they can be cleaned up in a follow-up.
- Historical data in `json_store/` is not migrated automatically. Use the `panoptes-utils migrate` CLI if needed.
- `find()` on `TelemetryClient` always returns `None` — POCS does not use this method in production code.


Closes #1410 