### PR TITLE
Allow exptime to be entered as a string fraction (#1367)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added support for entering exposure times (`exptime`) as string fractions (e.g., `'1/4'`, `'1/1000'`) in cameras and scheduled observations. #1367
+
 ### Changed
 
 - Updated `fastapi` to `0.136.3` and `panoptes-utils[config,images]` to `>0.3.0,<0.4.0`.

--- a/src/panoptes/pocs/camera/camera.py
+++ b/src/panoptes/pocs/camera/camera.py
@@ -13,6 +13,7 @@ import time
 import warnings
 from abc import ABCMeta, abstractmethod
 from contextlib import suppress
+from fractions import Fraction
 from pathlib import Path
 
 import astropy.units as u
@@ -586,6 +587,12 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
             self.logger.warning(f"Cameras not ready: {self.readiness!r}")
             raise error.PanError(f"Attempt to start exposure on {self} while not ready.")
 
+        if isinstance(seconds, str):
+            try:
+                seconds = float(Fraction(seconds.strip()))
+            except (ValueError, TypeError):
+                pass
+
         if not isinstance(seconds, u.Quantity):
             seconds = seconds * u.second
 
@@ -1017,6 +1024,11 @@ class AbstractCamera(PanBase, metaclass=ABCMeta):
         # The exptime header data is set as part of observation but can
         # be overridden by passed parameter so update here.
         exptime = kwargs.get("exptime", get_quantity_value(observation.exptime, unit=u.second))
+        if isinstance(exptime, str):
+            try:
+                exptime = float(Fraction(exptime.strip()))
+            except (ValueError, TypeError):
+                pass
 
         # Camera metadata
         metadata = {

--- a/src/panoptes/pocs/camera/gphoto/canon.py
+++ b/src/panoptes/pocs/camera/gphoto/canon.py
@@ -5,6 +5,7 @@ Implements exposure sequencing, property setup, and a shutterspeed index helper
 compatible with the CLI-driven gphoto2 interface.
 """
 
+from fractions import Fraction
 from functools import lru_cache
 
 from astropy import units as u
@@ -23,6 +24,62 @@ class Camera(AbstractGPhotoCamera):
     Provides Canon-specific property defaults and exposure sequencing on top of
     AbstractGPhotoCamera.
     """
+
+    _shutter_speeds = {
+        "bulb": "bulb",
+        "30": 30,
+        "25": 25,
+        "20": 20,
+        "15": 15,
+        "13": 13,
+        "10.3": 10.3,
+        "8": 8,
+        "6.3": 6.3,
+        "5": 5,
+        "4": 4,
+        "3.2": 3.2,
+        "2.5": 2.5,
+        "2": 2,
+        "1.6": 1.6,
+        "1.3": 1.3,
+        "1": 1,
+        "0.8": 0.8,
+        "0.6": 0.6,
+        "0.5": 0.5,
+        "0.4": 0.4,
+        "0.3": 0.3,
+        "1/4": 1 / 4,
+        "1/5": 1 / 5,
+        "1/6": 1 / 6,
+        "1/8": 1 / 8,
+        "1/10": 1 / 10,
+        "1/13": 1 / 13,
+        "1/15": 1 / 15,
+        "1/20": 1 / 20,
+        "1/25": 1 / 25,
+        "1/30": 1 / 30,
+        "1/40": 1 / 40,
+        "1/50": 1 / 50,
+        "1/60": 1 / 60,
+        "1/80": 1 / 80,
+        "1/100": 1 / 100,
+        "1/125": 1 / 125,
+        "1/160": 1 / 160,
+        "1/200": 1 / 200,
+        "1/250": 1 / 250,
+        "1/320": 1 / 320,
+        "1/400": 1 / 400,
+        "1/500": 1 / 500,
+        "1/640": 1 / 640,
+        "1/800": 1 / 800,
+        "1/1000": 1 / 1000,
+        "1/1250": 1 / 1250,
+        "1/1600": 1 / 1600,
+        "1/2000": 1 / 2000,
+        "1/2500": 1 / 2500,
+        "1/3200": 1 / 3200,
+        "1/4000": 1 / 4000,
+    }
 
     def __init__(
         self,
@@ -131,6 +188,15 @@ class Camera(AbstractGPhotoCamera):
 
         shutterspeed_idx = self.get_shutterspeed_index(seconds=seconds, return_minimum=True)
 
+        # Update FITS header with actual shutterspeed if not in bulb mode
+        shutter_speed_keys = list(self._shutter_speeds.keys())
+        if shutterspeed_idx < len(shutter_speed_keys):
+            actual_speed_str = shutter_speed_keys[shutterspeed_idx]
+            if actual_speed_str != "bulb":
+                actual_seconds = float(Fraction(actual_speed_str))
+                if header is not None:
+                    header.set("EXPTIME", actual_seconds, "Seconds")
+
         cmd_args = [
             "--set-config",
             f"iso={iso}",
@@ -190,72 +256,17 @@ class Camera(AbstractGPhotoCamera):
         seconds = get_quantity_value(seconds, unit="second")
         # TODO derive these from `load_properties`.
         # The index corresponds to what gphoto2 expects.
-        shutter_speeds = {
-            "bulb": "bulb",
-            "30": 30,
-            "25": 25,
-            "20": 20,
-            "15": 15,
-            "13": 13,
-            "10.3": 10.3,
-            "8": 8,
-            "6.3": 6.3,
-            "5": 5,
-            "4": 4,
-            "3.2": 3.2,
-            "2.5": 2.5,
-            "2": 2,
-            "1.6": 1.6,
-            "1.3": 1.3,
-            "1": 1,
-            "0.8": 0.8,
-            "0.6": 0.6,
-            "0.5": 0.5,
-            "0.4": 0.4,
-            "0.3": 0.3,
-            "1/4": 1 / 4,
-            "1/5": 1 / 5,
-            "1/6": 1 / 6,
-            "1/8": 1 / 8,
-            "1/10": 1 / 10,
-            "1/13": 1 / 13,
-            "1/15": 1 / 15,
-            "1/20": 1 / 20,
-            "1/25": 1 / 25,
-            "1/30": 1 / 30,
-            "1/40": 1 / 40,
-            "1/50": 1 / 50,
-            "1/60": 1 / 60,
-            "1/80": 1 / 80,
-            "1/100": 1 / 100,
-            "1/125": 1 / 125,
-            "1/160": 1 / 160,
-            "1/200": 1 / 200,
-            "1/250": 1 / 250,
-            "1/320": 1 / 320,
-            "1/400": 1 / 400,
-            "1/500": 1 / 500,
-            "1/640": 1 / 640,
-            "1/800": 1 / 800,
-            "1/1000": 1 / 1000,
-            "1/1250": 1 / 1250,
-            "1/1600": 1 / 1600,
-            "1/2000": 1 / 2000,
-            "1/2500": 1 / 2500,
-            "1/3200": 1 / 3200,
-            "1/4000": 1 / 4000,
-        }
 
         try:
             # First check by key.
-            return list(shutter_speeds.keys()).index(seconds)
+            return list(cls._shutter_speeds.keys()).index(seconds)
         except ValueError:
             # Then check by value.
             try:
                 # Check minimum of everything after 'bulb'.
-                if return_minimum and seconds < min(list(shutter_speeds.values())[1:]):
-                    return len(shutter_speeds) - 1
+                if return_minimum and seconds < min(list(cls._shutter_speeds.values())[1:]):
+                    return len(cls._shutter_speeds) - 1
                 else:
-                    return list(shutter_speeds.values()).index(seconds)
+                    return list(cls._shutter_speeds.values()).index(seconds)
             except ValueError:
                 return 0

--- a/src/panoptes/pocs/camera/simulator/dslr.py
+++ b/src/panoptes/pocs/camera/simulator/dslr.py
@@ -92,8 +92,18 @@ class Camera(AbstractCamera):
         Returns:
             dict: The metadata returned by AbstractCamera.take_observation.
         """
+        from fractions import Fraction
+
         exptime = kwargs.get("exptime", observation.exptime.value)
-        if exptime > 1:
+        if isinstance(exptime, str):
+            try:
+                exptime = float(Fraction(exptime.strip()))
+                kwargs["exptime"] = exptime
+            except (ValueError, TypeError):
+                pass
+
+        exptime_val = get_quantity_value(exptime, unit=u.second)
+        if exptime_val > 1:
             kwargs["exptime"] = 1
             self.logger.debug("Trimming camera simulator exposure to 1 s")
 

--- a/src/panoptes/pocs/camera/simulator/dslr.py
+++ b/src/panoptes/pocs/camera/simulator/dslr.py
@@ -98,7 +98,6 @@ class Camera(AbstractCamera):
         if isinstance(exptime, str):
             try:
                 exptime = float(Fraction(exptime.strip()))
-                kwargs["exptime"] = exptime
             except (ValueError, TypeError):
                 pass
 

--- a/src/panoptes/pocs/camera/simulator/dslr.py
+++ b/src/panoptes/pocs/camera/simulator/dslr.py
@@ -116,6 +116,17 @@ class Camera(AbstractCamera):
         self._is_exposing_event.set()
         seconds = kwargs.get("simulator_exptime", seconds)
         interval = get_quantity_value(seconds, unit=u.second)
+
+        # Clip to mimic discrete DSLR/CCD minimum shutterspeed (1/4000 s)
+        # or go to 0 when it's below a 1e-9 s threshold.
+        if interval < 1e-9:
+            interval = 0.0
+        elif interval < 0.00025:
+            interval = 0.00025
+
+        if header is not None:
+            header.set("EXPTIME", interval, "Seconds")
+
         if interval <= 0:
             self._end_exposure()
         else:

--- a/src/panoptes/pocs/camera/simulator/dslr.py
+++ b/src/panoptes/pocs/camera/simulator/dslr.py
@@ -101,10 +101,13 @@ class Camera(AbstractCamera):
             except (ValueError, TypeError):
                 pass
 
-        exptime_val = get_quantity_value(exptime, unit=u.second)
-        if exptime_val > 1:
-            kwargs["exptime"] = 1
-            self.logger.debug("Trimming camera simulator exposure to 1 s")
+        try:
+            exptime_val = get_quantity_value(exptime, unit=u.second)
+            if exptime_val > 1:
+                kwargs["exptime"] = 1
+                self.logger.debug("Trimming camera simulator exposure to 1 s")
+        except (ValueError, TypeError):
+            pass
 
         return super().take_observation(observation, headers, filename, **kwargs)
 

--- a/src/panoptes/pocs/camera/zwo.py
+++ b/src/panoptes/pocs/camera/zwo.py
@@ -8,6 +8,7 @@ and basic video capture.
 import threading
 import time
 from contextlib import suppress
+from fractions import Fraction
 
 import numpy as np
 from astropy import units as u
@@ -317,6 +318,12 @@ class Camera(AbstractSDKCamera):
         Returns:
             threading.Thread: The readout thread
         """
+        if isinstance(seconds, str):
+            try:
+                seconds = float(Fraction(seconds.strip()))
+            except (ValueError, TypeError):
+                pass
+
         # Ensure seconds is a Quantity
         if not isinstance(seconds, u.Quantity):
             seconds = seconds * u.second

--- a/src/panoptes/pocs/scheduler/observation/base.py
+++ b/src/panoptes/pocs/scheduler/observation/base.py
@@ -7,6 +7,7 @@ represent an observing block (target field, exposure timing/sets, and progress).
 import os
 from collections import OrderedDict, defaultdict
 from contextlib import suppress
+from fractions import Fraction
 from pathlib import Path
 
 from astropy import units as u
@@ -97,6 +98,12 @@ class Observation(PanBase):
         if exptime is None:
             exptime = self.get_config("cameras.defaults.exptime", default=120)
 
+        if isinstance(exptime, str):
+            try:
+                exptime = float(Fraction(exptime.strip()))
+            except (ValueError, TypeError):
+                pass
+
         exptime = get_quantity_value(exptime, u.second) * u.second
 
         if not isinstance(field, Field):
@@ -183,6 +190,11 @@ class Observation(PanBase):
     @exptime.setter
     def exptime(self, value):
         """Set the exposure time (Quantity or seconds)."""
+        if isinstance(value, str):
+            try:
+                value = float(Fraction(value.strip()))
+            except (ValueError, TypeError):
+                pass
         self._exptime = get_quantity_value(value, u.second) * u.second
 
     @property

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -844,3 +844,13 @@ def test_move_filterwheel_focus_offset(camera):
             assert new_position == initial_position + offset
         else:
             assert new_position == initial_position
+
+
+def test_exposure_fraction(camera, tmpdir):
+    """Test that take_exposure accepts exposure time as a string fraction."""
+    fits_path = str(tmpdir.join("test_exposure_fraction.fits"))
+    # A 1/4 second exposure (should parse as 0.25).
+    camera.take_exposure(seconds="1/4", filename=fits_path, blocking=True)
+    assert os.path.exists(fits_path)
+    header = fits_utils.getheader(fits_path)
+    assert header["EXPTIME"] == 0.25

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -873,3 +873,18 @@ def test_exposure_fraction(camera, tmpdir):
         assert header_tiny["EXPTIME"] == min_exposure.value
     else:
         assert header_tiny["EXPTIME"] == 1e-20
+
+
+def test_canon_shutterspeed_index():
+    from panoptes.pocs.camera.gphoto.canon import Camera as CanonCamera
+
+    # Test valid discrete speeds
+    assert CanonCamera.get_shutterspeed_index(0.25) == CanonCamera.get_shutterspeed_index("1/4")
+
+    # Test scientific notation
+    assert CanonCamera.get_shutterspeed_index(1e-2) == CanonCamera.get_shutterspeed_index("1/100")
+
+    # Test tiny value return_minimum
+    # min discrete speed is 1/4000
+    idx_4000 = list(CanonCamera._shutter_speeds.keys()).index("1/4000")
+    assert CanonCamera.get_shutterspeed_index(1e-20, return_minimum=True) == idx_4000

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -904,3 +904,38 @@ def test_observation_invalid_exptime(camera):
     observation = Observation(field)
     with pytest.raises((ValueError, TypeError, error.PanError)):
         camera.take_observation(observation, exptime="invalid_exptime")
+
+
+def test_observation_exptime_fraction(camera, images_dir):
+    """
+    Tests functionality of take_observation() with fractional/scientific notation exptime strings in kwargs.
+    """
+    from astropy import units as u
+
+    from panoptes.pocs.scheduler.field import Field
+    from panoptes.pocs.scheduler.observation.base import Observation
+
+    field = Field("Test Observation Fraction", "20h00m43.7135s +22d42m39.0645s")
+    observation = Observation(field, exptime=1.5 * u.second)
+    observation.seq_time = "19991231T234559"
+    # Override exptime with a fraction string
+    camera.take_observation(observation, exptime="1/4", blocking=True)
+    observation_pattern = os.path.join(
+        images_dir, "TestObservationFraction", camera.uid, observation.seq_time, "*.fits*"
+    )
+    image_files = glob.glob(observation_pattern)
+    assert len(image_files) == 1
+    headers = fits_utils.getheader(image_files[0])
+    assert headers["EXPTIME"] == 0.25
+
+    # Override exptime with a scientific notation string
+    observation2 = Observation(field, exptime=1.5 * u.second)
+    observation2.seq_time = "19991231T234659"
+    camera.take_observation(observation2, exptime="1e-2", blocking=True)
+    observation_pattern2 = os.path.join(
+        images_dir, "TestObservationFraction", camera.uid, observation2.seq_time, "*.fits*"
+    )
+    image_files2 = glob.glob(observation_pattern2)
+    assert len(image_files2) == 1
+    headers2 = fits_utils.getheader(image_files2[0])
+    assert headers2["EXPTIME"] == 0.01

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -854,3 +854,22 @@ def test_exposure_fraction(camera, tmpdir):
     assert os.path.exists(fits_path)
     header = fits_utils.getheader(fits_path)
     assert header["EXPTIME"] == 0.25
+
+    # Test scientific notation
+    fits_path_sci = str(tmpdir.join("test_exposure_sci.fits"))
+    camera.take_exposure(seconds="1e-2", filename=fits_path_sci, blocking=True)
+    assert os.path.exists(fits_path_sci)
+    header_sci = fits_utils.getheader(fits_path_sci)
+    assert header_sci["EXPTIME"] == 0.01
+
+    # Test tiny value (should be clipped to min_exposure for ZWO, or remain 1e-20)
+    fits_path_tiny = str(tmpdir.join("test_exposure_tiny.fits"))
+    camera.take_exposure(seconds="1e-20", filename=fits_path_tiny, blocking=True)
+    assert os.path.exists(fits_path_tiny)
+    header_tiny = fits_utils.getheader(fits_path_tiny)
+
+    if hasattr(camera, "_control_info") and "EXPOSURE" in camera._control_info:
+        min_exposure = camera._control_info["EXPOSURE"]["min_value"]
+        assert header_tiny["EXPTIME"] == min_exposure.value
+    else:
+        assert header_tiny["EXPTIME"] == 1e-20

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -862,7 +862,7 @@ def test_exposure_fraction(camera, tmpdir):
     header_sci = fits_utils.getheader(fits_path_sci)
     assert header_sci["EXPTIME"] == 0.01
 
-    # Test tiny value (should be clipped to min_exposure for ZWO, or remain 1e-20)
+    # Test tiny value (should be clipped to min_exposure for ZWO, or go to 0 for DSLR/CCD simulator)
     fits_path_tiny = str(tmpdir.join("test_exposure_tiny.fits"))
     camera.take_exposure(seconds="1e-20", filename=fits_path_tiny, blocking=True)
     assert os.path.exists(fits_path_tiny)
@@ -872,7 +872,19 @@ def test_exposure_fraction(camera, tmpdir):
         min_exposure = camera._control_info["EXPOSURE"]["min_value"]
         assert header_tiny["EXPTIME"] == min_exposure.value
     else:
-        assert header_tiny["EXPTIME"] == 1e-20
+        assert header_tiny["EXPTIME"] == 0.0
+
+    # Test small value above zero-threshold (should clip to 1/4000 s for DSLR/CCD simulator)
+    fits_path_small = str(tmpdir.join("test_exposure_small.fits"))
+    camera.take_exposure(seconds="1e-5", filename=fits_path_small, blocking=True)
+    assert os.path.exists(fits_path_small)
+    header_small = fits_utils.getheader(fits_path_small)
+
+    if hasattr(camera, "_control_info") and "EXPOSURE" in camera._control_info:
+        min_exposure = camera._control_info["EXPOSURE"]["min_value"]
+        assert header_small["EXPTIME"] == min_exposure.value
+    else:
+        assert header_small["EXPTIME"] == 0.00025
 
 
 def test_canon_shutterspeed_index():

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -888,3 +888,19 @@ def test_canon_shutterspeed_index():
     # min discrete speed is 1/4000
     idx_4000 = list(CanonCamera._shutter_speeds.keys()).index("1/4000")
     assert CanonCamera.get_shutterspeed_index(1e-20, return_minimum=True) == idx_4000
+
+
+def test_exposure_invalid_seconds(camera, tmpdir):
+    fits_path = str(tmpdir.join("test_exposure_invalid.fits"))
+    with pytest.raises((ValueError, TypeError, error.PanError)):
+        camera.take_exposure(seconds="invalid_seconds", filename=fits_path)
+
+
+def test_observation_invalid_exptime(camera):
+    from panoptes.pocs.scheduler.field import Field
+    from panoptes.pocs.scheduler.observation.base import Observation
+
+    field = Field("Test Observation", "20h00m43.7135s +22d42m39.0645s")
+    observation = Observation(field)
+    with pytest.raises((ValueError, TypeError, error.PanError)):
+        camera.take_observation(observation, exptime="invalid_exptime")

--- a/tests/test_observation.py
+++ b/tests/test_observation.py
@@ -227,3 +227,13 @@ def test_create_observation_exptime_fraction(field):
 
     obs.exptime = "1/10000000000000000"
     assert obs.exptime == 1e-16 * u.second
+
+
+def test_create_observation_exptime_invalid(field):
+    """Test that invalid exptime strings are rejected with ValueError."""
+    with pytest.raises(ValueError):
+        Observation(field, exptime="invalid_exptime")
+
+    obs = Observation(field)
+    with pytest.raises(ValueError):
+        obs.exptime = "invalid_exptime"

--- a/tests/test_observation.py
+++ b/tests/test_observation.py
@@ -216,3 +216,14 @@ def test_create_observation_exptime_fraction(field):
     # Test setter with string fraction
     obs.exptime = "1/10"
     assert obs.exptime == 0.1 * u.second
+
+    # Test scientific notation
+    obs.exptime = "1e-5"
+    assert obs.exptime == 1e-5 * u.second
+
+    # Test tiny value (scientific notation and fraction)
+    obs.exptime = "1e-20"
+    assert obs.exptime == 1e-20 * u.second
+
+    obs.exptime = "1/10000000000000000"
+    assert obs.exptime == 1e-16 * u.second

--- a/tests/test_observation.py
+++ b/tests/test_observation.py
@@ -206,3 +206,13 @@ def test_observation_from_dict_without_exptime():
     # Should use default from config (120 seconds in test config)
     assert obs.exptime == 120 * u.second
     assert obs.priority == 100
+
+
+def test_create_observation_exptime_fraction(field):
+    """Test that exptime can be entered as a string fraction."""
+    obs = Observation(field, exptime="1/4")
+    assert obs.exptime == 0.25 * u.second
+
+    # Test setter with string fraction
+    obs.exptime = "1/10"
+    assert obs.exptime == 0.1 * u.second


### PR DESCRIPTION
Closes #1367. This PR allows the camera times and scheduler observation times to be entered as a string fraction, such as '1/4'. Additionally, it updates the Canon DSLR driver to ensure that if the discrete shutterspeed table clips the requested exposure time (e.g. for tiny values like '1e-20'), the actual clipped physical shutterspeed is written to the FITS header instead of the requested value.