### PR TITLE
Fix pocs update failing with 'couldn't find remote ref --tags'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `pocs update` failing with `fatal: couldn't find remote ref --tags` by passing `tags=True` as a keyword argument to `origin.fetch()` instead of a positional refspec string.
+
 ### Changed
 
 - **Refactored POCS core:** Simplified the `POCS` class hierarchy by merging `PanStateMachine` directly into it and removing `panoptes/pocs/state/machine.py`.

--- a/src/panoptes/pocs/utils/cli/main.py
+++ b/src/panoptes/pocs/utils/cli/main.py
@@ -140,7 +140,7 @@ def update_repo(
         try:
             origin = repo.remotes.origin
             progress.update(t_update, description="Fetching remote information...")
-            origin.fetch("--tags")
+            origin.fetch(tags=True)
 
             # If local dir is dirty, stash changes.
             if repo.is_dirty():


### PR DESCRIPTION
## Summary

`pocs update` was failing with:

```
fatal: couldn't find remote ref --tags
```

## Root Cause

`origin.fetch("--tags")` passes `"--tags"` as a positional refspec argument. GitPython then generates `git fetch -v -- origin --tags`, where `--tags` is treated as a ref name rather than a flag.

## Fix

Changed to `origin.fetch(tags=True)`, which GitPython correctly converts to the `--tags` flag (`git fetch --tags origin`).