### PR TITLE
refactor: replace pocs config flags with instance variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Replaced `pocs.*` config-backed runtime flags (`INITIALIZED`, `CONNECTED`, `INTERRUPTED`, `DO_STATES`, `RUN_ONCE`) with plain instance variables on the `POCS` class; removed the `pocs:` section from `pocs.yaml` and `testing.yaml`.
+- Renamed `pocs.RETRY_ATTEMPTS` config key to top-level `observing_run_attempts`; default remains 3.
+
 ## 0.8.3 - 2026-05-26
 
 Security and dependency updates, plus a new weather station setup command.

--- a/conf_files/pocs.yaml
+++ b/conf_files/pocs.yaml
@@ -40,6 +40,7 @@ db:
 
 wait_delay: 180 # time in seconds before checking safety/etc while waiting.
 max_transition_attempts: 5  # number of transitions attempts.
+observing_run_attempts: 3  # number of observing run retries before giving up.
 status_check_interval: 60 # periodic status check.
 
 state_machine: panoptes
@@ -193,13 +194,3 @@ panoptes_network:
   buckets:
     upload: panoptes-images-incoming
 
-############################### pocs ##################################
-# POCS status flags. The values below represent initial values but
-# they can be switched at run-time if needed.
-#######################################################################
-pocs:
-  INITIALIZED: False
-  INTERRUPTED: False
-  KEEP_RUNNING: True
-  DO_STATES: True
-  RUN_ONCE: False

--- a/conf_files/pocs.yaml
+++ b/conf_files/pocs.yaml
@@ -40,7 +40,7 @@ db:
 
 wait_delay: 180 # time in seconds before checking safety/etc while waiting.
 max_transition_attempts: 5  # number of transitions attempts.
-observing_run_attempts: 3  # number of observing run retries before giving up.
+max_observing_attempts: 3  # maximum number of observing loop iterations before stopping.
 status_check_interval: 60 # periodic status check.
 
 state_machine: panoptes

--- a/src/panoptes/pocs/core.py
+++ b/src/panoptes/pocs/core.py
@@ -77,7 +77,7 @@ class POCS(PanStateMachine, PanBase):
         self._is_initialized: bool = False
         self._free_space = None
         self._run_once: bool = kwargs.get("run_once", False)
-        self._obs_run_retries: int = self.get_config("observing_run_attempts", default=3)
+        self._obs_run_retries: int = self.get_config("max_observing_attempts", default=3)
         self._connected: bool = True
         self._interrupted: bool = False
         self._do_states: bool = False
@@ -165,7 +165,7 @@ class POCS(PanStateMachine, PanBase):
         Returns:
             bool: True if remaining retry attempts are available; otherwise False.
         """
-        return self._obs_run_retries >= 0
+        return self._obs_run_retries > 0
 
     @property
     def status(self) -> dict:
@@ -287,7 +287,7 @@ class POCS(PanStateMachine, PanBase):
     def reset_observing_run(self):
         """Reset an observing run loop."""
         self.logger.debug("Resetting observing run attempts")
-        self._obs_run_retries = self.get_config("observing_run_attempts", default=3)
+        self._obs_run_retries = self.get_config("max_observing_attempts", default=3)
 
     def observe_target(self, observation: Observation | None = None, park_if_unsafe: bool = True):
         """Observe something! 🔭🌠

--- a/src/panoptes/pocs/core.py
+++ b/src/panoptes/pocs/core.py
@@ -74,81 +74,61 @@ class POCS(PanStateMachine, PanBase):
         # Add observatory object, which does the bulk of the work.
         self.observatory = observatory
 
-        self.is_initialized = False
+        self._is_initialized: bool = False
         self._free_space = None
-
-        self.run_once = kwargs.get("run_once", False)
-        self._obs_run_retries = self.get_config("pocs.RETRY_ATTEMPTS", default=3)
-        self.connected = True
-        self.interrupted = False
+        self._run_once: bool = kwargs.get("run_once", False)
+        self._obs_run_retries: int = self.get_config("observing_run_attempts", default=3)
+        self._connected: bool = True
+        self._interrupted: bool = False
+        self._do_states: bool = False
 
         self.say("Hi there!")
 
     @property
-    def is_initialized(self):
-        """Indicates if POCS has been initialized or not"""
-        return self.get_config("pocs.INITIALIZED", default=False)
+    def is_initialized(self) -> bool:
+        """Indicates if POCS has been initialized or not."""
+        return self._is_initialized
 
     @is_initialized.setter
-    def is_initialized(self, new_value):
-        """Set initialization flag.
-
-        Args:
-            new_value (bool): True if POCS has finished initialization.
-        """
-        self.set_config("pocs.INITIALIZED", new_value)
+    def is_initialized(self, new_value: bool) -> None:
+        self._is_initialized = new_value
 
     @property
-    def interrupted(self):
+    def interrupted(self) -> bool:
         """If POCS has been interrupted.
 
         Returns:
             bool: If an interrupt signal has been received
         """
-        return self.get_config("pocs.INTERRUPTED", default=False)
+        return self._interrupted
 
     @interrupted.setter
-    def interrupted(self, new_value):
-        """Mark POCS as interrupted.
-
-        Args:
-            new_value (bool): True if an interrupt signal has been received.
-        """
-        self.set_config("pocs.INTERRUPTED", new_value)
+    def interrupted(self, new_value: bool) -> None:
+        self._interrupted = new_value
         if new_value:
             self.logger.critical("POCS has been interrupted")
 
     @property
-    def connected(self):
-        """Indicates if POCS is connected"""
-        return self.get_config("pocs.CONNECTED", default=False)
+    def connected(self) -> bool:
+        """Indicates if POCS is connected."""
+        return self._connected
 
     @connected.setter
-    def connected(self, new_value):
-        """Set connection status flag.
-
-        Args:
-            new_value (bool): True if POCS is connected to required services.
-        """
-        self.set_config("pocs.CONNECTED", new_value)
+    def connected(self, new_value: bool) -> None:
+        self._connected = new_value
 
     @property
-    def do_states(self):
+    def do_states(self) -> bool:
         """Whether the state machine should currently process states.
 
         Returns:
             bool: True if state transitions should be executed.
         """
-        return self.get_config("pocs.DO_STATES", default=True)
+        return self._do_states
 
     @do_states.setter
-    def do_states(self, new_value):
-        """Enable or disable state-machine processing.
-
-        Args:
-            new_value (bool): True to process state transitions; False to pause.
-        """
-        self.set_config("pocs.DO_STATES", new_value)
+    def do_states(self, new_value: bool) -> None:
+        self._do_states = new_value
 
     @property
     def keep_running(self):
@@ -166,24 +146,17 @@ class POCS(PanStateMachine, PanBase):
         return self.connected and self.do_states and self.observatory.can_observe
 
     @property
-    def run_once(self):
+    def run_once(self) -> bool:
         """If POCS should exit the run loop after a single iteration.
-
-        This value reads the `pocs.RUN_ONCE` config value.
 
         Returns:
             bool: if machine should stop after single iteration, default False.
         """
-        return self.get_config("pocs.RUN_ONCE", default=False)
+        return self._run_once
 
     @run_once.setter
-    def run_once(self, new_value):
-        """Set whether to exit the run loop after a single iteration.
-
-        Args:
-            new_value (bool): True to perform only one run loop iteration.
-        """
-        self.set_config("pocs.RUN_ONCE", new_value)
+    def run_once(self, new_value: bool) -> None:
+        self._run_once = new_value
 
     @property
     def should_retry(self):
@@ -314,7 +287,7 @@ class POCS(PanStateMachine, PanBase):
     def reset_observing_run(self):
         """Reset an observing run loop."""
         self.logger.debug("Resetting observing run attempts")
-        self._obs_run_retries = self.get_config("pocs.RETRY_ATTEMPTS", default=3)
+        self._obs_run_retries = self.get_config("observing_run_attempts", default=3)
 
     def observe_target(self, observation: Observation | None = None, park_if_unsafe: bool = True):
         """Observe something! 🔭🌠

--- a/tests/test_pocs.py
+++ b/tests/test_pocs.py
@@ -400,8 +400,8 @@ def test_run_wait_until_safe(observatory, valid_observation, pocstime_day, pocst
         pocs.logger.warning(f"Waiting to get to slewing state... {pocs.state=} {pocs.next_state=}")
         time.sleep(1)
 
-    pocs.logger.warning("Stopping states via pocs.DO_STATES")
-    observatory.set_config("pocs.DO_STATES", False)
+    pocs.logger.warning("Stopping states via pocs.do_states")
+    pocs.do_states = False
 
     observatory.logger.warning("Waiting on pocs_thread")
     pocs_thread.join(timeout=300)
@@ -466,8 +466,8 @@ def test_unsafe_park(observatory, valid_observation, pocstime_night):
         assert pocs.state in ["sleeping", "housekeeping", "slewing", "parking", "parked"]
         time.sleep(0.25)
 
-    pocs.logger.warning("Stopping states via pocs.DO_STATES")
-    observatory.set_config("pocs.DO_STATES", False)
+    pocs.logger.warning("Stopping states via pocs.do_states")
+    pocs.do_states = False
 
     observatory.logger.warning("Waiting on pocs_thread")
     pocs_thread.join(timeout=300)
@@ -510,8 +510,8 @@ def test_run_power_down_interrupt(observatory, valid_observation, pocstime_night
         pocs.logger.debug(f"Waiting to get to slewing state. Currently next_state={pocs.next_state}")
         time.sleep(1)
 
-    pocs.logger.warning("Stopping states via pocs.DO_STATES")
-    observatory.set_config("pocs.DO_STATES", False)
+    pocs.logger.warning("Stopping states via pocs.do_states")
+    pocs.do_states = False
 
     observatory.logger.debug("Waiting on pocs_thread")
     pocs_thread.join(timeout=300)

--- a/tests/testing.yaml
+++ b/tests/testing.yaml
@@ -13,11 +13,6 @@
 name: Testing PANOPTES Unit
 pan_id: PAN000
 
-pocs:
-  INITIALIZED: false
-  CONNECTED: false
-  INTERRUPTED: false
-
 location:
   name: Mauna Loa Observatory
   latitude: 19.54 deg


### PR DESCRIPTION
## Summary

Removes the `pocs:` config section from `pocs.yaml` and `testing.yaml`. These were runtime state values (`INITIALIZED`, `CONNECTED`, `INTERRUPTED`, `DO_STATES`, `RUN_ONCE`, `KEEP_RUNNING`) incorrectly stored in the config server — no external consumers existed.

## Changes

- All flags replaced with plain instance variables on the `POCS` class
- `observing_run_attempts` (top-level key, default 3) replaces `pocs.RETRY_ATTEMPTS`
- Tests updated: `observatory.set_config("pocs.DO_STATES", False)` → `pocs.do_states = False`
- `pocs:` section removed from `conf_files/pocs.yaml` and `tests/testing.yaml`