### PR TITLE
Config store cleanup: remove deprecated params, add config_file, wire Pydantic validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Added `pocs telemetry current` subcommand — thin wrapper around `panoptes-utils telemetry current` for live telemetry inspection.
 - Added `sequence_id` property to `Observation` (returns `seq_time`) so callers can use a stable name for an observation run before any exposures start.
 - Telemetry run directories are now `telemetry/runs/<sequence_id>/` (no unit-id prefix, images remain in `images/`); `seq_time` is stamped at scheduling time.
+- `PanBase.__init__` now accepts a `config_file` parameter, allowing hardware sub-processes to load a specific config file independently via `init_config(config_file=...)`.
+- `PanBase` now validates the loaded config against `POCSConfig` (Pydantic) at startup; a warning is logged if validation fails rather than crashing.
 
 ### Changed
 
@@ -29,6 +31,7 @@
 
 - Legacy HTTP config server; POCS no longer depends on a running config server process. #1448
 - Removed `pocs-metadata-uploader` supervisord program — Firestore metadata uploads are now handled directly inside the telemetry server process via `post_event_hooks`.
+- Removed deprecated `config_host` and `config_port` parameters from `PanBase.__init__` and the `pocs` CLI.
 
 
 ## 0.8.3 - 2026-05-26

--- a/conftest.py
+++ b/conftest.py
@@ -202,11 +202,6 @@ def config_host():
     return "localhost"  # kept for backward compat; no longer used
 
 
-@pytest.fixture(scope="session")
-def config_port():
-    return 6563  # kept for backward compat; no longer used
-
-
 @pytest.fixture
 def temp_file(tmp_path):
     d = tmp_path

--- a/src/panoptes/pocs/base.py
+++ b/src/panoptes/pocs/base.py
@@ -5,7 +5,6 @@ shared lightweight telemetry client handle used throughout the project.
 """
 
 import os
-import warnings
 from typing import Any
 
 from loguru import logger as _bootstrap_logger
@@ -26,26 +25,26 @@ class PanBase:
     Defines common properties for each class (e.g. logger, config, db).
     """
 
-    def __init__(self, config_host=None, config_port=None, *args, **kwargs):
+    def __init__(self, config_file=None, *args, **kwargs):
         self.__version__ = __version__
-
-        if config_host is not None or config_port is not None:
-            warnings.warn(
-                "config_host and config_port are deprecated and have no effect. "
-                "Config is now loaded directly from the PANOPTES config file.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
 
         # Explicitly initialise the config store on first use so the resolved
         # config file path is logged before any config lookups are made.
         if not config_store._CONFIG:
-            loaded = config_store.init_config()
+            loaded = config_store.init_config(config_file=config_file)
             if loaded:
                 _bootstrap_logger.info(
                     f"PANOPTES config store initialised from {config_store._CONFIG_FILE!r} "
                     f"({len(loaded)} top-level keys)."
                 )
+                try:
+                    from panoptes.pocs.config import POCSConfig
+
+                    POCSConfig(**loaded)
+                except Exception as exc:
+                    _bootstrap_logger.warning(
+                        f"Config validation warning — some values may be incorrect: {exc}"
+                    )
             else:
                 _bootstrap_logger.debug(
                     "PANOPTES config store: no config file found. "

--- a/src/panoptes/pocs/utils/cli/main.py
+++ b/src/panoptes/pocs/utils/cli/main.py
@@ -45,8 +45,6 @@ app.add_typer(weather.app, name="weather", help="Interact with weather station s
 @app.callback()
 def main(
     context: typer.Context,
-    config_host: str = typer.Option("127.0.0.1", hidden=True),
-    config_port: int = typer.Option(6563, hidden=True),
     verbose: bool = False,
 ):
     """Top-level CLI callback to set shared options for subcommands.
@@ -60,8 +58,6 @@ def main(
     """
     state.update(
         {
-            "config_host": config_host,
-            "config_port": config_port,
             "verbose": verbose,
         }
     )

--- a/tests/test_pocs.py
+++ b/tests/test_pocs.py
@@ -615,7 +615,7 @@ def test_run_power_down_interrupt(observatory, valid_observation, pocstime_night
     assert pocs_thread.is_alive() is False
 
 
-def test_custom_state_file(observatory, temp_file, config_port):
+def test_custom_state_file(observatory, temp_file):
     state_table = POCS.load_state_table()
     assert isinstance(state_table, dict)
 


### PR DESCRIPTION
Completes the config store items from #1449 that were left after merging #1448.

## Changes

- **Remove `config_host`/`config_port`**: Deleted deprecated params from `PanBase.__init__` and the `pocs` CLI callback.
- **Add `config_file` param to `PanBase.__init__`**: Hardware sub-processes can now specify a config file directly.
- **Wire `POCSConfig` Pydantic validation at startup**: Validates the loaded config; logs a warning on failure rather than crashing.
- **Remove dead `config_port` test fixture** from `conftest.py`.

Closes config store items in #1449.